### PR TITLE
Change only the level of the root logger (effectively)

### DIFF
--- a/logging.py
+++ b/logging.py
@@ -1,11 +1,11 @@
-# -*- coding: utf-8 -*-
+import logging
+
 import google.cloud.logging
+from google.cloud.logging import Resource
 from google.cloud.logging.handlers import CloudLoggingHandler
 from google.cloud.logging_v2.handlers.handlers import EXCLUDED_LOGGER_DEFAULTS
-from google.cloud.logging import Resource
-import logging
-from viur.core.utils import currentRequest, projectID
 
+from viur.core.utils import currentRequest, projectID
 
 client = google.cloud.logging.Client()
 requestLoggingRessource = Resource(type="gae_app",
@@ -36,8 +36,15 @@ class ViURDefaultLogger(CloudLoggingHandler):
 		)
 
 
+oldLevels = {k: v.getEffectiveLevel()
+			 for k, v in logging.root.manager.loggerDict.items()
+			 if isinstance(v, logging.Logger)}
+
 logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
+
+for loggerName, level in oldLevels.items():
+	logging.getLogger(loggerName).setLevel(level)
 
 handler = ViURDefaultLogger(client, name="ViUR-Messages", resource=Resource(type="gae_app", labels={}))
 logger.addHandler(handler)


### PR DESCRIPTION
Currently we're changing the level of the root-logger to DEBUG. This causes other (child) loggers to take over the same level as well. In the devappserver now also the whole background_transport logs fall out. This is annoying.

I have now modified it so that in the end only the level of the root logger was changed, the other loggers keep their level. 
So only logs from the application are logged (and a few from the worker). 