### PR TITLE
subfield must always be parsed if a relSkel is defined even if it is not multiple

### DIFF
--- a/bones/relationalBone.py
+++ b/bones/relationalBone.py
@@ -373,7 +373,7 @@ class relationalBone(baseBone):
 		return None
 
 	def parseSubfieldsFromClient(self):
-		return self.multiple and (self.using is not None)
+		return self.using is not None
 
 	def singleValueFromClient(self, value, skel, name, origData):
 		oldValues = skel[name]


### PR DESCRIPTION
Currently, all relations that have a relSkel and are not multiple lose their data. 
This hotfix enables you to work with a single relation and relSkel. 