### PR TITLE
added exception for periodic decorated methods with leading underscore

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -428,6 +428,9 @@ def PeriodicTask(interval=0, cronName="default"):
 	"""
 
 	def mkDecorator(fn):
+		if fn.__name__.startswith("_"):
+			raise RuntimeError("Periodic called methods cannot start with an underscore! "
+							   f"Please rename {fn.__name__!r}")
 		global _periodicTasks, _periodicTaskID
 		if not cronName in _periodicTasks:
 			_periodicTasks[cronName] = {}


### PR DESCRIPTION
[Here](https://github.com/viur-framework/viur-core/blob/70a6f3fbece537ad522d7c554354769df1c4d1b2/tasks.py#L98) We would skip methods with an leading underscore from periodic execution, but never get an error. I added an Exception in the according decorator.