### PR TITLE
Fixed referencing viurCurrentSeoKeys in relations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ For the 2.x changelog see the [viur/server](https://github.com/viur-framework/se
 
 ### Fixed
 - AdminInfo for tree modules without a leaf skel
+- Referencing viurCurrentSeoKeys in relationalBones
 - Helptext support in Jinja2 translation extension
 - Bones with different languages can now be tested with {% if skel["bone"] %} as expected
 - Several bugs regarding importing data from an ViUR2 instance

--- a/core/skeleton.py
+++ b/core/skeleton.py
@@ -538,6 +538,22 @@ class seoKeyBone(stringBone):
 		except KeyError:
 			skel.accessedValues[name] = self.getDefaultValue(skel)
 
+	def serialize(self, skel: 'SkeletonInstance', name: str, parentIndexed: bool) -> bool:
+		# Serialize also to skel["viur"]["viurCurrentSeoKeys"], so we can use this bone in relations
+		if name in skel.accessedValues:
+			newVal = skel.accessedValues[name]
+			if not skel.dbEntity.get("viur"):
+				skel.dbEntity["viur"] = db.Entity()
+			res = db.Entity()
+			res["_viurLanguageWrapper_"] = True
+			for language in self.languages:
+				if not self.indexed:
+					res.exclude_from_indexes.add(language)
+				res[language] = None
+				if language in newVal:
+					res[language] = self.singleValueSerialize(newVal[language], skel, name, parentIndexed)
+			skel.dbEntity["viur"]["viurCurrentSeoKeys"] = res
+		return True
 
 class Skeleton(BaseSkeleton, metaclass=MetaSkel):
 	kindName: str = __undefindedC__  # To which kind we save our data to


### PR DESCRIPTION
Serialize viurCurrentSeoKeys back to skel.dbEntity["viur"]["viurCurrentSeoKeys"]. As this bone is always read from this "viur" entity, we'd have also to write back to it, otherwise it's not usable in relations.