### PR TITLE
added backwards compatibility to recordBone singleValueUnserialize method

### DIFF
--- a/bones/recordBone.py
+++ b/bones/recordBone.py
@@ -67,7 +67,7 @@ class recordBone(baseBone):
 							res.append(tag)
 			return res
 
-		value = values.get(key)
+		value = values[key]
 		res = []
 
 		if not value:


### PR DESCRIPTION
Same as in relationalBone, when working with existing viur2 datastore entries we will need this. Don't know if it has already been provided by someone else in some other branch though...