### PR TITLE
Correct the response status code

### DIFF
--- a/core/request.py
+++ b/core/request.py
@@ -19,7 +19,7 @@ from abc import ABC, abstractmethod
 	point for incomming http requests. The main class is the :class:BrowserHandler. Each request will get it's
 	own instance of that class which then holds the reference to the request and response object.
 	Additionally, this module defines the RequestValidator interface which provides a very early hook into the
-	request processing (useful for global ratelimiting, DDoS prevention or access control).  
+	request processing (useful for global ratelimiting, DDoS prevention or access control).
 """
 
 class RequestValidator(ABC):
@@ -314,7 +314,7 @@ class BrowseHandler():  # webapp.RequestHandler
 			if conf["viur.debug.traceExceptions"]:
 				raise
 			self.response.body = b""
-			self.response.status = '%d %s' % (e.status, e.descr)
+			self.response.status = '%d %s' % (e.status, e.name)
 			res = None
 			if conf["viur.errorHandler"]:
 				try:


### PR DESCRIPTION
Use the shorter `name` variable of the `HTTPException` instead of the verbose `descr`.
Then we also use the Reason-Phrases suggested in the [RFC 7231 Sec. 6.1](https://datatracker.ietf.org/doc/html/rfc7231#section-6.1).

Test with:
```py
class Index(BasicApplication):
    @exposed
    def testEx(self):
        raise errors.NotFound()
```
and
```sh
curl -I http://localhost:8080/testEx
```

Old result:
```plain
HTTP/1.1 404 The requested resource could not be found.
...
```

New result:
```plain
HTTP/1.1 404 Not Found
...
```