### PR TITLE
Set of parsing-fixes for new skeleton API

### DIFF
--- a/bones/bone.py
+++ b/bones/bone.py
@@ -191,6 +191,9 @@ class baseBone(object):  # One Bone:
 							else:
 								res[lang] = None
 				else:
+					for key in data.keys():  # Allow setting relations with using, multiple and languages back to none
+						if key == "%s.%s" % (name, lang):
+							fieldSubmitted = True
 					prefix = "%s.%s." % (name, lang)
 					if multiple:
 						tmpDict = {}
@@ -235,6 +238,9 @@ class baseBone(object):  # One Bone:
 				else:
 					return val, True
 			else:  # No multi-lang but collect subfields
+				for key in data.keys():  # Allow setting relations with using, multiple and languages back to none
+					if key == name:
+						fieldSubmitted = True
 				prefix = "%s." % name
 				if multiple:
 					tmpDict = {}

--- a/bones/numericBone.py
+++ b/bones/numericBone.py
@@ -42,10 +42,22 @@ class numericBone(baseBone):
 			return "NaN not allowed"
 
 	def getEmptyValue(self):
-		return 0
+		if self.precision:
+			return 0.0
+		else:
+			return 0
 
 	def isEmpty(self, rawValue: Any):
-		return not (rawValue != self.getEmptyValue() or bool(rawValue))
+		if isinstance(rawValue, str) and not rawValue:
+			return True
+		try:
+			if self.precision:
+				rawValue = float(rawValue.replace(",", ".", 1))
+			else:
+				rawValue = int(rawValue.replace(",", ".", 1))
+		except:
+			return True
+		return rawValue == self.getEmptyValue()
 
 	def singleValueFromClient(self, value, skel, name, origData):
 		try:

--- a/bones/relationalBone.py
+++ b/bones/relationalBone.py
@@ -879,6 +879,8 @@ class relationalBone(baseBone):
 		"""
 		def blobsFromRefSet(refSet):
 			result = set()
+			if refSet is None:
+				return result
 			for key, _bone in refSet["dest"].items():
 				result = result.union(_bone.getReferencedBlobs(refSet["dest"], key))
 			if refSet["rel"]:

--- a/modules/file.py
+++ b/modules/file.py
@@ -381,7 +381,7 @@ class File(Tree):
 			skel["mimetype"] = utils.escapeString(blob.content_type)
 			skel["name"] = utils.escapeString(blob.name.replace("%s/source/" % targetKey, ""))
 			skel["size"] = blob.size
-			skel["rootnode"] = rootNode["key"] if rootNode else None
+			skel["parentrepo"] = rootNode["key"] if rootNode else None
 			skel["weak"] = rootNode is None
 			skel.toDB()
 			# Add updated download-URL as the auto-generated isn't valid yet

--- a/modules/page.py
+++ b/modules/page.py
@@ -1,19 +1,19 @@
 # -*- coding: utf-8 -*-
-from viur.core.prototypes.hierarchy import Hierarchy, HierarchySkel
+from viur.core.prototypes.tree import Tree, TreeSkel
 from viur.core.bones import *
 
 
-class pageSkel(HierarchySkel):
+class pageSkel(TreeSkel):
 	kindName = "page"
 	searchindex = "page"
 	name = stringBone(descr=u"Name", indexed=True, searchable=True, required=True)
 	descr = textBone(descr=u"Content", required=True, searchable=True)
 
 
-class Page(Hierarchy):
+class Page(Tree):
 	adminInfo = {
 		"name": u"Pages",  # Name of this module, as shown in ViUR Admin (will be translated at runtime)
-		"handler": "hierarchy",  # Which handler to invoke
+		"handler": "tree.nodeonly.page",  # Which handler to invoke
 		"icon": "icons/modules/hierarchy.svg",  # Icon for this module
 		"columns": ["name", "language", "isactive"],
 		"previewurls": {
@@ -27,16 +27,8 @@ class Page(Hierarchy):
 		repo = self.ensureOwnModuleRootNode()
 		return [{
 			"name": u"pages",
-			"key": str(repo.key())
+			"key": repo.key
 		}]
-
-	getAvailableRootNodes.internalExposed = True
-
-	def canList(self, parent):
-		return True
-
-	def canView(self, key):
-		return True
 
 
 Page.html = True


### PR DESCRIPTION
- Allow setting relationalBones (with multiple, and using) back to empty
- Fixed isEmpty handling in numericBone
- Fixed imports in modules/page