### PR TITLE
Fixing AttributeError in json-renderer

### DIFF
--- a/render/json/default.py
+++ b/render/json/default.py
@@ -220,15 +220,18 @@ class DefaultRender(object):
 	def list(self, skellist, action="list", params=None, **kwargs):
 		res = {}
 		skels = []
+
 		if skellist:
 			for skel in skellist:
 				skels.append(self.renderSkelValues(skel))
 
+			res["cursor"] = skellist.getCursor()
 			res["structure"] = self.renderSkelStructure(skellist.baseSkel)
 		else:
 			res["structure"] = None
+			res["cursor"] = None
+
 		res["skellist"] = skels
-		res["cursor"] = skellist.getCursor()
 		res["action"] = action
 		res["params"] = params
 		currentRequest.get().response.headers["Content-Type"] = "application/json"


### PR DESCRIPTION
This error occurred when skellist is None, which occurs on a previous error.

Here's a log dump of a case where the problem occurred:
```
DEBUG    2020-07-21 14:49:57,575 request.py:391] Calling <bound method List.list of <modules.chatroom.ChatRoom object at 0x7f7d72415850>> with args=[] and kwargs={}
WARNING  2020-07-21 14:49:57,594 relationalBone.py:473] Invalid filtering! kind is not in parentKeys of RelationalBone users!
ERROR    2020-07-21 14:49:57,594 db.py:305] 
Traceback (most recent call last):
  File "~/myProject/deploy/viur/core/db.py", line 300, in mergeExternalFilter
    bone.buildDBFilter(key, skel, self, filters)
  File "~/myProject/deploy/viur/core/bones/relationalBone.py", line 500, in buildDBFilter
    name, skel, dbFilter, rawFilter = self._rewriteQuery(name, skel, dbFilter, rawFilter)
  File "~/myProject/deploy/viur/core/bones/relationalBone.py", line 475, in _rewriteQuery
    raise RuntimeError()
RuntimeError
ERROR    2020-07-21 14:49:57,612 request.py:245] Viur caught an unhandled exception!
ERROR    2020-07-21 14:49:57,612 request.py:246] 'NoneType' object has no attribute 'getCursor'
Traceback (most recent call last):
  File "~/myProject/deploy/viur/core/request.py", line 218, in processRequest
    self.findAndCall(path)
  File "~/myProject/deploy/viur/core/request.py", line 392, in findAndCall
    res = caller(*self.args, **self.kwargs)
  File "~/myProject/deploy/viur/core/prototypes/list.py", line 171, in list
    return self.render.list(res)
  File "~/myProject/deploy/viur/core/render/json/default.py", line 231, in list
    res["cursor"] = skellist.getCursor()
AttributeError: 'NoneType' object has no attribute 'getCursor'
```