### PR TITLE
Fixing two 500 errors relating key encoding

### DIFF
--- a/skeleton.py
+++ b/skeleton.py
@@ -1120,7 +1120,6 @@ class SkelList(list):
 
 @callDeferred
 def processRemovedRelations(removedKey, cursor=None):
-	removedKey = db.KeyClass.from_legacy_urlsafe(removedKey)
 	updateListQuery = db.Query("viur-relations").filter("dest.__key__ =", removedKey) \
 		.filter("viur_relational_consistency >", 2)
 	updateListQuery = updateListQuery.setCursor(cursor)
@@ -1153,7 +1152,7 @@ def processRemovedRelations(removedKey, cursor=None):
 def updateRelations(destID, minChangeTime, changeList, cursor=None):
 	logging.debug("Starting updateRelations for %s ; minChangeTime %s, Changelist: %s", destID, minChangeTime,
 				  changeList)
-	updateListQuery = db.Query("viur-relations").filter("dest.__key__ =", db.KeyClass.from_legacy_urlsafe(destID)) \
+	updateListQuery = db.Query("viur-relations").filter("dest.__key__ =", destID) \
 		.filter("viur_delayed_update_tag <", minChangeTime).filter("viur_relational_updateLevel =", 0)
 	if changeList:
 		updateListQuery.filter("viur_foreign_keys IN", changeList)


### PR DESCRIPTION
This PR fixes these two errors:

1. This occured when deleting entries:

```
INFO     2020-08-13 01:38:28,865 request.py:297] Running task directly after request: <function callDeferred.<locals>.mkDefered.<locals>.<lambda> at 0x7fc9b70531f0>
[2020-08-13 01:38:28 +0200] [22295] [ERROR] Error handling request /vi/_tasks/execute/clearKind?_unused_time_stamp=1597275500.0140002
Traceback (most recent call last):
  File "/tmp/tmpE5EVA7/lib/python3.8/site-packages/gunicorn/workers/gthread.py", line 271, in handle
    keepalive = self.handle_request(req, conn)
  File "/tmp/tmpE5EVA7/lib/python3.8/site-packages/gunicorn/workers/gthread.py", line 320, in handle_request
    respiter = self.wsgi(environ, resp.start_response)
INFO     2020-08-12 23:38:28,867 module.py:865] default: "POST /vi/_tasks/execute/clearKind?_unused_time_stamp=1597275500.0140002 HTTP/1.1" 500 141
  File "~/myproject/deploy/viur/core/__init__.py", line 293, in app
    handler.processRequest()
  File "~/myproject/deploy/viur/core/request.py", line 298, in processRequest
    task()
  File "~/myproject/deploy/viur/core/tasks.py", line 351, in <lambda>
    task = lambda: func(self, *args, **kwargs)
  File "~/myproject/deploy/viur/core/skeleton.py", line 1123, in processRemovedRelations
    removedKey = db.KeyClass.from_legacy_urlsafe(removedKey)
  File "/tmp/tmpE5EVA7/lib/python3.8/site-packages/google/cloud/datastore/key.py", line 356, in from_legacy_urlsafe
    urlsafe = _to_bytes(urlsafe, encoding="ascii")
  File "/tmp/tmpE5EVA7/lib/python3.8/site-packages/google/cloud/_helpers.py", line 370, in _to_bytes
    raise TypeError("%r could not be converted to bytes" % (value,))
TypeError: <Key('feedentry', 5731480697307136), project=myproject-dev> could not be converted to bytes
```

2. This occured during editing entries:

```
Traceback (most recent call last):
  File "/tmp/tmpE5EVA7/lib/python3.8/site-packages/gunicorn/workers/gthread.py", line 271, in handle
INFO     2020-08-12 23:39:56,582 module.py:865] default: "POST /vi/appcategory/edit/ag9qdXN0ZmFybWluZy1kZXZyGAsSC2FwcGNhdGVnb3J5GICAgJiQ9dAIDA?_unused_time_stamp=1597275595.2700002 HTTP/1.1" 500 141
    keepalive = self.handle_request(req, conn)
  File "/tmp/tmpE5EVA7/lib/python3.8/site-packages/gunicorn/workers/gthread.py", line 320, in handle_request
    respiter = self.wsgi(environ, resp.start_response)
  File "~/myproject/deploy/viur/core/__init__.py", line 293, in app
    handler.processRequest()
  File "~/myproject/deploy/viur/core/request.py", line 298, in processRequest
    task()
  File "~/myproject/deploy/viur/core/tasks.py", line 351, in <lambda>
    task = lambda: func(self, *args, **kwargs)
  File "~/myproject/deploy/viur/core/skeleton.py", line 1156, in updateRelations
    updateListQuery = db.Query("viur-relations").filter("dest.__key__ =", db.KeyClass.from_legacy_urlsafe(destID)) \
  File "/tmp/tmpE5EVA7/lib/python3.8/site-packages/google/cloud/datastore/key.py", line 356, in from_legacy_urlsafe
    urlsafe = _to_bytes(urlsafe, encoding="ascii")
  File "/tmp/tmpE5EVA7/lib/python3.8/site-packages/google/cloud/_helpers.py", line 370, in _to_bytes
    raise TypeError("%r could not be converted to bytes" % (value,))
TypeError: <Key('appcategory', 4859467782946816), project=myproject-dev> could not be converted to bytes
```

I'm not sure my fixes are correct, but they resolve the error.