### PR TITLE
Fixing an attribute error raising in the cloud

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -432,7 +432,7 @@ def callDeferred(func):
 			parent = taskClient.queue_path(project, location, queue)
 			task = {
 				'app_engine_http_request': {  # Specify the type of request.
-					'http_method': tasks_v2.HttpMethod.POST,
+					'http_method': tasks_v2.enums.HttpMethod.POST,
 					'relative_uri': '/_tasks/deferred'
 				}
 			}


### PR DESCRIPTION
Hello, I recently got this error causing a 502 Bad Gateway on Google Cloud:
```
Traceback (most recent call last): 
File "/env/lib/python3.7/site-packages/gunicorn/arbiter.py", line 583, in spawn_worker worker.init_process() 
File "/env/lib/python3.7/site-packages/gunicorn/workers/gthread.py", line 92, in init_process super().init_process() 
File "/env/lib/python3.7/site-packages/gunicorn/workers/base.py", line 119, in init_process self.load_wsgi() 
File "/env/lib/python3.7/site-packages/gunicorn/workers/base.py", line 144, in load_wsgi self.wsgi = self.app.wsgi() 
File "/env/lib/python3.7/site-packages/gunicorn/app/base.py", line 67, in wsgi self.callable = self.load() 
File "/env/lib/python3.7/site-packages/gunicorn/app/wsgiapp.py", line 49, in load return self.load_wsgiapp() 
File "/env/lib/python3.7/site-packages/gunicorn/app/wsgiapp.py", line 39, in load_wsgiapp return util.import_app(self.app_uri) 
File "/env/lib/python3.7/site-packages/gunicorn/util.py", line 358, in import_app mod = importlib.import_module(module) 
File "/opt/python3.7/lib/python3.7/importlib/__init__.py", line 127, in import_module return _bootstrap._gcd_import(name[level:], package, level) 
File "<frozen importlib._bootstrap>", line 1006, in _gcd_import 
File "<frozen importlib._bootstrap>", line 983, in _find_and_load 
File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked 
File "<frozen importlib._bootstrap>", line 677, in _load_unlocked 
File "<frozen importlib._bootstrap_external>", line 728, in exec_module 
File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed 
File "/srv/main.py", line 154, in <module> app = core.setup(modules, render) 
File "/srv/viur/core/__init__.py", line 279, in setup runStartupTasks() # Add a deferred call to run all queued startup tasks 
File "/srv/viur/core/tasks.py", line 454, in <lambda> return (lambda *args, **kwargs: mkDefered(func, *args, **kwargs)) 
File "/srv/viur/core/tasks.py", line 436, in mkDefered 'http_method': tasks_v2.HttpMethod.POST, AttributeError: module 'google.cloud.tasks_v2' has no attribute 'HttpMethod'
```

This fixes the problem, but I don't understand why the API changed in this case. This issue is only to don't forget about it.