### PR TITLE
Fix `setBoneValue` to work with multiple and language bones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ For the 2.x changelog see the [viur/server](https://github.com/viur-framework/se
 - Global jinja2 function "translate" for instances where compile-time resolving is not possible 
 - Passing getEmptyValue() in the structure definition in json-render
 - Support for srcsets in textBone
+- `language` paramater in `BaseSkeleton.setBoneValue()`
 
 ### Changed
 - Replaced viur.core.db with a shim around viur-datastore
@@ -25,6 +26,8 @@ For the 2.x changelog see the [viur/server](https://github.com/viur-framework/se
 - killSessionByUser function
 - deferred calls with _countdown etc. set from a cronjob
 - unique=True on multiple=True relationalBones
+- `setBoneValue` works now for multiple and (multiple and language) bones
+- default `defaultValue` for multiple and language `selectBone` 
 
 
 ### Removed

--- a/core/bones/bone.py
+++ b/core/bones/bone.py
@@ -769,9 +769,22 @@ class baseBone(object):  # One Bone:
 		"""
 		assert not (bool(self.languages) ^ bool(language)), "Language is required or not supported"
 		assert not append or self.multiple, "Can't append - bone is not multiple"
-		val, errs = self.singleValueFromClient(value, skel, boneName, {boneName: value})
-		if errs:
-			for e in errs:
+
+		if not append and self.multiple:
+			# set multiple values at once
+			val = []
+			errors = []
+			for singleValue in value:
+				singleValue, singleError = self.singleValueFromClient(singleValue, skel, boneName, {boneName: value})
+				val.append(singleValue)
+				if singleError:
+					errors.extend(singleError)
+		else:
+			# set or append one value
+			val, errors = self.singleValueFromClient(value, skel, boneName, {boneName: value})
+
+		if errors:
+			for e in errors:
 				if e.severity in [ReadFromClientErrorSeverity.Invalid, ReadFromClientErrorSeverity.NotSet]:
 					# If an invalid datatype (or a non-parseable structure) have been passed, abort the store
 					return False

--- a/core/bones/selectBone.py
+++ b/core/bones/selectBone.py
@@ -1,26 +1,35 @@
 from collections import OrderedDict
-from viur.core.i18n import translate
+from numbers import Number
+from typing import Callable, Dict, List, Tuple, Union
+
 from viur.core.bones import baseBone
 from viur.core.bones.bone import ReadFromClientError, ReadFromClientErrorSeverity
+from viur.core.i18n import translate
+
+SelectBoneValue = Union[str, Number]
+SelectBoneMultiple = List[SelectBoneValue]
 
 
 class selectBone(baseBone):
 	type = "select"
 
-	def __init__(self, defaultValue=None, values=(), multiple=False, *args, **kwargs):
+	def __init__(self, defaultValue: Union[None, Dict[str, Union[SelectBoneMultiple, SelectBoneValue]], SelectBoneMultiple] = None,
+				 values: Union[Dict, List, Tuple, Callable] = (),
+				 multiple: bool = False, languages: bool = False, *args, **kwargs):
 		"""
 			Creates a new selectBone.
 
-			:param defaultValue: List of keys which will be checked by default
-			:type defaultValue: list
-
+			:param defaultValue: key(s) which will be checked by default
 			:param values: dict of key->value pairs from which the user can choose from.
-			:type values: dict | OrderedDict | list | tuple | callable
 		"""
 		if defaultValue is None and multiple:
-			defaultValue = []
+			if languages:
+				defaultValue = {}
+			else:
+				defaultValue = []
 
-		super(selectBone, self).__init__(defaultValue=defaultValue, multiple=multiple, *args, **kwargs)
+		super(selectBone, self).__init__(
+			defaultValue=defaultValue, multiple=multiple, languages=languages, *args, **kwargs)
 
 		# handle list/tuple as dicts
 		if isinstance(values, (list, tuple)):

--- a/core/skeleton.py
+++ b/core/skeleton.py
@@ -9,12 +9,12 @@ import sys
 from functools import partial
 from itertools import chain
 from time import time
-from typing import Any, Callable, Dict, Iterable, List, Tuple, Union, Set, Optional
+from typing import Any, Callable, Dict, Iterable, List, Optional, Set, Tuple, Union
 
-from viur.core import conf, errors, utils, email, db
+from viur.core import conf, db, email, errors, utils
 from viur.core.bones import baseBone, dateBone, keyBone, relationalBone, selectBone, stringBone
 from viur.core.bones.bone import ReadFromClientError, ReadFromClientErrorSeverity, getSystemInitialized
-from viur.core.tasks import CallableTask, CallableTaskBase, callDeferred, QueryIter
+from viur.core.tasks import CallableTask, CallableTaskBase, QueryIter, callDeferred
 
 try:
 	import pytz
@@ -274,27 +274,25 @@ class BaseSkeleton(object, metaclass=MetaBaseSkel):
 				bone.setSystemInitialized()
 
 	@classmethod
-	def setBoneValue(cls, skelValues, boneName, value, append=False):
+	def setBoneValue(cls, skelValues: Any, boneName: str, value: Any,
+					 append: bool = False, language: Optional[str] = None) -> bool:
 		"""
 			Allow setting a bones value without calling fromClient or assigning to valuesCache directly.
 			Santy-Checks are performed; if the value is invalid, that bone flips back to its original
 			(default) value and false is returned.
 
 			:param boneName: The Bone which should be modified
-			:type boneName: str
 			:param value: The value that should be assigned. It's type depends on the type of that bone
-			:type value: object
 			:param append: If true, the given value is appended to the values of that bone instead of
 				replacing it. Only supported on bones with multiple=True
-			:type append: bool
+			:param language: Set/append which language
 			:return: Wherever that operation succeeded or not.
-			:rtype: bool
 		"""
 		bone = getattr(skelValues, boneName, None)
 		if not isinstance(bone, baseBone):
 			raise ValueError("%s is no valid bone on this skeleton (%s)" % (boneName, str(skelValues)))
 		skelValues[boneName]  # FIXME, ensure this bone is unserialized first
-		return bone.setBoneValue(skelValues, boneName, value, append)
+		return bone.setBoneValue(skelValues, boneName, value, append, language)
 
 	@classmethod
 	def fromClient(cls, skelValues: SkeletonInstance, data: Dict[str, Union[List[str], str]],


### PR DESCRIPTION
A value via `BaseSkeleton.setBoneValue()` was not setable to a multiple or language `selectBone` and `stringBone`.
* Extend `baseBone.setBoneValue()` to fix this
* Add `language` parameter in `BaseSkeleton.setBoneValue()`
* Correct default `defaultValue` for multiple and language `selectBone`
* Fix and add several related docstrings and type annotations

