### PR TITLE
Added logic to import blobs that have been copied client-side

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ For the 2.x changelog see the [viur/server](https://github.com/viur-framework/se
 ## Added
 - Added validations to catch invalid recipient addresses early in sendEmail
 - 'connect-src': self and 'upgrade-insecure-requests' CSP directives by default
+- The ability to import blobs that have been copied client-side from the old (non cloud-storage) blobstore
 
 ## Changed
 - Replaced *.ggpht.com and *.googleusercontent.com CSP directives by storage.googleapis.com

--- a/core/bones/fileBone.py
+++ b/core/bones/fileBone.py
@@ -164,8 +164,10 @@ class fileBone(treeLeafBone):
 			val = skel[boneName]
 			if isinstance(val, list):
 				for x in val:
-					importBlobFromViur2(x["dest"]["dlkey"])
+					importBlobFromViur2(x["dest"]["dlkey"], x["dest"]["name"])
 					recreateFileEntryIfNeeded(x["dest"])
 			elif isinstance(val, dict):
-				importBlobFromViur2(val["dest"]["dlkey"])
+				if not "dest" in val:
+					return
+				importBlobFromViur2(val["dest"]["dlkey"], val["dest"]["name"])
 				recreateFileEntryIfNeeded(val["dest"])


### PR DESCRIPTION
Some (very old projects) don't have their blobstore exposed in the cloud store yet, so these blobs have to be copied client-side.
The advance is that we don't have to resolve blob-store dlkeys to cloud-storage files, so we don't need a mapping service to be depoyed to the old project we're importing from.