### PR TITLE
Determine appVersion in order for cache to work

### DIFF
--- a/core/cache.py
+++ b/core/cache.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-import logging
+import logging, os
 from datetime import timedelta
 from functools import wraps
 from hashlib import sha512
@@ -87,9 +87,8 @@ def keyFromArgs(f, userSensitive, languageSensitive, evaluatedArgs, path, args, 
 			return None
 	res["__path"] = path  # Different path might have different output (html,xml,..)
 	try:
-		appVersion = currentRequest.get().request.environ["CURRENT_VERSION_ID"].split('.')[0]
+		appVersion = os.getenv("GAE_VERSION")
 	except:
-		# FIXME
 		logging.error("Could not determine the current application version! Caching might produce unexpected results!")
 		appVersion = ""
 	res["__appVersion"] = appVersion


### PR DESCRIPTION
"CURRENT_PROJECT_ID" does not exist anymore... just let the host OS report the env var "GAE_VERSION"