### PR TITLE
Fix NoneType error when more than one bcc has been pushed into bcc list.

### DIFF
--- a/core/email.py
+++ b/core/email.py
@@ -323,11 +323,13 @@ class EmailTransportSendInBlue(EmailTransport):
 		if bcc:
 			dataDict["bcc"] = []
 			for dest in bcc:
-				dataDict["bcc"].append(EmailTransportSendInBlue.splitAddress(dest))
+				if dest:
+					dataDict["bcc"].append(EmailTransportSendInBlue.splitAddress(dest))
 		if cc:
 			dataDict["cc"] = []
 			for dest in cc:
-				dataDict["cc"].append(EmailTransportSendInBlue.splitAddress(dest))
+				if dest:
+					dataDict["cc"].append(EmailTransportSendInBlue.splitAddress(dest))
 		if headers:
 			if "Reply-To" in headers:
 				dataDict["replyTo"] = EmailTransportSendInBlue.splitAddress(headers["Reply-To"])


### PR DESCRIPTION
BCC can be a list of several addresses which lead to an error... probably due to my very inelegant fix of the former problem where bcc and cc did not work at all.