### PR TITLE
Ensure the current projectid is whitelisted in conf["viur.validApplicationIDs"]

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -34,7 +34,7 @@ from viur.core import request
 from viur.core import languages as servertrans
 from viur.core.i18n import initializeTranslations
 from viur.core import logging as viurLogging  # Initialize request logging
-from viur.core.utils import currentRequest, currentSession, currentLanguage, currentRequestData
+from viur.core.utils import currentRequest, currentSession, currentLanguage, currentRequestData, projectID
 from viur.core.session import GaeSession
 import logging
 import webob
@@ -241,11 +241,11 @@ def setup(modules, render=None, default="html"):
 		(=> /user instead of /html/user)
 		:type default: str
 	"""
+	from viur.core.bones import bone
 	import skeletons  # This import is not used here but _must_ remain to ensure that the
 	# application's data models are explicitly imported at some place!
-
-	from viur.core.bones import bone
-
+	assert projectID in conf["viur.validApplicationIDs"], \
+		"Refusing to start, applicationID %s is not in conf['viur.validApplicationIDs']" % projectID
 	if not render:
 		import viur.core.render
 		render = viur.core.render

--- a/core/config.py
+++ b/core/config.py
@@ -142,6 +142,9 @@ conf = {
 	# If set, must be a tuple of two functions serializing/restoring additional environmental data in deferred requests
 	"viur.tasks.customEnvironmentHandler": None,
 
+	# Which application-ids we're supposed to run on
+	"viur.validApplicationIDs": [],
+
 	# Will be set to server.__version__ in server.__init__
 	"viur.version": None,
 }


### PR DESCRIPTION
This should prevent accidental deployments to the wrong application or starting the dev_appserver on another appid