### PR TITLE
recordBone ignore errors when not fromClient succeeds

### DIFF
--- a/core/bones/recordBone.py
+++ b/core/bones/recordBone.py
@@ -62,7 +62,8 @@ class recordBone(baseBone):
 			usingSkel.errors.append(
 				ReadFromClientError(ReadFromClientErrorSeverity.Invalid, "Incomplete data")
 			)
-		return usingSkel, usingSkel.errors
+			return usingSkel, usingSkel.errors
+		return usingSkel, []
 
 	def getSearchTags(self, values, key):
 		def getValues(res, skel, valuesCache):


### PR DESCRIPTION
Bones which are empty and not required should not return any error.
In case this behavior is wrong, make a proposal so that it works.
Currently, recordBone is rejected when it contains non-required files set empty.