### PR TITLE
Set x-viur-error in header with exception description

### DIFF
--- a/core/request.py
+++ b/core/request.py
@@ -259,6 +259,11 @@ class BrowseHandler():  # webapp.RequestHandler
 				raise
 			self.response.body = b""
 			self.response.status = '%d %s' % (e.status, e.name)
+
+			# Set machine-readable x-viur-error response header in case there is an exception description.
+			if e.descr:
+				self.response.headers["x-viur-error"] = e.descr.replace("\n", "")
+
 			res = None
 			if conf["viur.errorHandler"]:
 				try:


### PR DESCRIPTION
This enables Ajax-requests to access detailed information when something went wrong. This is already implemented in flare, for example.