### PR TITLE
Strip username from userpassword/login parameters

### DIFF
--- a/modules/user.py
+++ b/modules/user.py
@@ -142,8 +142,10 @@ class UserPassword(object):
 		if not name or not password or not securitykey.validate(skey, useSessionKey=True):
 			return self.userModule.render.login(self.loginSkel())
 
+		name = name.lower().strip()
+
 		query = db.Query(self.userModule.viewSkel().kindName)
-		res = query.filter("name.idx >=", name.lower()).getEntry()
+		res = query.filter("name.idx >=", name).getEntry()
 
 		if res is None:
 			res = {"password": {"pwhash": "-invalid-", "salt": "-invalid"}, "status": 0, "name": {}}
@@ -155,10 +157,10 @@ class UserPassword(object):
 
 		# Check if the username matches
 		storedUserName = (res.get("name") or {}).get("idx", "")
-		if len(storedUserName) != len(name.lower()):
+		if len(storedUserName) != len(name):
 			isOkay = False
 		else:
-			for x, y in zip(storedUserName, name.lower()):
+			for x, y in zip(storedUserName, name):
 				if x != y:
 					isOkay = False
 


### PR DESCRIPTION
It already happened twice in two ViUR projects, that users reported a login problem which was obviously heavy to find. The reason is: There was a space character behind the user's name. In one case, this was inserted automatically by the operating system which was Android and an android keyboard app. To avoid this problem in future, a strip() function is applied onto the username to make it clean.