### PR TITLE
Fixed re-deferring in deferred calls

### DIFF
--- a/core/tasks.py
+++ b/core/tasks.py
@@ -262,6 +262,9 @@ class TaskHandler:
 		elif cmd == "unb":
 			if not funcPath in _deferedTasks:
 				logging.error("ViUR missed a deferred task! %s(%s,%s)", funcPath, args, kwargs)
+			# We call the deferred function *directly* (without walking through the mkDeferred lambda), so ensure
+			# that any hit to another deferred function will defer again
+			req.DEFERED_TASK_CALLED = True
 			try:
 				_deferedTasks[funcPath](*args, **kwargs)
 			except PermanentTaskFailure:


### PR DESCRIPTION
This Bug has been ported from ViUR2 - it causes two deferred calls being executed in the same http request if the deferred function is not bound to a BasicApplication (eg. it's defined on module-level).