### PR TITLE
Add support to use a task queue emulator

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -58,11 +58,11 @@ if _gaeApp:
 	regionPrefix = _gaeApp.split("~")[0]
 	queueRegion = regionMap.get(regionPrefix)
 
-if not queueRegion and os.getenv("TASKS_EMULATOR") is None:
+if not queueRegion and utils.isLocalDevelopmentServer and os.getenv("TASKS_EMULATOR") is None:
 	# Probably local development server
 	logging.warning("Taskqueue disabled, tasks will run inline!")
 
-if os.getenv("TASKS_EMULATOR") is None:
+if not utils.isLocalDevelopmentServer or os.getenv("TASKS_EMULATOR") is None:
 	taskClient = tasks_v2.CloudTasksClient()
 else:
 	taskClient = tasks_v2.CloudTasksClient(
@@ -197,7 +197,7 @@ class TaskHandler:
 			logging.critical('Detected an attempted XSRF attack. The header "X-AppEngine-Taskname" was not set.')
 			raise errors.Forbidden()
 		if req.environ.get("HTTP_X_APPENGINE_USER_IP") not in _appengineServiceIPs \
-				and os.getenv("TASKS_EMULATOR") is None:
+				and (not utils.isLocalDevelopmentServer or os.getenv("TASKS_EMULATOR") is None):
 			logging.critical('Detected an attempted XSRF attack. This request did not originate from Task Queue.')
 			raise errors.Forbidden()
 		# Check if the retry count exceeds our warning threshold

--- a/tasks.py
+++ b/tasks.py
@@ -445,7 +445,6 @@ def callDeferred(func):
 			except:
 				usr = None
 			env = {"user": usr}
-			logging.error(env)
 			try:
 				env["lang"] = currentLanguage.get()
 			except AttributeError:  # This isn't originating from a normal request

--- a/tasks.py
+++ b/tasks.py
@@ -8,8 +8,10 @@ from functools import wraps
 from time import sleep
 from typing import Any, Callable, Dict
 
+import grpc
 import pytz
 from google.cloud import tasks_v2
+from google.cloud.tasks_v2.services.cloud_tasks.transports import CloudTasksGrpcTransport
 from google.protobuf import timestamp_pb2
 
 from viur.core import db, errors, utils
@@ -56,11 +58,17 @@ if _gaeApp:
 	regionPrefix = _gaeApp.split("~")[0]
 	queueRegion = regionMap.get(regionPrefix)
 
-if not queueRegion:
+if not queueRegion and os.getenv("TASKS_EMULATOR") is None:
 	# Probably local development server
 	logging.warning("Taskqueue disabled, tasks will run inline!")
 
-taskClient = tasks_v2.CloudTasksClient()
+if os.getenv("TASKS_EMULATOR") is None:
+	taskClient = tasks_v2.CloudTasksClient()
+else:
+	taskClient = tasks_v2.CloudTasksClient(
+		transport=CloudTasksGrpcTransport(channel=grpc.insecure_channel(os.getenv("TASKS_EMULATOR")))
+	)
+	queueRegion = "local"
 
 _periodicTasks: Dict[str, Dict[Callable, int]] = {}
 _callableTasks = {}
@@ -188,7 +196,8 @@ class TaskHandler:
 		if 'X-AppEngine-TaskName' not in req.headers:
 			logging.critical('Detected an attempted XSRF attack. The header "X-AppEngine-Taskname" was not set.')
 			raise errors.Forbidden()
-		if req.environ.get("HTTP_X_APPENGINE_USER_IP") not in _appengineServiceIPs:
+		if req.environ.get("HTTP_X_APPENGINE_USER_IP") not in _appengineServiceIPs \
+				and os.getenv("TASKS_EMULATOR") is None:
 			logging.critical('Detected an attempted XSRF attack. This request did not originate from Task Queue.')
 			raise errors.Forbidden()
 		# Check if the retry count exceeds our warning threshold


### PR DESCRIPTION
This changes allows to run tasks (with retries) in a separate request even on local development server.

# Usage

## Install emulator
I've used https://pypi.org/project/gcloud-tasks-emulator/
```sh
pip install gcloud-tasks-emulator
```

## Start the emulator
```sh
gcloud-tasks-emulator start -p=9999 -t=9090 --queue-yaml=deploy/queue.yaml --queue-yaml-project=$YOUR_PROJECT_NAME --queue-yaml-location=local -r 50
```
Take a look at `gcloud-tasks-emulator start -h` for the meaning of the commands

## Start ViUR
with the environment variable `TASKS_EMULATOR` pointing to the emulator-server.
```sh
dev_appserver.py -A $YOUR_PROJECT_NAME --port=9090 --env_var TASKS_EMULATOR=localhost:9999 deploy
```
(Alternatively you can add this in your app.yaml. However, be careful that you not deploy this, otherwise it will use this server in the cloud as well and will probably fail)
