### PR TITLE
Made the json-render aware of our translation-class

### DIFF
--- a/render/admin/__init__.py
+++ b/render/admin/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from viur.core.render.json.default import DefaultRender
+from viur.core.render.json.default import DefaultRender, CustomJsonEncoder
 from viur.core.render.json.user import UserRender as user
 from viur.core.render.json.file import FileRender as file
 from viur.core.utils import currentRequest, currentLanguage, currentSession
@@ -65,9 +65,9 @@ def getStructure(adminTree, module):
 						storeType = stype.replace("Skel", "")+("LeafSkel" if treeType == TreeType.Leaf else "NodeSkel")
 						res[storeType] = default().renderSkelStructure(skel)
 	if res:
-		return (json.dumps(res))
+		return json.dumps(res, cls=CustomJsonEncoder)
 	else:
-		return (json.dumps(None))
+		return json.dumps(None)
 
 
 def setLanguage(lang, skey):

--- a/render/json/default.py
+++ b/render/json/default.py
@@ -1,10 +1,21 @@
 # -*- coding: utf-8 -*-
 import json
 from collections import OrderedDict
-from viur.core import errors, bones, utils, db
-from viur.core.skeleton import RefSkel, skeletonByKind, BaseSkeleton, SkeletonInstance
+from viur.core import bones, utils, db
+from viur.core.skeleton import SkeletonInstance
 from viur.core.utils import currentRequest
+from viur.core.i18n import translate
+from typing import Any
 
+class CustomJsonEncoder(json.JSONEncoder):
+	"""
+		This custom JSON-Encoder for this json-render ensures that translations are evaluated and can be dumped.
+	"""
+
+	def default(self, o: Any) -> Any:
+		if isinstance(o, translate):
+			return str(o)
+		return json.JSONEncoder.default(self, o)
 
 class DefaultRender(object):
 	kind = "json"
@@ -210,7 +221,7 @@ class DefaultRender(object):
 			"params": params
 		}
 		currentRequest.get().response.headers["Content-Type"] = "application/json"
-		return json.dumps(res)
+		return json.dumps(res, cls=CustomJsonEncoder)
 
 	def view(self, skel, action="view", params=None, *args, **kwargs):
 		return self.renderEntry(skel, action, params)
@@ -239,7 +250,7 @@ class DefaultRender(object):
 		res["action"] = action
 		res["params"] = params
 		currentRequest.get().response.headers["Content-Type"] = "application/json"
-		return json.dumps(res)
+		return json.dumps(res, cls=CustomJsonEncoder)
 
 	def editSuccess(self, skel, params=None, **kwargs):
 		return self.renderEntry(skel, "editSuccess", params)
@@ -266,7 +277,7 @@ class DefaultRender(object):
 			skels.append(self.renderSkelValues(skel))
 
 		res["entrys"] = skels
-		return json.dumps(res)
+		return json.dumps(res, cls=CustomJsonEncoder)
 
 	def renameSuccess(self, rootNode, path, src, dest, params=None, *args, **kwargs):
 		return json.dumps("OKAY")

--- a/render/vi/__init__.py
+++ b/render/vi/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from viur.core.render.json.default import DefaultRender
+from viur.core.render.json.default import DefaultRender, CustomJsonEncoder
 from viur.core.render.vi.user import UserRender as user
 from viur.core.render.json.file import FileRender as file
 from viur.core.skeleton import Skeleton
@@ -70,9 +70,9 @@ def getStructure(adminTree, module):
 						storeType = stype.replace("Skel", "")+("LeafSkel" if treeType == TreeType.Leaf else "NodeSkel")
 						res[storeType] = default().renderSkelStructure(skel)
 	if res:
-		return (json.dumps(res))
+		return json.dumps(res, cls=CustomJsonEncoder)
 	else:
-		return (json.dumps(None))
+		return json.dumps(None)
 
 
 def setLanguage(lang, skey):


### PR DESCRIPTION
This allows translations to be used anywhere (bone-descriptions; it's params; in values for selectBones etc).
Replaces #15