### PR TITLE
Hash passwords in passwordBone early on (in fromClient)

### DIFF
--- a/core/render/html/default.py
+++ b/core/render/html/default.py
@@ -294,7 +294,8 @@ class Render(object):
 				for entry in value:
 					ret.append(self.collectSkelData(entry))
 				return ret
-
+		elif bone.type == "password":
+			return ""
 		elif bone.type == "key":
 			return db.encodeKey(boneValue) if boneValue else None
 

--- a/core/render/json/default.py
+++ b/core/render/json/default.py
@@ -151,6 +151,8 @@ class DefaultRender(object):
 				}
 		elif isinstance(bone, bones.recordBone):
 			return self.renderSkelValues(value)
+		elif isinstance(bone, bones.passwordBone):
+			return ""
 		elif isinstance(bone, bones.keyBone):
 			return db.encodeKey(value) if value else None
 		else:

--- a/core/render/xml/default.py
+++ b/core/render/xml/default.py
@@ -201,6 +201,8 @@ class DefaultRender(object):
 					"dest": self.renderSkelValues(value["dest"]),
 					"rel": self.renderSkelValues(value.get("rel"))
 				}
+		elif isinstance(bone, passwordBone):
+			return ""
 		else:
 			return value
 


### PR DESCRIPTION
And prevent passwordBones from being rendered in html/json/xml render
As we don't escape passwords (to allow special characters) we must ensure it's never looped back to the client