### PR TITLE
added args to html-render logging function to support formatstring

### DIFF
--- a/render/html/env/debug.py
+++ b/render/html/env/debug.py
@@ -1,38 +1,38 @@
 # -*- coding: utf-8 -*-
-from viur.core.render.html.utils import jinjaGlobalFunction, jinjaGlobalFilter
-from logging import critical, error, warning, debug, info
 import pprint
+from logging import critical, debug, error, info, warning
+from typing import Any
+
+from viur.core.render.html.utils import jinjaGlobalFunction
 
 
 @jinjaGlobalFunction
-def logging(render, msg, kind="info", **kwargs):
+def logging(render, msg: str, level: str = "info", *args, **kwargs):
 	"""
 	Jinja2 global: Write log-level entry.
 	The function shall be used for debug and tracing purposes.
 
 	:param msg: Message to be delivered into logging.
-	:type msg: str
 
-	:param kind: Logging kind. This can either be "info" (default), "debug", "warning", "error" or "critical".
-	:type kind: str
+	:param level: Logging level. This can either be "info" (default), "debug", "warning", "error" or "critical".
 	"""
 
-	kind = kind.lower()
+	level = level.lower()
 
-	if kind == "critical":
-		critical(msg, **kwargs)
-	elif kind == "error":
-		error(msg, **kwargs)
-	elif kind == "warning":
-		warning(msg, **kwargs)
-	elif kind == "debug":
-		debug(msg, **kwargs)
+	if level == "critical":
+		critical(msg, *args, **kwargs)
+	elif level == "error":
+		error(msg, *args, **kwargs)
+	elif level == "warning":
+		warning(msg, *args, **kwargs)
+	elif level == "debug":
+		debug(msg, *args, **kwargs)
 	else:
-		info(msg, **kwargs)
+		info(msg, *args, **kwargs)
 
 
 @jinjaGlobalFunction
-def pprint(render, obj):
+def pprint(render, obj: Any) -> str:
 	"""
 	Jinja2 global: Provides a pprint function that renders into HTML.
 	The function shall be used for debug purposes.


### PR DESCRIPTION
Without these args it wasn't possible to use a format logging string like this:
```jinja2
{% do logging("Hello %s!", "debug", "World") %}
```