### PR TITLE
Raise exception when invalid objects are assigned to multiple=True bones

### DIFF
--- a/core/bones/bone.py
+++ b/core/bones/bone.py
@@ -417,8 +417,14 @@ class baseBone(object):  # One Bone:
 						res[language] = self.singleValueSerialize(newVal[language], skel, name, parentIndexed)
 			elif self.multiple:
 				res = []
-				for singleValue in newVal:
+
+				# Convert single-value into list as this is required here.
+				if not isinstance(newVal, list) and newVal is not None:
+					newVal = [newVal]
+
+				for singleValue in (newVal or []):
 					res.append(self.singleValueSerialize(singleValue, skel, name, parentIndexed))
+
 			else:  # No Languages, not Multiple
 				res = self.singleValueSerialize(newVal, skel, name, parentIndexed)
 			skel.dbEntity[name] = res

--- a/core/bones/bone.py
+++ b/core/bones/bone.py
@@ -418,11 +418,10 @@ class baseBone(object):  # One Bone:
 			elif self.multiple:
 				res = []
 
-				# Convert single-value into list as this is required here.
-				if not isinstance(newVal, list) and newVal is not None:
-					newVal = [newVal]
+				assert newVal is None or isinstance(newVal, (list, tuple)), \
+					f"Cannot handle {repr(newVal)} here. Expecting list or tuple."
 
-				for singleValue in (newVal or []):
+				for singleValue in (newVal or ()):
 					res.append(self.singleValueSerialize(singleValue, skel, name, parentIndexed))
 
 			else:  # No Languages, not Multiple


### PR DESCRIPTION
This...
```python
b = stringBone(multiple=True)

skel["b"] = "test"
```
...will write `['t', 'e', 's', 't']` into the bone in the datastore.

This fix will write `["test"]`, as wanted.