### PR TITLE
Improve SEO url integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ For the 2.x changelog see the [viur/server](https://github.com/viur-framework/se
 
 ### Changed
 - Replaced viur.core.db with a shim around viur-datastore
+- Improve SEO url integration: refactoring and redirect from old keys to the current
 
 ### Fixed
 - files embedded in textBones don't expire anymore and get correctly locked

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -308,7 +308,7 @@ def forcePost(f: Callable) -> Callable:
 	return f
 
 
-def exposed(f: Callable) -> Callable:
+def exposed(f: Union[Callable, dict]) -> Callable:
 	"""
 		Decorator, which marks an function as exposed.
 


### PR DESCRIPTION
* Correct the type annotation of the `@exposed` decorator
* Eliminate duplicate by calling `list()` instead
* Add docstrings
* Redirect to the current seo-key if the site was opened with an old one