### PR TITLE
Extend relationalBone to hook-able getEntity function

### DIFF
--- a/bones/relationalBone.py
+++ b/bones/relationalBone.py
@@ -384,8 +384,7 @@ class relationalBone(baseBone):
 			dbKey = None
 			errors = []
 			try:
-				dbKey = db.keyHelper(key, self.kind)
-				entry = db.Get(dbKey)
+				entry = self.getEntity(key)
 				assert entry
 			except:  # Invalid key or something like that
 				logging.info("Invalid reference key >%s< detected on bone '%s'",
@@ -784,12 +783,21 @@ class relationalBone(baseBone):
 
 		return res
 
+	def getEntity(self, key):
+		"""
+		Used to retrieve the referenced entity.
+
+		:param key: Any valid key for self.kind
+		:return: The entity
+		"""
+		key = db.keyHelper(key, self.kind)
+		return db.Get(key)
+
 	def createRelSkelFromKey(self, key: Union[str, db.KeyClass], rel: Union[dict, None] = None):
 		"""
 			Creates a relSkel instance valid for this bone from the given database key.
 		"""
-		key = db.keyHelper(key, self.kind)
-		entity = db.Get(key)
+		entity = self.getEntity(key)
 		if not entity:
 			logging.error("Key %s not found" % str(key))
 			return None


### PR DESCRIPTION
I need this to override the way how an entity is retrieved: It may also be referenced by an unique îdentifier that needs to be looked-up. Here's an example implementation:

```python
class appBone(relationalBone):
	"""
	appBones is a relationalBone that accepts also the app identifier as valid key...
	"""

	def __init__(self, descr="App", kind="app", indexed=True, *args, **kwargs):
		super().__init__(kind=kind, descr=descr, indexed=indexed, *args, **kwargs)

	def getEntity(self, key):
		entity = super().getEntity(key)

		if not entity:
			entity = db.Query(self.kind).filter("identifier", key).getEntry()

		return entity
```