### PR TITLE
ratelimit.py - determinate IP:  Use the network identifier, and not the interface. 

### DIFF
--- a/ratelimit.py
+++ b/ratelimit.py
@@ -57,7 +57,7 @@ class RateLimit(object):
 				return ":".join(remoteAddr[:4])
 			elif ":" in remoteAddr:  # It's IPv6, so we remove the last 64 bits (interface id)
 				# as it is easily controlled by the user
-				return ":".join(remoteAddr.split(":")[4:])
+				return ":".join(remoteAddr.split(":")[:4])
 			else:  # It's IPv4, simply return that address
 				return remoteAddr
 


### PR DESCRIPTION
I fixed the probably typo which led to use the interface identifier, and not the network identifier.

This is already correctly in [l.57](https://github.com/sveneberth/viur-core/blob/eae5cb96a9e91357d2e804d676ecf9c994b3fcde/ratelimit.py#L57)