### PR TITLE
Feature/hooks before actions

### DIFF
--- a/prototypes/list.py
+++ b/prototypes/list.py
@@ -180,7 +180,7 @@ class List(BasicApplication):
 		or as the first parameter in *args*. The function performs several access control checks
 		on the requested entity before it is modified.
 
-		.. seealso:: :func:`editSkel`, :func:`onEdited`, :func:`canEdit`
+		.. seealso:: :func:`editSkel`, :func:`onEdit`, :func:`onEdited`, :func:`canEdit`
 
 		:returns: The rendered, edited object of the entry, eventually with error hints.
 
@@ -230,7 +230,7 @@ class List(BasicApplication):
 
 		The function performs several access control checks on the requested entity before it is added.
 
-		.. seealso:: :func:`addSkel`, :func:`onAdded`, :func:`canAdd`
+		.. seealso:: :func:`addSkel`, :func:`onAdd`, :func:`onAdded`, :func:`canAdd`
 
 		:returns: The rendered, added object of the entry, eventually with error hints.
 
@@ -515,7 +515,7 @@ class List(BasicApplication):
 
 		.. seealso:: :func:`add`, :func:`onAdded`
 		"""
-		pass
+		logging.debug("onAdd")
 
 	def onAdded(self, skel):
 		"""
@@ -546,7 +546,7 @@ class List(BasicApplication):
 
 		.. seealso:: :func:`edit`, :func:`onEdited`
 		"""
-		pass
+		logging.debug("onEdit")
 
 	def onEdited(self, skel):
 		"""
@@ -578,7 +578,7 @@ class List(BasicApplication):
 
 		.. seealso:: :func:`view`
 		"""
-		pass
+		logging.debug("onView")
 
 	def onDelete(self, skel):
 		"""
@@ -591,7 +591,7 @@ class List(BasicApplication):
 
 		.. seealso:: :func:`delete`, :func:`onDeleted`
 		"""
-		pass
+		logging.debug("onDelete")
 
 	def onDeleted(self, skel):
 		"""

--- a/prototypes/list.py
+++ b/prototypes/list.py
@@ -515,7 +515,7 @@ class List(BasicApplication):
 
 		.. seealso:: :func:`add`, :func:`onAdded`
 		"""
-		logging.debug("onAdd")
+		pass
 
 	def onAdded(self, skel):
 		"""
@@ -546,7 +546,7 @@ class List(BasicApplication):
 
 		.. seealso:: :func:`edit`, :func:`onEdited`
 		"""
-		logging.debug("onEdit")
+		pass
 
 	def onEdited(self, skel):
 		"""
@@ -578,7 +578,7 @@ class List(BasicApplication):
 
 		.. seealso:: :func:`view`
 		"""
-		logging.debug("onView")
+		pass
 
 	def onDelete(self, skel):
 		"""
@@ -591,7 +591,7 @@ class List(BasicApplication):
 
 		.. seealso:: :func:`delete`, :func:`onDeleted`
 		"""
-		logging.debug("onDelete")
+		pass
 
 	def onDeleted(self, skel):
 		"""

--- a/prototypes/singleton.py
+++ b/prototypes/singleton.py
@@ -104,7 +104,7 @@ class Singleton(BasicApplication):
 
 		The function performs several access control checks on the requested entity before it is rendered.
 
-		.. seealso:: :func:`viewSkel`, :func:`canView`, :func:`onViewed`
+		.. seealso:: :func:`viewSkel`, :func:`canView`, :func:`onView`
 
 		:returns: The rendered representation of the entity.
 
@@ -121,7 +121,7 @@ class Singleton(BasicApplication):
 		if not skel.fromDB(key):
 			raise errors.NotFound()
 
-		self.onViewed(skel)
+		self.onView(skel)
 		return self.render.view(skel)
 
 	@exposed
@@ -165,6 +165,7 @@ class Singleton(BasicApplication):
 		if not securitykey.validate(skey, useSessionKey=True):
 			raise errors.PreconditionFailed()
 
+		self.onEdit(skel)
 		skel.toDB()
 		self.onEdited(skel)
 		return self.render.editSuccess(skel)
@@ -276,6 +277,19 @@ class Singleton(BasicApplication):
 			return (True)
 		return (False)
 
+	def onEdit(self, skel):
+		"""
+		Hook function that is called before editing an entry.
+
+		It can be overridden for a module-specific behavior.
+
+		:param skel: The Skeleton that is going to be edited.
+		:type skel: :class:`server.skeleton.Skeleton`
+
+		.. seealso:: :func:`edit`, :func:`onEdited`
+		"""
+		logging.debug("onEdit")
+
 	def onEdited(self, skel):
 		"""
 		Hook function that is called after modifying the entry.
@@ -286,26 +300,26 @@ class Singleton(BasicApplication):
 		:param skel: The Skeleton that has been modified.
 		:type skel: :class:`server.skeleton.Skeleton`
 
-		.. seealso:: :func:`edit`
+		.. seealso:: :func:`edit`, :func:`onEdit`
 		"""
 		logging.info("Entry changed: %s" % skel["key"])
 		user = utils.getCurrentUser()
 		if user:
 			logging.info("User: %s (%s)" % (user["name"], user["key"]))
 
-	def onViewed(self, skel):
+	def onView(self, skel):
 		"""
 		Hook function that is called when viewing an entry.
 
 		It should be overridden for a module-specific behavior.
 		The default is doing nothing.
 
-		:param skel: The Skeleton that is viewed.
+		:param skel: The Skeleton that is being viewed.
 		:type skel: :class:`server.skeleton.Skeleton`
 
 		.. seealso:: :func:`view`
 		"""
-		pass
+		logging.debug("onView")
 
 
 Singleton.admin = True

--- a/prototypes/singleton.py
+++ b/prototypes/singleton.py
@@ -288,7 +288,7 @@ class Singleton(BasicApplication):
 
 		.. seealso:: :func:`edit`, :func:`onEdited`
 		"""
-		logging.debug("onEdit")
+		pass
 
 	def onEdited(self, skel):
 		"""
@@ -319,7 +319,7 @@ class Singleton(BasicApplication):
 
 		.. seealso:: :func:`view`
 		"""
-		logging.debug("onView")
+		pass
 
 
 Singleton.admin = True

--- a/prototypes/tree.py
+++ b/prototypes/tree.py
@@ -722,7 +722,7 @@ class Tree(BasicApplication):
 
 		.. seealso:: :func:`add`, :func:`onAdded`
 		"""
-		logging.debug("onAdd")
+		pass
 
 	def onAdded(self, skel):
 		"""
@@ -752,7 +752,7 @@ class Tree(BasicApplication):
 
 		.. seealso:: :func:`edit`, :func:`onEdited`
 		"""
-		logging.debug("onEdit")
+		pass
 
 	def onEdited(self, skel):
 		"""
@@ -783,7 +783,7 @@ class Tree(BasicApplication):
 
 		.. seealso:: :func:`view`
 		"""
-		logging.debug("onView")
+		pass
 
 	def onDelete(self, skel):
 		"""
@@ -796,7 +796,7 @@ class Tree(BasicApplication):
 
 		.. seealso:: :func:`delete`, :func:`onDeleted`
 		"""
-		logging.debug("onDelete")
+		pass
 
 	def onDeleted(self, skel):
 		"""


### PR DESCRIPTION
Additionally to the **onAdded**, **onEdited**, **onDeleted** hooks, this pull request introduces further hooks called before the specific database operation is performed, using **onAdd**, **onEdit** and **onDelete**.
Furthermore **onViewed** has been renamed to **onView** because the hook is performed before the operation takes place.