### PR TITLE
Set parentnode and parentrepo before fromClient()

### DIFF
--- a/core/prototypes/tree.py
+++ b/core/prototypes/tree.py
@@ -389,6 +389,11 @@ class Tree(BasicApplication):
 			raise errors.NotFound()
 		if not self.canAdd(skelType, parentNodeSkel):
 			raise errors.Unauthorized()
+
+		skel["parententry"] = parentNodeSkel["key"]
+		# parentrepo may not exist in parentNodeSkel as it may be an rootNode
+		skel["parentrepo"] = parentNodeSkel["parentrepo"] or parentNodeSkel["key"]
+
 		if (len(kwargs) == 0  # no data supplied
 			or skey == ""  # no security key
 			or not skel.fromClient(kwargs)  # failure on reading into the bones
@@ -398,9 +403,7 @@ class Tree(BasicApplication):
 			return self.render.add(skel)
 		if not securitykey.validate(skey, useSessionKey=True):
 			raise errors.PreconditionFailed()
-		skel["parententry"] = parentNodeSkel["key"]
-		# parentrepo may not exist of parentNodeSkel as it may be an rootNode
-		skel["parentrepo"] = parentNodeSkel["parentrepo"] or parentNodeSkel["key"]
+
 		self.onAdd(skelType, skel)
 		skel.toDB()
 		self.onAdded(skelType, skel)


### PR DESCRIPTION
This change sets the readOnly-bones parentnode and parentrepo of a TreeSkel before the fromClient call. The reason for this is, that in a specific use-case, a unique value is build, which may only be unique per repository. This construction was made in a custom fromClient function implemented on the Skeleton, which requires the parentrepo to be known.