### PR TITLE
Updated CSP-Rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ For the 2.x changelog see the [viur/server](https://github.com/viur-framework/se
 - Added validations to catch invalid recipient addresses early in sendEmail
 - 'connect-src': self and 'upgrade-insecure-requests' CSP directives by default
 
+## Changed
+- Replaced *.ggpht.com and *.googleusercontent.com CSP directives by storage.googleapis.com
+
 ### Fixed
 - Bones with different languages can now be tested with {% if skel["bone"] %} as expected
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ For the 2.x changelog see the [viur/server](https://github.com/viur-framework/se
 
 ## Added
 - Added validations to catch invalid recipient addresses early in sendEmail
+- 'connect-src': self and 'upgrade-insecure-requests' CSP directives by default
 
 ### Fixed
 - Bones with different languages can now be tested with {% if skel["bone"] %} as expected

--- a/core/config.py
+++ b/core/config.py
@@ -115,7 +115,9 @@ conf = {
 			'script-src': ['self'],
 			# Required to login with google:
 			'frame-src': ['self', 'www.google.com', 'drive.google.com', 'accounts.google.com'],
-			'form-action': ['self']
+			'form-action': ['self'],
+			'connect-src': ['self'],
+			'upgrade-insecure-requests': [],
 		}
 	},
 	# Per default, we'll emit Referrer-Policy: strict-origin so no referrers leak to external services

--- a/core/config.py
+++ b/core/config.py
@@ -111,7 +111,7 @@ conf = {
 		'enforce': {
 			'style-src': ['self'],
 			'default-src': ['self'],
-			'img-src': ['self', '*.ggpht.com', '*.googleusercontent.com'],  # Serving-URLs of file-Bones will point here
+			'img-src': ['self', 'storage.googleapis.com'],  # Serving-URLs of file-Bones will point here
 			'script-src': ['self'],
 			# Required to login with google:
 			'frame-src': ['self', 'www.google.com', 'drive.google.com', 'accounts.google.com'],


### PR DESCRIPTION
Added connect-src: self and upgrade-insecure-requests CSP rules by default,
Replaced img-src  '*.ggpht.com' and '*.googleusercontent.com' (which where only used by the old blobstore) with storage.googleapis.com