### PR TITLE
Fixing subSkel behavior to be ViUR2 compliant

### DIFF
--- a/skeleton.py
+++ b/skeleton.py
@@ -84,7 +84,7 @@ class SkeletonInstance:
 		if clonedBoneMap:
 			self.boneMap = clonedBoneMap
 		elif subSkelNames:
-			boneList = list(chain(*[skelCls.subSkels.get(x, []) for x in subSkelNames]))
+			boneList = ["key", "changedate", "creationdate"] + list(chain(*[skelCls.subSkels.get(x, []) for x in ["*"] + subSkelNames]))
 			doesMatch = lambda name: name in boneList or any([name.startswith(x[:-1]) for x in boneList if x[-1] == "*"])
 			if fullClone:
 				self.boneMap = {k: copy.deepcopy(v) for k, v in skelCls.__boneMap__.items() if doesMatch(k)}
@@ -233,7 +233,7 @@ class BaseSkeleton(object, metaclass=MetaBaseSkel):
 		"""
 		if not args:
 			raise ValueError("Which subSkel?")
-		return cls(subSkelNames=args, fullClone=fullClone)
+		return cls(subSkelNames=list(args), fullClone=fullClone)
 
 	@classmethod
 	def setSystemInitialized(cls):

--- a/skeleton.py
+++ b/skeleton.py
@@ -84,7 +84,7 @@ class SkeletonInstance:
 		if clonedBoneMap:
 			self.boneMap = clonedBoneMap
 		elif subSkelNames:
-			boneList = ["key", "changedate", "creationdate"] + list(chain(*[skelCls.subSkels.get(x, []) for x in ["*"] + subSkelNames]))
+			boneList = ["key"] + list(chain(*[skelCls.subSkels.get(x, []) for x in ["*"] + subSkelNames]))
 			doesMatch = lambda name: name in boneList or any([name.startswith(x[:-1]) for x in boneList if x[-1] == "*"])
 			if fullClone:
 				self.boneMap = {k: copy.deepcopy(v) for k, v in skelCls.__boneMap__.items() if doesMatch(k)}


### PR DESCRIPTION
- the subskel named "*" was always integrated in the past
- it was possible to create subskels without the "key" bone
- IMHO "creationdate" and "changedate" should also be taken always