### PR TITLE
Replace CustomJsonEncoder by viur.json module

### DIFF
--- a/core/json.py
+++ b/core/json.py
@@ -1,0 +1,32 @@
+"""
+JSON module replacement for ViUR
+"""
+import json, typing, datetime
+
+from viur.core import db
+from viur.core.i18n import translate
+
+
+loads = json.loads
+
+
+def dumps(o: typing.Any, cls=None, *args, **kwargs) -> str:
+
+	class ViurJsonEncoder(json.JSONEncoder):
+		"""
+			This custom JSON-Encoder for this json-render ensures that translations are evaluated and can be dumped.
+		"""
+
+		def default(self, o: typing.Any) -> typing.Any:
+			if isinstance(o, translate):
+				return str(o)
+			elif isinstance(o, datetime.datetime):
+				return o.isoformat()
+			elif isinstance(o, db.Key):
+				return db.encodeKey(o)
+			return json.JSONEncoder.default(self, o)
+
+	if cls is None:
+		cls = ViurJsonEncoder
+
+	return json.dumps(o, cls=cls, *args, **kwargs)

--- a/core/render/admin/__init__.py
+++ b/core/render/admin/__init__.py
@@ -1,14 +1,14 @@
 # -*- coding: utf-8 -*-
 
-from viur.core.render.json.default import DefaultRender, CustomJsonEncoder
+from viur.core.render.json.default import DefaultRender
 from viur.core.render.json.user import UserRender as user
 from viur.core.render.json.file import FileRender as file
 from viur.core.utils import currentRequest, currentLanguage, currentSession
 from viur.core.skeleton import SkeletonInstance
 from viur.core import conf
 from viur.core import securitykey
-from viur.core import utils, errors
-import datetime, json
+from viur.core import utils, errors, json
+import datetime
 
 
 class default(DefaultRender):
@@ -66,7 +66,7 @@ def getStructure(adminTree, module):
 						storeType = stype.replace("Skel", "") + ("LeafSkel" if treeType == "leaf" else "NodeSkel")
 						res[storeType] = default().renderSkelStructure(skel)
 	if res:
-		return json.dumps(res, cls=CustomJsonEncoder)
+		return json.dumps(res)
 	else:
 		return json.dumps(None)
 

--- a/core/render/json/default.py
+++ b/core/render/json/default.py
@@ -1,28 +1,7 @@
-# -*- coding: utf-8 -*-
-import json
 from collections import OrderedDict
-from viur.core import bones, utils, config
-from viur.core import db
+from viur.core import db, bones, config, utils, json
 from viur.core.skeleton import SkeletonInstance
 from viur.core.utils import currentRequest
-from viur.core.i18n import translate
-from datetime import datetime
-from typing import Any
-
-
-class CustomJsonEncoder(json.JSONEncoder):
-	"""
-		This custom JSON-Encoder for this json-render ensures that translations are evaluated and can be dumped.
-	"""
-
-	def default(self, o: Any) -> Any:
-		if isinstance(o, translate):
-			return str(o)
-		elif isinstance(o, datetime):
-			return o.isoformat()
-		elif isinstance(o, db.Key):
-			return db.encodeKey(o)
-		return json.JSONEncoder.default(self, o)
 
 
 class DefaultRender(object):
@@ -224,7 +203,7 @@ class DefaultRender(object):
 			"params": params
 		}
 		currentRequest.get().response.headers["Content-Type"] = "application/json"
-		return json.dumps(res, cls=CustomJsonEncoder)
+		return json.dumps(res)
 
 	def view(self, skel, action="view", params=None, *args, **kwargs):
 		return self.renderEntry(skel, action, params)
@@ -253,7 +232,7 @@ class DefaultRender(object):
 		res["action"] = action
 		res["params"] = params
 		currentRequest.get().response.headers["Content-Type"] = "application/json"
-		return json.dumps(res, cls=CustomJsonEncoder)
+		return json.dumps(res)
 
 	def editSuccess(self, skel, params=None, **kwargs):
 		return self.renderEntry(skel, "editSuccess", params)
@@ -280,7 +259,7 @@ class DefaultRender(object):
 			skels.append(self.renderSkelValues(skel))
 
 		res["entrys"] = skels
-		return json.dumps(res, cls=CustomJsonEncoder)
+		return json.dumps(res)
 
 	def renameSuccess(self, rootNode, path, src, dest, params=None, *args, **kwargs):
 		return json.dumps("OKAY")

--- a/core/render/vi/__init__.py
+++ b/core/render/vi/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from viur.core.render.json.default import DefaultRender, CustomJsonEncoder
+from viur.core.render.json.default import DefaultRender
 from viur.core.render.vi.user import UserRender as user
 from viur.core.render.json.file import FileRender as file
 from viur.core.skeleton import Skeleton
@@ -9,9 +9,9 @@ from viur.core import conf
 from viur.core import securitykey
 from viur.core import utils
 from viur.core import request
-from viur.core import session
+from viur.core import json
 from viur.core import errors
-import datetime, json
+import datetime
 from viur.core.utils import currentRequest, currentLanguage
 from viur.core.skeleton import SkeletonInstance
 
@@ -71,7 +71,7 @@ def getStructure(adminTree, module):
 						storeType = stype.replace("Skel", "") + ("LeafSkel" if treeType == "leaf" else "NodeSkel")
 						res[storeType] = default().renderSkelStructure(skel)
 	if res:
-		return json.dumps(res, cls=CustomJsonEncoder)
+		return json.dumps(res)
 	else:
 		return json.dumps(None)
 


### PR DESCRIPTION
In custom project implementations, any calls to json.dumps() must be replaced by CustomJsonEncoder from viur.core.render.json.default to use the CustromJsonEncoder.

This change just requires to import viur.json instead of just json to provide a simular behavior and reduce amount of code changes in custom projects.