### PR TITLE
Added validations to catch invalid recipient addresses early in sendEmail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ For the 2.x changelog see the [viur/server](https://github.com/viur-framework/se
 
 ## [develop] - Current development version
 
+## Added
+- Added validations to catch invalid recipient addresses early in sendEmail
+
 ## [3.0.0]
 
 ### Changed

--- a/core/email.py
+++ b/core/email.py
@@ -181,6 +181,9 @@ def sendEMail(*,
 	cc = normalizeToList(cc)
 	bcc = normalizeToList(bcc)
 	assert dests or cc or bcc, "No destination address given"
+	assert all([isinstance(x, str) and x for x in dests]), "Found non-string or empty destination address"
+	assert all([isinstance(x, str) and x for x in cc]), "Found non-string or empty cc address"
+	assert all([isinstance(x, str) and x for x in bcc]), "Found non-string or empty bcc address"
 	attachments = normalizeToList(attachments)
 	if not (bool(stringTemplate) ^ bool(tpl)):
 		raise ValueError("You have to set the params 'tpl' xor a 'stringTemplate'.")


### PR DESCRIPTION
Currently, if f.E. None is contained in one list, only the deferred call will fail, making it hard to debug