### PR TITLE
Bugfixes for recordBone

### DIFF
--- a/core/bones/recordBone.py
+++ b/core/bones/recordBone.py
@@ -44,6 +44,9 @@ class recordBone(baseBone):
 		return usingSkel
 
 	def singleValueSerialize(self, value, skel: 'SkeletonInstance', name: str, parentIndexed: bool):
+		if not value:
+			return value
+
 		return value.serialize(parentIndexed=False)
 
 	def parseSubfieldsFromClient(self) -> bool:

--- a/core/render/html/env/viur.py
+++ b/core/render/html/env/viur.py
@@ -531,7 +531,7 @@ def renderEditBone(render, skel, boneName, boneErrors=None, prefix=None):
 	return tpl.render(
 		boneName=((prefix + ".") if prefix else "") + boneName,
 		boneParams=boneParams,
-		boneValue=skel["value"][boneName],
+		boneValue=skel["value"][boneName] if boneName in skel["value"] else None,
 		boneErrors=boneErrors
 	)
 


### PR DESCRIPTION
- singleValueSerialize is called with None as value when the field is unset
- boneName may not be available the dictionary `skel["value"}` as key