### PR TITLE
Removed internal resorting of items in selectBone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ For the 2.x changelog see the [viur/server](https://github.com/viur-framework/se
 - Correctly exclude non-indexed but translated bones from the datastore index
 - Reenabled changelist evaluation in updateRelations
 
+### Removed
+- Internals resorting of values in selectBone. They will be shown in the order specified
 
 ## [3.0.0]
 

--- a/core/bones/selectBone.py
+++ b/core/bones/selectBone.py
@@ -18,37 +18,10 @@ class selectBone(baseBone):
 			:param values: dict of key->value pairs from which the user can choose from. Values will be translated
 			:type values: dict
 		"""
-
 		if defaultValue is None and multiple:
 			defaultValue = []
-
 		super(selectBone, self).__init__(defaultValue=defaultValue, multiple=multiple, *args, **kwargs)
-
-		if "sortBy" in kwargs:
-			logging.warning("The sortBy parameter is deprecated. Please use an orderedDict for 'values' instead")
-
-		if isinstance(values, dict) and not isinstance(values, OrderedDict):
-			vals = list(values.items())
-			if "sortBy" in kwargs:
-				sortBy = kwargs["sortBy"]
-
-				if not sortBy in ["keys", "values"]:
-					raise ValueError("sortBy must be \"keys\" or \"values\"")
-
-				if sortBy == "keys":
-					vals.sort(key=lambda x: x[0])
-				else:
-					vals.sort(key=lambda x: x[1])
-			else:
-				vals.sort(key=lambda x: x[1])
-
-			self.values = OrderedDict(vals)
-
-		elif isinstance(values, list):
-			self.values = OrderedDict([(x, x) for x in values])
-
-		elif isinstance(values, OrderedDict):
-			self.values = values
+		self.values = values
 
 	def singleValueFromClient(self, value, skel, name, origData):
 		if not str(value):


### PR DESCRIPTION
This is not needed in python3 as all dictionaries are sorted and will break if values are translated