### PR TITLE
Let embedsvg load icons from poolfiles

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -16,7 +16,7 @@
    I N F O R M A T I O N    S Y S T E M
 
  ViUR SERVER
- Copyright 2012-2019 by Mausbrand Informationssysteme GmbH
+ Copyright 2012-2020 by Mausbrand Informationssysteme GmbH
 
  ViUR is a free software development framework for the Google App Engine™.
  More about ViUR can be found at https://www.viur.is/.
@@ -34,6 +34,7 @@ from viur.core import request
 from viur.core import languages as servertrans
 from viur.core.i18n import initializeTranslations
 from viur.core import logging as viurLogging  # Initialize request logging
+from viur.core.embedsvg import initializeEmbedSvgPool
 from viur.core.utils import currentRequest, currentSession, currentLanguage, currentRequestData
 from viur.core.session import GaeSession
 import logging
@@ -278,6 +279,8 @@ def setup(modules, render=None, default="html"):
 					uri.lower().startswith("https://") or uri.lower().startswith("http://"))
 	runStartupTasks()  # Add a deferred call to run all queued startup tasks
 	initializeTranslations()
+	initializeEmbedSvgPool()
+
 	assert conf["viur.file.hmacKey"], "You must set a secret and unique Application-Key to viur.file.hmacKey"
 	return app
 

--- a/config.py
+++ b/config.py
@@ -99,6 +99,12 @@ conf = {
 	# Allows the application to register a function that's called before the request gets routed
 	"viur.requestPreprocessor": None,
 
+	# Pathes to icon pool files (JSON-files) used to fill the icon pool
+	"viur.render.html.embedsvg.path": ["/static/icons.json"],
+
+	# This is the embedSvg icon pool
+	"viur.render.html.embedsvg.pool": None,
+
 	# Characters valid for the internal search functionality (all other chars are ignored)
 	"viur.searchValidChars": "abcdefghijklmnopqrstuvwxyz0123456789",
 

--- a/config.py
+++ b/config.py
@@ -100,7 +100,7 @@ conf = {
 	"viur.requestPreprocessor": None,
 
 	# Pathes to icon pool files (JSON-files) used to fill the icon pool
-	"viur.render.html.embedsvg.path": ["/static/icons.json"],
+	"viur.render.html.embedsvg.path": ["/static/embedsvg.json"],
 
 	# This is the embedSvg icon pool
 	"viur.render.html.embedsvg.pool": None,

--- a/embedsvg.py
+++ b/embedsvg.py
@@ -1,0 +1,28 @@
+import os, json, logging
+from viur.core import conf
+
+
+def initializeEmbedSvgPool():
+	if conf["viur.render.html.embedsvg.pool"] is None:
+		conf["viur.render.html.embedsvg.pool"] = {}
+
+		for path in conf["viur.render.html.embedsvg.path"]:
+			logging.debug("embedsvg caching path %r", path)
+
+			content = None
+			try:
+				with open(os.path.join(os.getcwd(), *path.split("/")), "rb") as f:
+					content = f.read().decode("UTF-8")
+			except Exception as e:
+				logging.exception(e)
+
+			if not content:
+				continue
+
+			try:
+				content = json.loads(content)
+				conf["viur.render.html.embedsvg.pool"].update(content)
+
+				logging.info("%d images added successfully to svg pool", len(content))
+			except:
+				logging.error("Content of file %r doesn't look like JSON", path)

--- a/render/html/env/viur.py
+++ b/render/html/env/viur.py
@@ -586,7 +586,7 @@ def embedSvg(self, name):
 
 	The SVG-images are normally generated into a JSON-file located somewhere in the /static folder,
 	where both server and client can fetch the same icon set from one specific place. The default
-	is /static/icons.json, this can be changed or extended to other files using the configuration
+	is /static/embedsvg.json, this can be changed or extended to other files using the configuration
 	variable `conf["viur.render.html.embedsvg.path"]`.
 
 	As a fallback, this function will also look into the /html/embedsvg folder for an SVG-file

--- a/render/html/env/viur.py
+++ b/render/html/env/viur.py
@@ -593,32 +593,8 @@ def embedSvg(self, name):
 	with the particular name. This fallback behavior was standard in ViUR2, the file-based approach
 	described above is standard in ViUR3 now.
 	"""
-	if conf["viur.render.html.embedsvg.pool"] is None:
-		conf["viur.render.html.embedsvg.pool"] = {}
 
-		logging.debug("Embedsvg image pool is empty, loading from configured pathes...")
-
-		for path in conf["viur.render.html.embedsvg.path"]:
-			logging.debug("embedsvg reading path %r", path)
-
-			content = None
-			try:
-				with open(os.path.join(os.getcwd(), *path.split("/")), "rb") as f:
-					content = f.read().decode("UTF-8")
-			except Exception as e:
-				logging.exception(e)
-
-			if not content:
-				continue
-
-			try:
-				content = json.loads(content)
-				conf["viur.render.html.embedsvg.pool"].update(content)
-
-				logging.info("%d images added successfully to svg pool", len(content))
-			except:
-				logging.error("Content of file %r doesn't look like JSON", path)
-
+	# Check for image name in svg pool first...
 	svg = conf["viur.render.html.embedsvg.pool"].get(name)
 	if svg:
 		return svg


### PR DESCRIPTION
This implements the embedsvg feature for the HTML-renderer in an improved version, by using poolfiles for icons that can be shared both by server and client apps.

The SVG-images are normally generated into a JSON-file located somewhere in the /static folder, where both server and client can fetch the same icon set from one specific place. The default is /static/icons.json, this can be changed or extended to other files using the configuration variable `conf["viur.render.html.embedsvg.path"]`.

As a fallback, this function will also look into the /html/embedsvg folder for an SVG-file with the particular name. This fallback behavior was standard in ViUR2, the file-based approach described above is standard in ViUR3 now.