### PR TITLE
Fix buildDBFilter rawFilter condition

### DIFF
--- a/core/bones/relationalBone.py
+++ b/core/bones/relationalBone.py
@@ -618,7 +618,7 @@ class relationalBone(baseBone):
 				dbFilter.setFilterHook(lambda s, filter, value: self.filterHook(name, s, filter, value))
 				dbFilter.setOrderHook(lambda s, orderings: self.orderHook(name, s, orderings))
 
-		elif name in rawFilter and rawFilter[name].lower() == "none":
+		elif name in rawFilter and isinstance(rawFilter[name], str) and rawFilter[name].lower() == "none":
 			dbFilter = dbFilter.filter("%s =" % name, None)
 
 		return dbFilter


### PR DESCRIPTION
In case `rawFilter[name].lower() == "none"` and rawFilter[name] is something else than str, ViUR will crash here.