### PR TITLE
Added versionHash and appVersion to utils.py and html render

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ For the 2.x changelog see the [viur/server](https://github.com/viur-framework/se
 ## Added
 - Added validations to catch invalid recipient addresses early in sendEmail
 - 'connect-src': self and 'upgrade-insecure-requests' CSP directives by default
+- versionHash and appVersion variables to utils and jinja2 render 
 
 ## Changed
 - Replaced *.ggpht.com and *.googleusercontent.com CSP directives by storage.googleapis.com

--- a/core/render/html/env/viur.py
+++ b/core/render/html/env/viur.py
@@ -11,6 +11,7 @@ from datetime import timedelta
 from hashlib import sha512
 from typing import Dict, List, Union, Optional
 
+import viur.core.render.html.default
 from viur.core import db, errors, prototypes, securitykey, utils
 from viur.core.render.html.utils import jinjaGlobalFilter, jinjaGlobalFunction
 from viur.core.skeleton import RelSkel, SkeletonInstance
@@ -210,6 +211,23 @@ def getHostUrl(render, forceSSL=False, *args, **kwargs):
 		url = "https://" + url[7:]
 	return url
 
+@jinjaGlobalFunction
+def getVersionHash(render: 'viur.core.render.html.default.Render') -> str:
+	"""
+		Jinja2 global: Return the application hash for the current version. This can be used for cache-busting in
+			resource links (eg. /static/css/style.css?v={{ getVersionHash() }}. This hash is stable for each version
+			deployed (identical across all instances), but will change whenever a new version is deployed.
+	:return: The current version hash
+	"""
+	return utils.versionHash
+
+@jinjaGlobalFunction
+def getAppVersion(render: 'viur.core.render.html.default.Render') -> str:
+	"""
+		Jinja2 global: Return the application version for the current version as set on deployment.
+	:return: The current version
+	"""
+	return utils.appVersion
 
 @jinjaGlobalFunction
 def redirect(render, url):

--- a/core/utils.py
+++ b/core/utils.py
@@ -20,6 +20,10 @@ currentLanguage = ContextVar("Language", default=None)
 # Determine which ProjectID we currently run in (as the app_identity module isn't available anymore)
 _, projectID = google.auth.default()
 del _
+appVersion = os.getenv("GAE_VERSION")  # Name of this version as deployed to the appengine
+# Hash of appVersion used for cache-busting for static resources (css etc) that does not reveal the actual version name
+versionHash = urlsafe_b64encode(hashlib.sha256((appVersion+projectID).encode("UTF8")).digest()).decode("ASCII")
+versionHash = "".join([x for x in versionHash if x in string.digits+string.ascii_letters])[1:7]  # Strip +, / and =
 # Determine our basePath (as os.getCWD is broken on appengine)
 projectBasePath = globals()["__file__"].replace("/viur/core/utils.py", "")
 isLocalDevelopmentServer = os.environ['GAE_ENV'] == "localdev"


### PR DESCRIPTION
This will provide a consistent way for cache-busting resource links (eg /static/css/style.css?v={{getVersionHash()}}) when a new version is deployed