### PR TITLE
Deferr tasks to the end of the current request instead of calling them inline

### DIFF
--- a/request.py
+++ b/request.py
@@ -156,6 +156,9 @@ class BrowseHandler():  # webapp.RequestHandler
 		self.args = []
 		self.kwargs = {}
 		path = self.request.path
+		if self.isDevServer:
+			# We'll have to emulate the task-queue locally as far as possible until supported by dev_appserver again
+			self.pendingTasks = []
 
 		# Add CSP headers early (if any)
 		if conf["viur.security.contentSecurityPolicy"] and conf["viur.security.contentSecurityPolicy"]["_headerCache"]:
@@ -288,6 +291,11 @@ class BrowseHandler():  # webapp.RequestHandler
 			}
 			requestLogger.log_text("", client=loggingClient, severity=SEVERITY, http_request=REQUEST, trace=TRACE,
 								   resource=requestLoggingRessource)
+		if self.isDevServer:
+			while self.pendingTasks:
+				task = self.pendingTasks.pop()
+				logging.info("Running task directly after request: %s" % str(task))
+				task()
 
 	def findAndCall(self, path, *args, **kwargs):  # Do the actual work: process the request
 		# Prevent Hash-collision attacks

--- a/tasks.py
+++ b/tasks.py
@@ -323,9 +323,16 @@ def callDeferred(func):
 			# Run tasks inline
 			logging.error("Running inline: %s" % func)
 			if self is __undefinedFlag_:
-				func(*args, **kwargs)
+				task = lambda: func(*args, **kwargs)
 			else:
-				func(self, *args, **kwargs)
+				task = lambda: func(self, *args, **kwargs)
+			req = currentRequest.get()
+			if req:
+				req.pendingTasks.append(task)  # < This property will be only exist on development server!
+			else:
+				# Warmup request or something - we have to call it now as we can't deferr it :/
+				task()
+
 			return  # Ensure no result gets passed back
 
 		from viur.core.utils import getCurrentUser


### PR DESCRIPTION
This will fix deferred tasks called inside transactions on the local development server
as they would be called inside the transaction instead.