### PR TITLE
Added a lockEmpty property to UniqueValue

### DIFF
--- a/bones/bone.py
+++ b/bones/bone.py
@@ -47,6 +47,7 @@ class UniqueLockMethod(Enum):
 @dataclass
 class UniqueValue:
 	method: UniqueLockMethod
+	lockEmpty: bool
 	message: str
 
 class baseBone(object):  # One Bone:
@@ -553,6 +554,8 @@ class baseBone(object):  # One Bone:
 			elif isinstance(value, str):
 				return "S-%s" % res
 			raise NotImplementedError("Type %s can't be safely used in an uniquePropertyIndex" % type(value))
+		if not value and not self.unique.lockEmpty:
+			return []  # We are zero/empty string and these should not be locked
 		if not self.multiple:
 			return [hashValue(value)]
 		# We have an multiple bone here

--- a/bones/bone.py
+++ b/bones/bone.py
@@ -45,10 +45,10 @@ class UniqueLockMethod(Enum):
 	SameList = 3  # Same Set of entries (including duplicates), in this specific order
 
 @dataclass
-class UniqueValue:
-	method: UniqueLockMethod
-	lockEmpty: bool
-	message: str
+class UniqueValue:  # Mark a bone as unique (it must have a different value for each entry)
+	method: UniqueLockMethod  # How to handle multiple values (for bones with multiple=True)
+	lockEmpty: bool  # If False, empty values ("", 0) are not locked - needed if a field is unique but not required
+	message: str  # Error-Message displayed to the user if the requested value is already taken
 
 class baseBone(object):  # One Bone:
 	hasDBField = True

--- a/modules/user.py
+++ b/modules/user.py
@@ -32,7 +32,7 @@ class userSkel(Skeleton):
 		caseSensitive=False,
 		searchable=True,
 		indexed=True,
-		unique=UniqueValue(UniqueLockMethod.SameValue, "Username already taken")
+		unique=UniqueValue(UniqueLockMethod.SameValue, True, "Username already taken")
 	)
 
 	# Properties required by custom auth
@@ -49,7 +49,7 @@ class userSkel(Skeleton):
 		indexed=True,
 		required=False,
 		readOnly=True,
-		unique=UniqueValue(UniqueLockMethod.SameValue, "UID already in use")
+		unique=UniqueValue(UniqueLockMethod.SameValue, False, "UID already in use")
 	)
 	gaeadmin = booleanBone(
 		descr=u"Is GAE Admin",


### PR DESCRIPTION
This allows the use of unique on properties that are not allways set (like uid in userSkel).
Currently, there can only be one user account that does not use oauth to authenicate as it locked the empty string