### PR TITLE
Run fixUnindexableProperties on dbSession["data"]

### DIFF
--- a/session.py
+++ b/session.py
@@ -86,7 +86,7 @@ class GaeSession:
 					userid = None
 				try:
 					dbSession = db.Entity(db.Key(self.kindName, self.cookieKey))
-					dbSession["data"] = self.session
+					dbSession["data"] = db.fixUnindexableProperties(self.session)
 					dbSession["staticSecurityKey"] = self.staticSecurityKey
 					dbSession["securityKey"] = self.securityKey
 					dbSession["lastseen"] = time()


### PR DESCRIPTION
This is a fix for session values with >1500 bytes, which couldn't be stored.