### PR TITLE
Push /file/download requests into the ede caches …

### DIFF
--- a/modules/file.py
+++ b/modules/file.py
@@ -332,6 +332,13 @@ class File(Tree):
 				raise errors.NotFound()
 			signed_url = blob.generate_signed_url(datetime.now() + timedelta(seconds=60))
 		else:  # We are inside the appengine
+			if validUntil == "0":  # Its an indefinitely valid URL
+				blob = bucket.get_blob(dlPath)
+				if blob.size < 5 * 1024 * 1024:  # Less than 5 MB - Serve directly and push it into the ede caches
+					response = utils.currentRequest.get().response
+					response.headers["Content-Type"] = blob.content_type
+					response.headers["Cache-Control"] = "public, max-age=604800"  # 7 Days
+					return blob.download_as_bytes()
 			auth_request = requests.Request()
 			signed_blob_path = bucket.blob(dlPath)
 			expires_at_ms = datetime.now() + timedelta(seconds=60)

--- a/render/html/env/viur.py
+++ b/render/html/env/viur.py
@@ -615,7 +615,11 @@ def embedSvg(render, name: str, classes: Union[List[str], None] = None, **kwargs
 
 
 @jinjaGlobalFunction
-def downloadUrlFor(render, fileObj, derived=None, expires=timedelta(hours=1)):
+def downloadUrlFor(render, fileObj, expires, derived=None):
+	if "dlkey" not in fileObj and "dest" in fileObj:
+		fileObj = fileObj["dest"]
+	if expires:
+		expires = timedelta(minutes=expires)
 	if not isinstance(fileObj, (SkeletonInstance, dict)) or "dlkey" not in fileObj or "name" not in fileObj:
 		return None
 	if derived and ("derived" not in fileObj or not isinstance(fileObj["derived"], dict)):
@@ -626,7 +630,11 @@ def downloadUrlFor(render, fileObj, derived=None, expires=timedelta(hours=1)):
 		return utils.downloadUrlFor(folder=fileObj["dlkey"], fileName=fileObj["name"], derived=False, expires=expires)
 
 @jinjaGlobalFunction
-def srcSetFor(render, fileObj, expires=timedelta(hours=1)):
+def srcSetFor(render, fileObj, expires):
+	if "dlkey" not in fileObj and "dest" in fileObj:
+		fileObj = fileObj["dest"]
+	if expires:
+		expires = timedelta(minutes=expires)
 	if not isinstance(fileObj, (SkeletonInstance, dict)) or not "dlkey" in fileObj or "derived" not in fileObj:
 		return None
 	if not isinstance(fileObj["derived"], dict):


### PR DESCRIPTION
…if it does not expire; require exiration explictly set in jinja2 render