### PR TITLE
Fix timezone mismatch in dateBone.py

### DIFF
--- a/core/bones/dateBone.py
+++ b/core/bones/dateBone.py
@@ -222,10 +222,7 @@ class dateBone(baseBone):
 		for key in [x for x in rawFilter.keys() if x.startswith(name)]:
 			resDict = {}
 			if not self.fromClient(resDict, key, rawFilter):  # Parsing succeeded
-				super(dateBone, self).buildDBFilter(name, skel, dbFilter, {
-					# TODO: Should we use utcNow?
-					key: datetime.now().strptime(resDict[key].strftime("%d.%m.%Y %H:%M:%S"), "%d.%m.%Y %H:%M:%S")},
-													prefix=prefix)
+				super(dateBone, self).buildDBFilter(name, skel, dbFilter, {key: resDict[key]}, prefix=prefix)
 		return dbFilter
 
 	def performMagic(self, valuesCache, name, isAdd):

--- a/core/bones/dateBone.py
+++ b/core/bones/dateBone.py
@@ -99,7 +99,7 @@ class dateBone(baseBone):
 				value = datetime.fromtimestamp(float(rawValue), tz=time_zone).replace(microsecond=0)
 		elif not self.date and self.time:
 			try:
-				value = datetime.fromisoformat(value)
+				value = time_zone.localize(datetime.fromisoformat(value))
 			except:
 				try:
 					if str(rawValue).count(":") > 1:
@@ -124,7 +124,7 @@ class dateBone(baseBone):
 			value = tmpRes
 		else:
 			try:
-				value = datetime.fromisoformat(value)
+				value = time_zone.localize(datetime.fromisoformat(value))
 			except:
 				try:
 					if " " in rawValue:  # Date with time

--- a/core/bones/dateBone.py
+++ b/core/bones/dateBone.py
@@ -1,28 +1,13 @@
 # -*- coding: utf-8 -*-
 from viur.core.bones import baseBone
 from viur.core import request
-from time import time, mktime
-from datetime import time, datetime, timedelta
+from datetime import datetime, timedelta
 from viur.core.bones.bone import ReadFromClientError, ReadFromClientErrorSeverity
 from viur.core.i18n import translate
 from viur.core.utils import currentRequest, currentRequestData, utcNow
-import logging
 from typing import List, Union
 
-try:
-	import pytz
-except:
-	pytz = None
-
-## Workaround for Python Bug #7980 - time.strptime not thread safe
-datetime.now().strptime("2010%02d%02d" % (1, 1), "%Y%m%d")
-datetime.now().strftime("%Y%m%d")
-
-
-def datetimeToTimestamp(datetimeObj: datetime) -> int:
-	"""Converts this DateTime-Object back into Unixtime"""
-	return int(round(mktime(datetimeObj.timetuple())))
-
+import pytz
 
 class dateBone(baseBone):
 	type = "date"
@@ -44,8 +29,8 @@ class dateBone(baseBone):
 			:type date: bool
 			:param time: Should this bone contain time information?
 			:type time: bool
-			:param localize: Automatically convert this time into the users timezone? Only valid if this bone
-                                contains date and time-information!
+			:param localize: Assume users timezone for in and output? Only valid if this bone
+                                contains date and time-information! Per default, UTC time is used.
 			:type localize: bool
 		"""
 		baseBone.__init__(self, *args, **kwargs)
@@ -72,34 +57,62 @@ class dateBone(baseBone):
 			left unchanged and an error-message
 			is returned.
 
+			Value is assumed to be in local time zone only if both self.date and self.time are set to True
+			and self.localize is True.
+
+			Value is valid if, when converted into String, it complies following formats:\n
+			- is digit (may include one '-') and valid POSIX timestamp: converted from timestamp; assumes UTC timezone\n
+			- is digit (may include one '-') and NOT valid POSIX timestamp and not date and time: interpreted as seconds after epoch\n
+			- 'now': current time\n
+			- 'nowX', where X converted into String is added as seconds to current time\n
+			- '%H:%M:%S' if not date and time\n
+			- '%M:%S' if not date and time\n
+			- '%S' if not date and time\n
+			- '%Y-%m-%d %H:%M:%S' (ISO date format)\n
+			- '%Y-%m-%d %H:%M' (ISO date format)\n
+			- '%Y-%m-%d' (ISO date format)\n
+			- '%m/%d/%Y %H:%M:%S' (US date-format)\n
+			- '%m/%d/%Y %H:%M' (US date-format)\n
+			- '%m/%d/%Y' (US date-format)\n
+			- '%d.%m.%Y %H:%M:%S' (EU date-format)\n
+			- '%d.%m.%Y %H:%M' (EU date-format)\n
+			- '%d.%m.%Y' (EU date-format)\n
+			-  \n
+
+			The resulting year must be >= 1900.
+
 			:param name: Our name in the skeleton
 			:type name: str
-			:param data: *User-supplied* request-data
-			:type data: dict
-			:returns: str or None
+			:param value: *User-supplied* request-data
+			:type value: str(value) has to be of valid format
+			:returns: tuple[datetime or None, [Errors] or None]
 		"""
+		if self.date and self.time and self.localize:
+			time_zone = self.guessTimeZone()
+		else:
+			time_zone = pytz.utc
 		rawValue = value
 		if str(rawValue).replace("-", "", 1).replace(".", "", 1).isdigit():
 			if int(rawValue) < -1 * (2 ** 30) or int(rawValue) > (2 ** 31) - 2:
 				value = False  # its invalid
 			else:
-				value = datetime.fromtimestamp(float(rawValue))
+				value = datetime.fromtimestamp(float(rawValue), tz=time_zone)
 		elif not self.date and self.time:
 			try:
 				if str(rawValue).count(":") > 1:
 					(hour, minute, second) = [int(x.strip()) for x in str(rawValue).split(":")]
-					value = datetime(year=1970, month=1, day=1, hour=hour, minute=minute, second=second)
+					value = datetime(year=1970, month=1, day=1, hour=hour, minute=minute, second=second, tzinfo=time_zone)
 				elif str(rawValue).count(":") > 0:
 					(hour, minute) = [int(x.strip()) for x in str(rawValue).split(":")]
-					value = datetime(year=1970, month=1, day=1, hour=hour, minute=minute)
+					value = datetime(year=1970, month=1, day=1, hour=hour, minute=minute, tzinfo=time_zone)
 				elif str(rawValue).replace("-", "", 1).isdigit():
-					value = datetime(year=1970, month=1, day=1, second=int(rawValue))
+					value = datetime(year=1970, month=1, day=1, second=int(rawValue), tzinfo=time_zone)
 				else:
 					value = False  # its invalid
 			except:
 				value = False
 		elif str(rawValue).lower().startswith("now"):
-			tmpRes = utcNow().astimezone(self.guessTimeZone())
+			tmpRes = datetime.now(time_zone)
 			if len(str(rawValue)) > 4:
 				try:
 					tmpRes += timedelta(seconds=int(str(rawValue)[3:]))
@@ -108,33 +121,28 @@ class dateBone(baseBone):
 			value = tmpRes
 		else:
 			try:
-				if self.date and self.time:
-					timeZone = self.guessTimeZone()
-				else:
-					timeZone = pytz.utc
 				if " " in rawValue:  # Date with time
 					try:  # Times with seconds
 						if "-" in rawValue:  # ISO Date
-							value = datetime.strptime(str(rawValue), "%Y-%m-%d %H:%M:%S")
+							value = time_zone.localize(datetime.strptime(str(rawValue), "%Y-%m-%d %H:%M:%S"))
 						elif "/" in rawValue:  # Ami Date
-							value = datetime.strptime(str(rawValue), "%m/%d/%Y %H:%M:%S")
+							value = time_zone.localize(datetime.strptime(str(rawValue), "%m/%d/%Y %H:%M:%S"))
 						else:  # European Date
-							value = datetime.strptime(str(rawValue), "%d.%m.%Y %H:%M:%S")
+							value = time_zone.localize(datetime.strptime(str(rawValue), "%d.%m.%Y %H:%M:%S"))
 					except:
 						if "-" in rawValue:  # ISO Date
-							value = datetime.strptime(str(rawValue), "%Y-%m-%d %H:%M")
+							value = time_zone.localize(datetime.strptime(str(rawValue), "%Y-%m-%d %H:%M"))
 						elif "/" in rawValue:  # Ami Date
-							value = datetime.strptime(str(rawValue), "%m/%d/%Y %H:%M")
+							value = time_zone.localize(datetime.strptime(str(rawValue), "%m/%d/%Y %H:%M"))
 						else:  # European Date
-							value = datetime.strptime(str(rawValue), "%d.%m.%Y %H:%M")
+							value = time_zone.localize(datetime.strptime(str(rawValue), "%d.%m.%Y %H:%M"))
 				else:
 					if "-" in rawValue:  # ISO (Date only)
-						value = datetime.strptime(str(rawValue), "%Y-%m-%d")
+						value = time_zone.localize(datetime.strptime(str(rawValue), "%Y-%m-%d"))
 					elif "/" in rawValue:  # Ami (Date only)
-						value = datetime.strptime(str(rawValue), "%m/%d/%Y")
+						value = time_zone.localize(datetime.strptime(str(rawValue), "%m/%d/%Y"))
 					else:  # European (Date only)
-						value = datetime.strptime(str(rawValue), "%d.%m.%Y")
-				value = datetime(value.year, value.month, value.day, value.hour, value.minute, value.second, tzinfo=timeZone)
+						value = time_zone.localize(datetime.strptime(str(rawValue), "%d.%m.%Y"))
 			except:
 				value = False  # its invalid
 		if value is False:
@@ -193,17 +201,19 @@ class dateBone(baseBone):
 				value = value.replace(hour=0, minute=0, second=0, microsecond=0)
 			elif not self.date:
 				value = value.replace(year=1970, month=1, day=1)
-			elif self.date and self.time:
-				# This usually happens due to datetime.now(). Use utils.utcNow() instead
-				assert value.tzinfo, "Encountered a native Datetime object in %s - refusing to save." % name
+			# We should always deal with timezone aware datetimes
+			assert value.tzinfo, "Encountered a native Datetime object in %s - refusing to save." % name
 		return value
 
 	def singleValueUnserialize(self, value, skel: 'viur.core.skeleton.SkeletonInstance', name: str):
 		if isinstance(value, datetime):
-			if self.date and self.time:
-				return value.astimezone(self.guessTimeZone())
+			# Serialized value is timezone aware.
+			# If local timezone is needed, set here, else force UTC.
+			if self.date and self.time and self.localize:
+				time_zone = self.guessTimeZone()
 			else:
-				return value
+				time_zone = pytz.utc
+			return value.astimezone(time_zone)
 		else:
 			# We got garbage from the datastore
 			return None
@@ -213,6 +223,7 @@ class dateBone(baseBone):
 			resDict = {}
 			if not self.fromClient(resDict, key, rawFilter):  # Parsing succeeded
 				super(dateBone, self).buildDBFilter(name, skel, dbFilter, {
+					# TODO: Should we use utcNow?
 					key: datetime.now().strptime(resDict[key].strftime("%d.%m.%Y %H:%M:%S"), "%d.%m.%Y %H:%M:%S")},
 													prefix=prefix)
 		return dbFilter

--- a/core/bones/dateBone.py
+++ b/core/bones/dateBone.py
@@ -99,18 +99,21 @@ class dateBone(baseBone):
 				value = datetime.fromtimestamp(float(rawValue), tz=time_zone).replace(microsecond=0)
 		elif not self.date and self.time:
 			try:
-				if str(rawValue).count(":") > 1:
-					(hour, minute, second) = [int(x.strip()) for x in str(rawValue).split(":")]
-					value = datetime(year=1970, month=1, day=1, hour=hour, minute=minute, second=second, tzinfo=time_zone)
-				elif str(rawValue).count(":") > 0:
-					(hour, minute) = [int(x.strip()) for x in str(rawValue).split(":")]
-					value = datetime(year=1970, month=1, day=1, hour=hour, minute=minute, tzinfo=time_zone)
-				elif str(rawValue).replace("-", "", 1).isdigit():
-					value = datetime(year=1970, month=1, day=1, second=int(rawValue), tzinfo=time_zone)
-				else:
-					value = False  # its invalid
+				value = datetime.fromisoformat(value)
 			except:
-				value = False
+				try:
+					if str(rawValue).count(":") > 1:
+						(hour, minute, second) = [int(x.strip()) for x in str(rawValue).split(":")]
+						value = datetime(year=1970, month=1, day=1, hour=hour, minute=minute, second=second, tzinfo=time_zone)
+					elif str(rawValue).count(":") > 0:
+						(hour, minute) = [int(x.strip()) for x in str(rawValue).split(":")]
+						value = datetime(year=1970, month=1, day=1, hour=hour, minute=minute, tzinfo=time_zone)
+					elif str(rawValue).replace("-", "", 1).isdigit():
+						value = datetime(year=1970, month=1, day=1, second=int(rawValue), tzinfo=time_zone)
+					else:
+						value = False  # its invalid
+				except:
+					value = False
 		elif str(rawValue).lower().startswith("now"):
 			tmpRes = datetime.now(time_zone)
 			if len(str(rawValue)) > 4:
@@ -121,30 +124,33 @@ class dateBone(baseBone):
 			value = tmpRes
 		else:
 			try:
-				if " " in rawValue:  # Date with time
-					try:  # Times with seconds
-						if "-" in rawValue:  # ISO Date
-							value = time_zone.localize(datetime.strptime(str(rawValue), "%Y-%m-%d %H:%M:%S"))
-						elif "/" in rawValue:  # Ami Date
-							value = time_zone.localize(datetime.strptime(str(rawValue), "%m/%d/%Y %H:%M:%S"))
-						else:  # European Date
-							value = time_zone.localize(datetime.strptime(str(rawValue), "%d.%m.%Y %H:%M:%S"))
-					except:
-						if "-" in rawValue:  # ISO Date
-							value = time_zone.localize(datetime.strptime(str(rawValue), "%Y-%m-%d %H:%M"))
-						elif "/" in rawValue:  # Ami Date
-							value = time_zone.localize(datetime.strptime(str(rawValue), "%m/%d/%Y %H:%M"))
-						else:  # European Date
-							value = time_zone.localize(datetime.strptime(str(rawValue), "%d.%m.%Y %H:%M"))
-				else:
-					if "-" in rawValue:  # ISO (Date only)
-						value = time_zone.localize(datetime.strptime(str(rawValue), "%Y-%m-%d"))
-					elif "/" in rawValue:  # Ami (Date only)
-						value = time_zone.localize(datetime.strptime(str(rawValue), "%m/%d/%Y"))
-					else:  # European (Date only)
-						value = time_zone.localize(datetime.strptime(str(rawValue), "%d.%m.%Y"))
+				value = datetime.fromisoformat(value)
 			except:
-				value = False  # its invalid
+				try:
+					if " " in rawValue:  # Date with time
+						try:  # Times with seconds
+							if "-" in rawValue:  # ISO Date
+								value = time_zone.localize(datetime.strptime(str(rawValue), "%Y-%m-%d %H:%M:%S"))
+							elif "/" in rawValue:  # Ami Date
+								value = time_zone.localize(datetime.strptime(str(rawValue), "%m/%d/%Y %H:%M:%S"))
+							else:  # European Date
+								value = time_zone.localize(datetime.strptime(str(rawValue), "%d.%m.%Y %H:%M:%S"))
+						except:
+							if "-" in rawValue:  # ISO Date
+								value = time_zone.localize(datetime.strptime(str(rawValue), "%Y-%m-%d %H:%M"))
+							elif "/" in rawValue:  # Ami Date
+								value = time_zone.localize(datetime.strptime(str(rawValue), "%m/%d/%Y %H:%M"))
+							else:  # European Date
+								value = time_zone.localize(datetime.strptime(str(rawValue), "%d.%m.%Y %H:%M"))
+					else:
+						if "-" in rawValue:  # ISO (Date only)
+							value = time_zone.localize(datetime.strptime(str(rawValue), "%Y-%m-%d"))
+						elif "/" in rawValue:  # Ami (Date only)
+							value = time_zone.localize(datetime.strptime(str(rawValue), "%m/%d/%Y"))
+						else:  # European (Date only)
+							value = time_zone.localize(datetime.strptime(str(rawValue), "%d.%m.%Y"))
+				except:
+					value = False  # its invalid
 		if value is False:
 			return self.getEmptyValue(), [ReadFromClientError(ReadFromClientErrorSeverity.Invalid, "Invalid value entered")]
 		value = value.replace(microsecond=0)

--- a/core/render/json/default.py
+++ b/core/render/json/default.py
@@ -137,11 +137,7 @@ class DefaultRender(object):
 		"""
 		if bone.type == "date" or bone.type.startswith("date."):
 			if value:
-				if bone.date and bone.time:
-					return value.strftime("%d.%m.%Y %H:%M:%S%z")
-				elif bone.date:
-					return value.strftime("%d.%m.%Y")
-				return value.strftime("%H:%M:%S")
+				return value.isoformat()
 		elif isinstance(bone, bones.relationalBone):
 			if isinstance(value, dict):
 				return {

--- a/core/render/json/default.py
+++ b/core/render/json/default.py
@@ -138,10 +138,9 @@ class DefaultRender(object):
 		if bone.type == "date" or bone.type.startswith("date."):
 			if value:
 				if bone.date and bone.time:
-					return value.strftime("%d.%m.%Y %H:%M:%S")
+					return value.strftime("%d.%m.%Y %H:%M:%S%z")
 				elif bone.date:
 					return value.strftime("%d.%m.%Y")
-
 				return value.strftime("%H:%M:%S")
 		elif isinstance(bone, bones.relationalBone):
 			if isinstance(value, dict):


### PR DESCRIPTION
Changed to always use timezone aware datetime objects, with UTC as default.
Fixed usage of localize flag.
Fixed documentation for singleValueFromClient.
Removed Workaround for a Python 2.7-only bug.
Removed datetimeToTimestamp, since it is never used. Additionally, it would convert local time into Unixtime, maintaining timezone time shifts. The posix timestamp should always be UTC-time, since no assumptions about timezone can be made.
Made pytz library mandatory.