### PR TITLE
generally overworked the sendEmail method and the according render method

### DIFF
--- a/errors.py
+++ b/errors.py
@@ -3,7 +3,6 @@
 class HTTPException(Exception):
 	"""
 		Base-Class for all Exceptions that should match to an http error-code
-
 	"""
 
 	def __init__(self, status, name, descr):
@@ -232,3 +231,12 @@ class ReadFromClientError(object):
 		super(ReadFromClientError, self).__init__()
 		self.errors = errors
 		self.forceFail = forceFail
+
+
+class ViurException(Exception): pass
+
+
+class InvalidConfigException(ViurException):
+	"""
+		This exception is usually thrown if a config isn't set or is incorrect.
+	"""

--- a/render/html/default.py
+++ b/render/html/default.py
@@ -99,6 +99,8 @@ class Render(object):
 		super(Render, self).__init__(*args, **kwargs)
 		if not Render.__haveEnvImported_:
 			# We defer loading our plugins to this point to avoid circular imports
+			# noinspection PyUnresolvedReferences
+			from . import env
 			Render.__haveEnvImported_ = True
 		self.parent = parent
 

--- a/render/html/default.py
+++ b/render/html/default.py
@@ -1,15 +1,18 @@
 # -*- coding: utf-8 -*-
+import codecs
+import logging
+import os
+from collections import OrderedDict
+from typing import Any, Dict, List, Union
+
+from jinja2 import ChoiceLoader, Environment, FileSystemLoader
+
+from viur.core import errors, request, securitykey, utils
+from viur.core.bones import *
+from viur.core.i18n import translate
+from viur.core.skeleton import BaseSkeleton, RefSkel, Skeleton, skeletonByKind
 from . import utils as jinjaUtils
 from .wrap import ListWrapper, SkelListWrapper
-
-from viur.core import utils, request, errors, securitykey
-from viur.core.skeleton import Skeleton, BaseSkeleton, RefSkel, skeletonByKind
-from viur.core.bones import *
-
-from collections import OrderedDict
-from jinja2 import Environment, FileSystemLoader, ChoiceLoader
-from viur.core.i18n import translate
-import os, logging, codecs
 
 
 class KeyValueWrapper:
@@ -96,7 +99,6 @@ class Render(object):
 		super(Render, self).__init__(*args, **kwargs)
 		if not Render.__haveEnvImported_:
 			# We defer loading our plugins to this point to avoid circular imports
-			from . import env
 			Render.__haveEnvImported_ = True
 		self.parent = parent
 
@@ -408,9 +410,11 @@ class Render(object):
 			if isinstance(skel, BaseSkeleton):
 				super(BaseSkeleton, skel).__setattr__("errors", {})
 
-		return template.render(skel={"structure": self.renderSkelStructure(skel),
-									 "errors": skel.errors,
-									 "value": self.collectSkelData(skel)},
+		return template.render(skel={
+			"structure": self.renderSkelStructure(skel),
+			"errors": skel.errors,
+			"value": self.collectSkelData(skel)
+		},
 							   params=params, **kwargs)
 
 	def edit(self, skel, tpl=None, params=None, **kwargs):
@@ -450,9 +454,11 @@ class Render(object):
 			if isinstance(skel, BaseSkeleton):
 				super(BaseSkeleton, skel).__setattr__("errors", {})
 
-		return template.render(skel={"structure": self.renderSkelStructure(skel),
-									 "errors": skel.errors,
-									 "value": self.collectSkelData(skel)},
+		return template.render(skel={
+			"structure": self.renderSkelStructure(skel),
+			"errors": skel.errors,
+			"value": self.collectSkelData(skel)
+		},
 							   params=params, **kwargs)
 
 	def addItemSuccess(self, skel, tpl=None, params=None, *args, **kwargs):
@@ -817,62 +823,50 @@ class Render(object):
 		template = self.getEnv().get_template(self.getTemplateFileName(tpl))
 		return template.render(params=params, **kwargs)
 
-	def renderEmail(self, skel, tpl, dests, params=None, **kwargs):
+	def renderEmail(self,
+					dests: List[str],
+					file: str = None,
+					template: str = None,
+					skel: Union[None, Dict, BaseSkeleton, List[BaseSkeleton]] = None,
+					# FIXME: Limit or could it be any?
+					params: Any = None,
+					**kwargs
+					) -> str:
 		"""
 			Renders an email.
 
-			:param skel: Skeleton or dict which data to supply to the template.
-			:type skel: server.db.skeleton.Skeleton | dict
-
-			:param tpl: Name of the email-template to use. If this string is longer than 100 characters,
-				this string is interpreted as the template contents instead of its filename.
-			:type tpl: str
-
 			:param dests: Destination recipients.
-			:type dests: list | str
+
+
+			:param file: The name of a template from the deploy/emails directory.
+
+			:param template: This string is interpreted as the template contents. Alternative to load from template file.
+
+			:param skel: Skeleton or dict which data to supply to the template.
 
 			:param params: Optional data that will be passed unmodified to the template
-			:type params: object
 
-			:return: Returns a tuple consisting of email header and body.
-			:rtype: str, str
+			:return: Returns the rendered email body.
 		"""
-		headers = {}
 		user = utils.getCurrentUser()
+
 		if isinstance(skel, BaseSkeleton):
 			res = self.collectSkelData(skel)
 		elif isinstance(skel, list) and all([isinstance(x, BaseSkeleton) for x in skel]):
 			res = [self.collectSkelData(x) for x in skel]
 		else:
 			res = skel
-		if len(tpl) < 101:
+
+		if file is not None:
 			try:
-				template = self.getEnv().from_string(codecs.open("emails/" + tpl + ".email", "r", "utf-8").read())
+				tpl = self.getEnv().from_string(codecs.open("emails/" + file + ".email", "r", "utf-8").read())
 			except Exception as err:
 				logging.exception(err)
-				template = self.getEnv().get_template(tpl + ".email")
+				tpl = self.getEnv().get_template(file + ".email")
 		else:
-			template = self.getEnv().from_string(tpl)
-		data = template.render(skel=res, dests=dests, user=user, params=params, **kwargs)
-		body = False
-		lineCount = 0
-		for line in data.splitlines():
-			if lineCount > 3 and body is False:
-				body = "\n\n"
-			if body != False:
-				body += line + "\n"
-			else:
-				if line.lower().startswith("from:"):
-					headers["from"] = line[len("from:"):]
-				elif line.lower().startswith("subject:"):
-					headers["subject"] = line[len("subject:"):]
-				elif line.lower().startswith("references:"):
-					headers["references"] = line[len("references:"):]
-				else:
-					body = "\n\n"
-					body += line
-			lineCount += 1
-		return (headers, body)
+			tpl = self.getEnv().from_string(template)
+
+		return tpl.render(skel=res, dests=dests, user=user, params=params, **kwargs)
 
 	def getEnv(self):
 		"""

--- a/render/html/default.py
+++ b/render/html/default.py
@@ -9,8 +9,12 @@ from jinja2 import ChoiceLoader, Environment, FileSystemLoader
 
 from viur.core import errors, request, securitykey, utils
 from viur.core.bones import *
+from viur.core.skeleton import BaseSkeleton, RefSkel, Skeleton, skeletonByKind
+from . import utils as jinjaUtils
+from .wrap import ListWrapper
 
 KeyValueWrapper = namedtuple("KeyValueWrapper", ["key", "descr"])
+
 
 class Render(object):
 	"""
@@ -169,7 +173,7 @@ class Render(object):
 
 		elif bone.type == "select" or bone.type.startswith("select."):
 			ret.update({
-				"values": {k: v for (k, v) in bone.values.items()}, #FIXME: translate!
+				"values": {k: v for (k, v) in bone.values.items()},  # FIXME: translate!
 				"multiple": bone.multiple
 			})
 
@@ -260,7 +264,7 @@ class Render(object):
 					if bone.using is None:
 						tmpList.append(self.collectSkelData(refSkel))
 					else:
-						#usingSkel = bone._usingSkelCache
+						# usingSkel = bone._usingSkelCache
 						if k["rel"]:
 							usingSkel.setValuesCache(k["rel"])
 							usingData = self.collectSkelData(usingSkel)
@@ -278,7 +282,7 @@ class Render(object):
 				if bone.using is None:
 					return refSkel
 				else:
-					#usingSkel = bone._usingSkelCache
+					# usingSkel = bone._usingSkelCache
 					if boneValue["rel"]:
 						usingSkel.setValuesCache(boneValue["rel"])
 						usingData = self.collectSkelData(usingSkel)
@@ -366,9 +370,11 @@ class Render(object):
 			if isinstance(skel, BaseSkeleton):
 				super(BaseSkeleton, skel).__setattr__("errors", {})
 
-		return template.render(skel={"structure": self.renderSkelStructure(skel),
-									 "errors": skel.errors,
-									 "value": self.collectSkelData(skel)},
+		return template.render(skel={
+			"structure": self.renderSkelStructure(skel),
+			"errors": skel.errors,
+			"value": self.collectSkelData(skel)
+		},
 							   params=params, **kwargs)
 
 	def edit(self, skel, tpl=None, params=None, **kwargs):
@@ -408,9 +414,11 @@ class Render(object):
 			if isinstance(skel, BaseSkeleton):
 				super(BaseSkeleton, skel).__setattr__("errors", {})
 
-		return template.render(skel={"structure": self.renderSkelStructure(skel),
-									 "errors": skel.errors,
-									 "value": self.collectSkelData(skel)},
+		return template.render(skel={
+			"structure": self.renderSkelStructure(skel),
+			"errors": skel.errors,
+			"value": self.collectSkelData(skel)
+		},
 							   params=params, **kwargs)
 
 	def addItemSuccess(self, skel, tpl=None, params=None, *args, **kwargs):

--- a/utils.py
+++ b/utils.py
@@ -6,7 +6,7 @@ import logging
 import random
 import string
 from base64 import urlsafe_b64encode
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Tuple, Union
 
 import google.auth
@@ -15,21 +15,15 @@ from viur.core import conf, db, errors
 
 # from .skeleton import BaseSkeleton #FIXME: circular import
 BaseSkeleton = object
-from datetime import datetime, timedelta, timezone
-import hashlib
-import hmac
-from quopri import decodestring
-from base64 import urlsafe_b64decode, urlsafe_b64encode
-from hashlib import sha256
-import email.header
-from typing import Any, Union
 
 # Determine which ProjectID we currently run in (as the app_identity module isn't available anymore)
 _, projectID = google.auth.default()
 del _
 
+
 def utcNow():
 	return datetime.now(timezone.utc)
+
 
 def generateRandomString(length: int = 13) -> str:
 	"""
@@ -159,7 +153,7 @@ def sendEMailToAdmins(subject: str, body: str, sender: str = None):
 
 	if "user" in dir(conf["viur.mainApp"]):
 		users = []
-		for userSkel in conf["viur.mainApp"].user.viewSkel().all().filter("access AC", "root").fetch():
+		for userSkel in conf["viur.mainApp"].user.viewSkel().all().filter("access", "root").fetch():
 			users.append(userSkel["name"])
 
 		if users:

--- a/utils.py
+++ b/utils.py
@@ -1,21 +1,20 @@
 # -*- coding: utf-8 -*-
 
-# from google.appengine.api import memcache, app_identity, mail
-# from google.appengine.ext import deferred
-import os
-from viur.core import db
-import string, random, base64
-from viur.core import conf
-import logging
-import google.auth
-from datetime import datetime, timedelta
 import hashlib
 import hmac
-from quopri import decodestring
-from base64 import urlsafe_b64decode, urlsafe_b64encode
-from hashlib import sha256
-import email.header
-from typing import Any
+import logging
+import random
+import string
+from base64 import urlsafe_b64encode
+from datetime import datetime, timedelta
+from typing import Any, Dict, List, Tuple, Union
+
+import google.auth
+
+from viur.core import conf, db, errors
+
+# from .skeleton import BaseSkeleton #FIXME: circular import
+BaseSkeleton = object
 
 # Determine which ProjectID we currently run in (as the app_identity module isn't available anymore)
 _, projectID = google.auth.default()
@@ -38,40 +37,70 @@ def generateRandomString(length: int = 13) -> str:
 		for x in range(length)]))
 
 
-def sendEMail(dests, name, skel, extraFiles=[], cc=None, bcc=None, replyTo=None, *args, **kwargs):
+def sendEMail(dests: Union[str, List[str]],
+			  subject: str,
+			  file: str = None,
+			  template: str = None,
+			  skel: Union[None, Dict, BaseSkeleton, List[BaseSkeleton]] = None,  # FIXME: Limit or could it be any?
+			  attachments: List[Tuple[str, str]] = None,
+			  sender: str = None,
+			  cc: Union[str, List[str]] = None,
+			  bcc: Union[str, List[str]] = None,
+			  replyTo: str = None,
+			  header: Dict = None,
+			  template_params: Any = None,
+			  *args, **kwargs) -> Any:
 	"""
 	General purpose function for sending e-mail.
 
 	This function allows for sending e-mails, also with generated content using the Jinja2 template engine.
 
-	:type dests: str | list of str
-	:param dests: Full-qualified recipient email addresses; These can be assigned as list, for multiple targets.
+	Your have to implement a method which should be called to send the prepared email finally. For this you have
+	to allocate *viur.emailHandler* in conf.
 
-	:type name: str
-	:param name: The name of a template from the appengine/emails directory, or the template string itself.
+	:param dests: A list of addresses to send this mail to. A bare string will be treated as a list with 1 address.
 
-	:type skel: server.skeleton.Skeleton | dict | None
-	:param skel: The data made available to the template. In case of a Skeleton, its parsed the usual way;\
-	Dictionaries are passed unchanged.
+	:param subject: The subject of the email.
 
-	:type extraFiles: list of fileobjects
-	:param extraFiles: List of **open** fileobjects to be sent within the mail as attachments
+	:param file: The name of a template from the deploy/emails directory.
 
-	:type cc: str | list of str
-	:param cc: Carbon-copy recipients
+	:param template: This string is interpreted as the template contents. Alternative to load from template file.
 
-	:type bcc: str | list of str
-	:param bcc: Blind carbon-copy recipients
+	:param skel: The data made available to the template. In case of a Skeleton or SkelList, its parsed the usual way;\
+		Dictionaries are passed unchanged.
 
-	:type replyTo: str
-	:param replyTo: A reply-to email address
+	:param attachments: List of files ((filename, filecontent)-pairs) to be sent within the mail as attachments.
+
+	:param sender: The address sending this mail.
+
+	:param cc: Carbon-copy recipients. A bare string will be treated as a list with 1 address.
+
+	:param bcc: Blind carbon-copy recipients. A bare string will be treated as a list with 1 address.
+
+	:param replyTo: A reply-to email address.
+
+	:param header: Specify headers for this email.
+
+	:param template_params: Supply params for the template.
+
 	"""
+	if (not file and not template) or (file and template):
+		raise ValueError("You have to set the params 'file' xor a 'template'.")
+
+	# Normalize to lists
+	if not isinstance(dests, list):
+		dests = [dests]
+	if not isinstance(cc, list):
+		cc = [cc]
+	if not isinstance(bcc, list):
+		bcc = [bcc]
+	if attachments is None:
+		attachments = []
+
 	if conf["viur.emailRecipientOverride"]:
 		logging.warning("Overriding destination %s with %s", dests, conf["viur.emailRecipientOverride"])
 
 		oldDests = dests
-		if isinstance(oldDests, str):
-			oldDests = [oldDests]
 
 		newDests = conf["viur.emailRecipientOverride"]
 		if isinstance(newDests, str):
@@ -87,102 +116,54 @@ def sendEMail(dests, name, skel, extraFiles=[], cc=None, bcc=None, replyTo=None,
 
 	elif conf["viur.emailRecipientOverride"] is False:
 		logging.warning("Sending emails disabled by config[viur.emailRecipientOverride]")
-		return
+		return False
+
+	if conf["viur.emailSenderOverride"]:
+		sender = conf["viur.emailSenderOverride"]
+	elif sender is None:
+		sender = f"viur@{projectID}.appspotmail.com"
 
 	handler = conf.get("viur.emailHandler")
 
 	if handler is None:
-		handler = _GAE_sendEMail
+		raise errors.InvalidConfigException("No emailHandler specified!")
+	elif not callable(handler):
+		raise errors.InvalidConfigException("Invalid emailHandler configured, no email will be sent!")
 
-	if not callable(handler):
-		logging.warning("Invalid emailHandler configured, no email will be sent.")
-		return False
+	body = conf["viur.emailRenderer"](dests, file, template, skel, template_params, **kwargs)
 
-	logging.debug("CALLING %s" % str(handler))
-
-	return handler(dests, name, skel, extraFiles=extraFiles, cc=cc, bcc=bcc, replyTo=replyTo, *args, **kwargs)
+	return handler(dests=dests, sender=sender, cc=cc, bcc=bcc, replyTo=replyTo,
+				   subject=subject, header=header, body=body, attachments=attachments, *args, **kwargs)
 
 
-def _GAE_sendEMail(dests, name, skel, extraFiles=[], cc=None, bcc=None, replyTo=None, *args, **kwargs):
+def sendEMailToAdmins(subject: str, body: str, sender: str = None):
 	"""
-	Internal function for using Google App Engine Email processing API.
-	"""
-	headers, data = conf["viur.emailRenderer"](skel, name, dests, **kwargs)
-
-	xheader = {}
-
-	if "references" in headers:
-		xheader["References"] = headers["references"]
-
-	if "in-reply-to" in headers:
-		xheader["In-Reply-To"] = headers["in-reply-to"]
-
-	if xheader:
-		message = mail.EmailMessage(headers=xheader)
-	else:
-		message = mail.EmailMessage()
-
-	mailfrom = "viur@%s.appspotmail.com" % app_identity.get_application_id()
-
-	if "subject" in headers:
-		message.subject = "=?utf-8?B?%s?=" % base64.b64encode(headers["subject"].encode("UTF-8"))
-	else:
-		message.subject = "No Subject"
-
-	if "from" in headers:
-		mailfrom = headers["from"]
-
-	if conf["viur.emailSenderOverride"]:
-		mailfrom = conf["viur.emailSenderOverride"]
-
-	if isinstance(dests, list):
-		message.to = ", ".join(dests)
-	else:
-		message.to = dests
-
-	if cc:
-		if isinstance(cc, list):
-			message.cc = ", ".join(cc)
-		else:
-			message.cc = cc
-
-	if bcc:
-		if isinstance(bcc, list):
-			message.bcc = ", ".join(bcc)
-		else:
-			message.bcc = bcc
-
-	if replyTo:
-		message.reply_to = replyTo
-
-	message.sender = mailfrom
-	message.html = data.replace("\x00", "").encode('ascii', 'xmlcharrefreplace')
-
-	if len(extraFiles) > 0:
-		message.attachments = extraFiles
-	message.send()
-	return True
-
-
-def sendEMailToAdmins(subject, body, sender=None):
-	"""
-		Sends an e-mail to the appengine administration of the current app.
-		(all users having access to the applications dashboard)
+		Sends an e-mail to the root users of the current app.
 
 		:param subject: Defines the subject of the message.
-		:type subject: str
 
 		:param body: Defines the message body.
-		:type body: str
 
 		:param sender: (optional) specify a different sender
-		:type sender: str
 	"""
 	if not sender:
-		sender = "viur@%s.appspotmail.com" % app_identity.get_application_id()
+		sender = f"viur@{projectID}.appspotmail.com"
 
-	mail.send_mail_to_admins(sender, "=?utf-8?B?%s?=" % base64.b64encode(subject.encode("UTF-8")),
-							 body.encode('ascii', 'xmlcharrefreplace'))
+	if "user" in dir(conf["viur.mainApp"]):
+		users = []
+		for userSkel in conf["viur.mainApp"].user.viewSkel().all().filter("access AC", "root").fetch():
+			users.append(userSkel["name"])
+
+		if users:
+			return sendEMail(dests=users, subject=subject, template=body, sender=sender)
+		else:
+			logging.warning("There are no root-users.")
+
+	logging.critical("Cannot send mail to Admins.")
+	logging.critical("Subject of mail: %s", subject)
+	logging.critical("Content of mail: %s", body)
+
+	return False
 
 
 def getCurrentUser():
@@ -272,6 +253,7 @@ def downloadUrlFor(folder: str, fileName: str, derived: bool = False, expires: t
 	resstr = hmacSign(sigStr)
 	return "/file/download/%s?sig=%s" % (sigStr.decode("ASCII"), resstr)
 
+
 def seoUrlToEntry(module, entry=None, skelType=None, language=None):
 	from viur.core import request, conf
 	lang = request.current.get().language
@@ -279,7 +261,7 @@ def seoUrlToEntry(module, entry=None, skelType=None, language=None):
 		module = conf["viur.languageModuleMap"][module][lang]
 	if not entry:
 		return "/%s/%s" % (lang, module)
-	#elif isinstance(entry, dict):
+	# elif isinstance(entry, dict):
 	else:
 		try:
 			currentSeoKeys = entry.get("viurCurrentSeoKeys")
@@ -294,6 +276,7 @@ def seoUrlToEntry(module, entry=None, skelType=None, language=None):
 		else:
 			return "/%s/%s" % (lang, module)
 		return "/%s/%s/%s" % (lang, module, seoKey)
+
 
 def seoUrlToFunction(module, function, render=None):
 	from viur.core import request, conf
@@ -315,5 +298,3 @@ def seoUrlToFunction(module, function, render=None):
 		else:
 			pathComponents.append(function)
 	return "/".join(pathComponents)
-
-


### PR DESCRIPTION
- utils.sendEMail does now the fundamental preparation of an email
(normalize arguments, consider the config and render the template with the supplied
arguments)
- utils.sendEMailToAdmins send now emails to all root-users of our
user-module.
- htmlRenderer.renderEmail renders only the body of an email with a
given template-string or from a template file
- with this changes I introduces ViUR-Exceptions to signal errors which
are thrown explicit by ViUR.
- I also added type-annotation and adjusted the docstrings.