### PR TITLE
Replaced enum Tree.TreeType by string

### DIFF
--- a/modules/file.py
+++ b/modules/file.py
@@ -23,7 +23,7 @@ from google.oauth2.service_account import Credentials as ServiceAccountCredentia
 
 from viur.core import db, errors, exposed, forcePost, forceSSL, internalExposed, securitykey, utils
 from viur.core.bones import *
-from viur.core.prototypes.tree import Tree, TreeSkel, TreeType
+from viur.core.prototypes.tree import Tree, TreeSkel
 from viur.core.skeleton import skeletonByKind
 from viur.core.tasks import PeriodicTask, callDeferred
 from viur.core.utils import projectID
@@ -296,13 +296,13 @@ class File(Tree):
 		uploadUrl = blob.create_resumable_upload_session(content_type=mimeType, size=size, timeout=60)
 		# Create a corresponding file-lock object early, otherwise we would have to ensure that the file-lock object
 		# the user creates matches the file he had uploaded
-		fileSkel = self.addSkel(TreeType.Leaf)
+		fileSkel = self.addSkel("leaf")
 		fileSkel["name"] = "pending"
 		fileSkel["size"] = 0
 		fileSkel["mimetype"] = "application/octetstream"
 		fileSkel["dlkey"] = targetKey
 		fileSkel["parentdir"] = None
-		fileSkel["pendingparententry"] = db.keyHelper(node, self.addSkel(TreeType.Node).kindName) if node else None
+		fileSkel["pendingparententry"] = db.keyHelper(node, self.addSkel("node").kindName) if node else None
 		fileSkel["pending"] = True
 		fileSkel["weak"] = True
 		fileSkel["width"] = 0
@@ -340,10 +340,10 @@ class File(Tree):
 		else:
 			if node:
 				rootNode = self.getRootNode(node)
-				if not self.canAdd(TreeType.Leaf, rootNode):
+				if not self.canAdd("leaf", rootNode):
 					raise errors.Forbidden()
 			else:
-				if not self.canAdd(TreeType.Leaf, None):
+				if not self.canAdd("leaf", None):
 					raise errors.Forbidden()
 			maxSize = None  # The user has some file/add permissions, don't restrict fileSize
 		if maxSize:
@@ -470,7 +470,7 @@ class File(Tree):
 			targetKey = kwargs.get("key")
 			if not skey or not securitykey.validate(skey, useSessionKey=True) or not targetKey:
 				raise errors.PreconditionFailed()
-			skel = self.addSkel(TreeType.Leaf)
+			skel = self.addSkel("leaf")
 			if not skel.fromDB(targetKey):
 				raise errors.NotFound()
 			if not skel["pending"]:

--- a/render/admin/__init__.py
+++ b/render/admin/__init__.py
@@ -32,7 +32,6 @@ timestamp.exposed = True
 
 
 def getStructure(adminTree, module):
-	from viur.core.prototypes.tree import TreeType
 	if not module in dir(adminTree) \
 		or not "adminInfo" in dir(getattr(adminTree, module)) \
 		or not getattr(adminTree, module).adminInfo:
@@ -55,14 +54,14 @@ def getStructure(adminTree, module):
 	if not res and "nodeSkelCls" in dir(moduleObj):
 		# Try Node/Leaf
 		for stype in ["viewSkel", "editSkel", "addSkel"]:
-			for treeType in [TreeType.Node, TreeType.Leaf]:
+			for treeType in ["node", "leaf"]:
 				if stype in dir(moduleObj):
 					try:
 						skel = getattr(moduleObj, stype)(treeType)
 					except TypeError:
 						continue
 					if isinstance(skel, SkeletonInstance):
-						storeType = stype.replace("Skel", "")+("LeafSkel" if treeType == TreeType.Leaf else "NodeSkel")
+						storeType = stype.replace("Skel", "")+("LeafSkel" if treeType == "leaf" else "NodeSkel")
 						res[storeType] = default().renderSkelStructure(skel)
 	if res:
 		return json.dumps(res, cls=CustomJsonEncoder)

--- a/render/vi/__init__.py
+++ b/render/vi/__init__.py
@@ -37,7 +37,6 @@ timestamp.exposed = True
 
 
 def getStructure(adminTree, module):
-	from viur.core.prototypes.tree import TreeType
 	if not module in dir(adminTree) \
 		or not "adminInfo" in dir(getattr(adminTree, module)) \
 		or not getattr(adminTree, module).adminInfo:
@@ -60,14 +59,14 @@ def getStructure(adminTree, module):
 	if not res and "nodeSkelCls" in dir(moduleObj):
 		# Try Node/Leaf
 		for stype in ["viewSkel", "editSkel", "addSkel"]:
-			for treeType in [TreeType.Node, TreeType.Leaf]:
+			for treeType in ["node", "leaf"]:
 				if stype in dir(moduleObj):
 					try:
 						skel = getattr(moduleObj, stype)(treeType)
 					except TypeError:
 						continue
 					if isinstance(skel, SkeletonInstance):
-						storeType = stype.replace("Skel", "")+("LeafSkel" if treeType == TreeType.Leaf else "NodeSkel")
+						storeType = stype.replace("Skel", "")+("LeafSkel" if treeType == "leaf" else "NodeSkel")
 						res[storeType] = default().renderSkelStructure(skel)
 	if res:
 		return json.dumps(res, cls=CustomJsonEncoder)


### PR DESCRIPTION
Using string here instead of the enum has several advantages, especially because it is checked and delegated in several situations from a string into the enum. This has been discussed in ViUR meeting from Mar 05, 2021.

With Python 3.8, [string literals](https://www.python.org/dev/peps/pep-0586/) will also be made available to test against in the annotations then.