### PR TITLE
Fix for bcc and cc key error when trying to send an email

### DIFF
--- a/core/email.py
+++ b/core/email.py
@@ -319,10 +319,15 @@ class EmailTransportSendInBlue(EmailTransport):
 		}
 		for dest in dests:
 			dataDict["to"].append(EmailTransportSendInBlue.splitAddress(dest))
-		for dest in bcc:
-			dataDict["bcc"].append(EmailTransportSendInBlue.splitAddress(dest))
-		for dest in cc:
-			dataDict["cc"].append(EmailTransportSendInBlue.splitAddress(dest))
+		# intitialize bcc and cc lists in dataDict
+		if bcc:
+			dataDict["bcc"] = []
+			for dest in bcc:
+				dataDict["bcc"].append(EmailTransportSendInBlue.splitAddress(dest))
+		if cc:
+			dataDict["cc"] = []
+			for dest in cc:
+				dataDict["cc"].append(EmailTransportSendInBlue.splitAddress(dest))
 		if headers:
 			if "Reply-To" in headers:
 				dataDict["replyTo"] = EmailTransportSendInBlue.splitAddress(headers["Reply-To"])


### PR DESCRIPTION
This cannot have been tested on a live system. When passing a list of strings for bcc and/or cc, the core throws an uncaught exception because the keys are missing from the dataDict in the deliverEmail method. This fix is probably not elegant and may be improved by someone who knows what they are doing.