### PR TITLE
Assert kwargs are empty on session security key

### DIFF
--- a/core/securitykey.py
+++ b/core/securitykey.py
@@ -43,6 +43,7 @@ def create(duration: Union[None, int] = None, **kwargs) -> str:
 		:returns: The new onetime key
 	"""
 	if not duration:
+		assert not kwargs, "kwargs are not allowed when session security key is wanted"
 		return currentSession.get().getSecurityKey()
 	key = generateRandomString()
 	duration = int(duration)


### PR DESCRIPTION
This little improvement might help to fix issues when porting from ViUR2 to ViUR3.