### PR TITLE
proposed var name correction in srcSetFor

### DIFF
--- a/render/html/env/viur.py
+++ b/render/html/env/viur.py
@@ -641,8 +641,8 @@ def srcSetFor(render, fileObj, expires):
 	if not isinstance(fileObj["derived"], dict):
 		return ""
 	resList = []
-	for fileName, deriviation in fileObj["derived"].items():
-		params = deriviation["params"]
+	for fileName, derivate in fileObj["derived"].items():
+		params = derivate["params"]
 		if params.get("group") == "srcset":
 			resList.append("%s %sw" % (utils.downloadUrlFor(fileObj["dlkey"], fileName, True, expires), params["width"]))
 	return ", ".join(resList)


### PR DESCRIPTION
deriviation is a made up word, derivation was probably meant, but it means something different. derivate would be the correct noun. we should name variables correctly if we want international developers to understand what is going on