### PR TITLE
Implement verbose error page mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ For the 2.x changelog see the [viur/server](https://github.com/viur-framework/se
 - "viur.db.engine" config variable to inject different database drivers
 - Global jinja2 function "translate" for instances where compile-time resolving is not possible 
 - Passing getEmptyValue() in the structure definition in json-render
+- A verbose error handler output, controllable by the "viur.debug.verboseErrorHandler" config variable.
 
 ### Changed
 - Replaced viur.core.db with a shim around viur-datastore

--- a/core/config.py
+++ b/core/config.py
@@ -37,6 +37,8 @@ conf = {
 	"viur.debug.traceInternalCallRouting": False,
 	# If enabled, we log all datastore queries performed
 	"viur.debug.traceQueries": False,
+	# If enabled, ViUR provides - in case of an error - several debug/meta information of the request
+	"viur.debug.verboseErrorHandler": False,
 
 	# Unless overridden by the Project: Use english as default language
 	"viur.defaultLanguage": "en",

--- a/core/resources/css/error/error.css
+++ b/core/resources/css/error/error.css
@@ -2,154 +2,246 @@
 @import url(http://fonts.googleapis.com/css?family=Open+Sans:400,300italic,300,400italic,600,600italic,700,700italic,800,800italic);
 /* css resets */
 @import url('../reset.css');
-html, body { height: 100% }
-body {background-color: #cccccc;
-      font-family: 'Open Sans', Helvetica, Arial, sans-serif;
-      -webkit-font-smoothing: antialiased;
-      overflow: hidden;}
 
+body {
+  font-family: 'Open Sans', Helvetica, Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  font-size: 100.01%;
+  line-height: 1.5;
+}
 
-@-webkit-keyframes popin { 
-    0% {
+@-webkit-keyframes popin {
+  0% {
     -webkit-transform: scale3d(0.1, 0.1, 1);
     opacity: 0;
-}
-45% {
+  }
+  45% {
     -webkit-transform: scale3d(1.07, 1.07, 1);
     opacity: 1;
+  }
+  70% {
+    -webkit-transform: scale3d(0.95, 0.95, 1)
+  }
+  100% {
+    -webkit-transform: scale3d(1, 1, 1)
+  }
 }
-70% { -webkit-transform: scale3d(0.95, 0.95, 1) }
-100% { -webkit-transform: scale3d(1, 1, 1) }
-}
-@-moz-keyframes popin { 
-    0% {
+
+@-moz-keyframes popin {
+  0% {
     -moz-transform: scale(0.1, 0.1);
     opacity: 0;
-}
-45% {
+  }
+  45% {
     -moz-transform: scale(1.07, 1.07);
     opacity: 1;
-}
-70% { -moz-transform: scale(0.95, 0.95) }
-100% { -moz-transform: scale(1, 1) }
+  }
+  70% {
+    -moz-transform: scale(0.95, 0.95)
+  }
+  100% {
+    -moz-transform: scale(1, 1)
+  }
 }
 
 
-a:link {color: #666666; text-decoration: none;}
-a:visited {text-decoration: none; color: #666666;}
-a:hover {text-decoration: none; color: #cc0000;}
-a:active {text-decoration: none; color: #cc0000;}
+a:link {
+  color: #666666;
+  text-decoration: none;
+}
+
+a:visited {
+  text-decoration: none;
+  color: #666666;
+}
+
+a:hover {
+  text-decoration: none;
+  color: #cc0000;
+}
+
+a:active {
+  text-decoration: none;
+  color: #cc0000;
+}
 
 #wrapper {
-    height: 100%;
-    background: #ccc;
-    background: -moz-linear-gradient(top, #ccc 0%, #f7f7f7 100%);
-    background: -webkit-gradient(linear, left top, left bottom, color-stop(0%, #ccc), color-stop(100%, #f7f7f7));
-    background: -webkit-linear-gradient(top, ccc 0%, #f7f7f7 100%);
-    background: -o-linear-gradient(top, #ccc 0%, #f7f7f7 100%);
-    background: -ms-linear-gradient(top, #ccc 0%, #f7f7f7 100%);
-    background: linear-gradient(to bottom, #ccc 0%, #f7f7f7 100%);
-    filter: progid:DXImageTransform.Microsoft.Gradient(StartColorStr='#ccc', EndColorStr='#f7f7f7', GradientType=0);
+  min-height: 100vh;
+  background: #ccc;
+  background: -moz-linear-gradient(top, #ccc 0%, #f7f7f7 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%, #ccc), color-stop(100%, #f7f7f7));
+  background: -webkit-linear-gradient(top, ccc 0%, #f7f7f7 100%);
+  background: -o-linear-gradient(top, #ccc 0%, #f7f7f7 100%);
+  background: -ms-linear-gradient(top, #ccc 0%, #f7f7f7 100%);
+  background: linear-gradient(to bottom, #ccc 0%, #f7f7f7 100%);
+  filter: progid:DXImageTransform.Microsoft.Gradient(StartColorStr='#ccc', EndColorStr='#f7f7f7', GradientType=0);
 }
 
-.clear {clear: both;display: block;overflow: hidden;visibility: hidden;width: 0;height: 0;}
+.clear {
+  clear: both;
+  display: block;
+  overflow: hidden;
+  visibility: hidden;
+  width: 0;
+  height: 0;
+}
 
-.logo {position: relative;
-       background: url(/resources/meta/viur-logo-error.png);
-       width: 140px;
-       height: 150px;
-       top: -3px;
-       float: right;
-       margin-top: -40px;
-       z-index: 99;
+.logo {
+  position: relative;
+  background: url(/resources/meta/viur-logo-error.png);
+  width: 140px;
+  height: 150px;
+  top: -3px;
+  float: right;
+  margin-top: -40px;
+  z-index: 99;
 }
 
 #error {
-    position: relative;
-    padding-top: 50px;
-    -webkit-animation-name: popin;
-    -moz-animation-name: popin;
-    -webkit-animation-duration: .8s;
-    -moz-animation-duration: 800ms;
-
+  position: relative;
+  padding-top: 50px;
+  -webkit-animation-name: popin;
+  -moz-animation-name: popin;
+  -webkit-animation-duration: .8s;
+  -moz-animation-duration: 800ms;
 }
 
 
 #content h1 {
-    font: 72px 'Open Sans', Arial, sans-serif;
-    line-height: 60px;
-    color: #d00f1c;
-    text-shadow: 0 1px #f7f7f7;
-    text-align: left;
-    float: left;
-    width: 370px;
+  font: 72px 'Open Sans', Arial, sans-serif;
+  line-height: 60px;
+  color: #d00f1c;
+  text-shadow: 0 1px #f7f7f7;
+  text-align: left;
+  float: left;
+  width: 370px;
 }
 
 
 #content {
-    position: relative;
-    left: 50%;
-    margin-left: -400px;
-    width: 800px;
-    height: 560px;
-    background: #ffffff;
-    border: solid 3px #f2f2f2;
-    -moz-box-shadow: 0 0 0 1px #bfbfbf, 0 0 10px rgba(0,0,0,.10);
-    -webkit-box-shadow: 0 0 0 1px #bfbfbf, 0 0 10px rgba(0,0,0,.10);
-    box-shadow: 0 0 0 1px #bfbfbf, 0 0 10px rgba(0,0,0,.10);
-    padding: 30px;
+  position: relative;
+  box-sizing: border-box;
+  left: 50%;
+  transform: translateX(-50%);
+  max-width: 1200px;
+  min-height: 560px;
+  background: #ffffff;
+  border: solid 3px #f2f2f2;
+  -moz-box-shadow: 0 0 0 1px #bfbfbf, 0 0 10px rgba(0, 0, 0, .10);
+  -webkit-box-shadow: 0 0 0 1px #bfbfbf, 0 0 10px rgba(0, 0, 0, .10);
+  box-shadow: 0 0 0 1px #bfbfbf, 0 0 10px rgba(0, 0, 0, .10);
+  padding: 30px;
 }
 
 #content h2 {
-    padding: 10px 0px;
-    font: 20px 'Open Sans', Arial, sans-serif;
-    color: #8e8e8e;
-    text-align: center;
-    border-top: 1px solid #ccc;
-    border-bottom: 1px solid #ccc;
-    margin-top: 30px;
-    margin-bottom: 20px;
+  padding: 10px 0px;
+  font: 20px 'Open Sans', Arial, sans-serif;
+  color: #8e8e8e;
+  text-align: center;
+  border-top: 1px solid #ccc;
+  border-bottom: 1px solid #ccc;
+  margin-top: 30px;
+  margin-bottom: 20px;
 }
 
 #content p {
-    position: relative;
-    font-size: 13px;
-    line-height: 1.5em;
-    color: #8e8e8e;
-    overflow: auto;
-    height: 300px;
-    padding: 10px 0px;
+  position: relative;
+  font-size: .9em;
+  line-height: 1.5em;
+  color: #8e8e8e;
+  overflow: auto;
+  padding: 10px 0px 50px;
 }
 
-.wrapper-buttons {padding: 10px 0px; z-index: 999;}
+.debug-information {
+    display: grid;
+    grid-template-columns: 25% 1fr;
+    font-size: .8em;
+    line-height: 1.5em;
+    color: #8e8e8e;
+}
+
+.debug-information > div {
+    word-break: break-word;
+    margin-bottom: 10px;
+}
+.debug-information > div:nth-child(odd) {
+    font-weight: bold;
+}
+.debug-information > div:first-child {
+    font-size: 1.3em;
+}
+
+table, thead, tbody, tfoot, tr {
+    width: 100%;
+}
+table th {
+  font-weight: bold;
+}
+th, td {
+  padding: 0.25em 0.5em;
+  vertical-align: top;
+}
+
+code, pre {
+  font-family: "Courier New", Courier, monospace;
+  background: #ededed;
+  color: #000;
+  tab-size: 4;
+}
+pre {
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  padding: 5px 10px;
+  margin-bottom: 10px;
+}
+code {
+  white-space: pre;
+  word-spacing: normal;
+  word-break: normal;
+  hyphens: none;
+  padding: 3px;
+  border-radius: 3px;
+  margin: 0 3px;
+}
+
+.wrapper-buttons {
+  padding: 10px 0px;
+  z-index: 999;
+}
 
 
 .button-red, .button-red:visited {
-    background-color:#08527f;
-    text-decoration:none;
-    float: right;
-    margin-left: 10px;
-    text-align: center;
-    font-size: 16px !important;
-    padding: 7px 10px !important;
-    -moz-box-orient: vertical;
-    background: #660000;
-    background: -moz-linear-gradient(#d00f1c, #660000) repeat scroll 0 0 #660000;
-    background: -webkit-linear-gradient(#d00f1c, #660000) repeat scroll 0 0 #660000;
-    background: -o-linear-gradient(#d00f1c, #660000) repeat scroll 0 0 #660000;
-    background: linear-gradient(#d00f1c, #660000) repeat scroll 0 0 #660000;
-    border: 1px solid #330000;
-    box-shadow: 0 1px 0 rgba(255, 255, 255, 0.3) inset, 0 1px 2px rgba(0, 0, 0, 0.05);
-    color: #FFFFFF !important;
-    display: inline-block;
-    line-height: 1 !important;
-    text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.3);
-    vertical-align: middle;
-    white-space: nowrap;
-    line-height: 32px;}
+  background-color: #08527f;
+  text-decoration: none;
+  float: right;
+  margin-left: 10px;
+  text-align: center;
+  font-size: 16px !important;
+  padding: 7px 10px !important;
+  -moz-box-orient: vertical;
+  background: #660000;
+  background: -moz-linear-gradient(#d00f1c, #660000) repeat scroll 0 0 #660000;
+  background: -webkit-linear-gradient(#d00f1c, #660000) repeat scroll 0 0 #660000;
+  background: -o-linear-gradient(#d00f1c, #660000) repeat scroll 0 0 #660000;
+  background: linear-gradient(#d00f1c, #660000) repeat scroll 0 0 #660000;
+  border: 1px solid #330000;
+  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.3) inset, 0 1px 2px rgba(0, 0, 0, 0.05);
+  color: #FFFFFF !important;
+  display: inline-block;
+  line-height: 1 !important;
+  text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.3);
+  vertical-align: middle;
+  white-space: nowrap;
+  line-height: 32px;
+}
 
-.button-red:hover {background-color:#d00f1c; color: #ffffff; text-decoration: none;
-                   background: -moz-linear-gradient(#d00f1c, #990000) repeat scroll 0 0 #990000;
-                   background: -webkit-linear-gradient(#d00f1c, #990000) repeat scroll 0 0 #990000;
-                   background: -o-linear-gradient(#d00f1c, #990000) repeat scroll 0 0 #990000;
-                   background: linear-gradient(#d00f1c, #990000) repeat scroll 0 0 #990000;}
+.button-red:hover {
+  background-color: #d00f1c;
+  color: #ffffff;
+  text-decoration: none;
+  background: -moz-linear-gradient(#d00f1c, #990000) repeat scroll 0 0 #990000;
+  background: -webkit-linear-gradient(#d00f1c, #990000) repeat scroll 0 0 #990000;
+  background: -o-linear-gradient(#d00f1c, #990000) repeat scroll 0 0 #990000;
+  background: linear-gradient(#d00f1c, #990000) repeat scroll 0 0 #990000;
+}

--- a/core/template/error.html
+++ b/core/template/error.html
@@ -21,6 +21,8 @@
 
                 <p>$error_descr</p>
 
+				<div class="debug-information">$debug_information</div>
+
 				<div class="wrapper-buttons">
                     <a href="/" class="button-red shadow">Home</a>
                     <div class="clear">&nbsp;</div>


### PR DESCRIPTION
Display several meta information of the current request, session and environment on the error page for faster debugging.
Can be enabled by setting `conf[viur.debug.verboseErrorHandler"]` to `True`.

I changed the error.css a bit to support larger content and the new content. Because afaik a new design is already in the pipeline, this is only very rudimentary.

![Screenshot](https://user-images.githubusercontent.com/10272292/156441385-21f31c2e-bf43-45eb-be4f-26f40a661bbc.png)
