### PR TITLE
Temp. disable the changelist evaluation in updateRelations

### DIFF
--- a/core/skeleton.py
+++ b/core/skeleton.py
@@ -1187,6 +1187,7 @@ def processRemovedRelations(removedKey, cursor=None):
 
 @callDeferred
 def updateRelations(destID, minChangeTime, changeList, cursor=None):
+	changeList = None  # Temp. disable the changeList evaluation as it causes the cursor to fail
 	logging.debug("Starting updateRelations for %s ; minChangeTime %s, Changelist: %s", destID, minChangeTime,
 				  changeList)
 	updateListQuery = db.Query("viur-relations").filter("dest.__key__ =", destID) \


### PR DESCRIPTION
This causes the query to become a list of queries (due to the IN filter) - which currently don't support cursors.
We'll loose a minor optimization (we'll process more entities in updateRelations than we've to) so we should re-enable this as soon we support (internal) cursors on queries with a IN filter.