### PR TITLE
Fixed serializing stringBones with languages without prior fromClient call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ For the 2.x changelog see the [viur/server](https://github.com/viur-framework/se
 ### Changed
 
 ### Fixed
+- serializing stringBones with languages without prior fromClient call
 
 ### Removed
 

--- a/core/bones/bone.py
+++ b/core/bones/bone.py
@@ -107,6 +107,9 @@ class baseBone(object):  # One Bone:
 		self.required = required
 		self.params = params or {}
 		self.multiple = multiple
+		if not (languages is None or (isinstance(languages, list) and len(languages) > 0 and all(
+				[isinstance(x, str) for x in languages]))):
+			raise ValueError("languages must be None or a list of strings")
 		self.languages = languages
 		self.indexed = indexed
 		# Convert a None default-value to the empty container that's expected if the bone is multiple or has languages

--- a/core/bones/stringBone.py
+++ b/core/bones/stringBone.py
@@ -17,18 +17,9 @@ class stringBone(baseBone):
 	def generageSearchWidget(target, name="STRING BONE", mode="equals"):
 		return ({"name": name, "mode": mode, "target": target, "type": "string"})
 
-	def __init__(self, caseSensitive=True, languages=None, defaultValue=None, *args, **kwargs):
-		super(stringBone, self).__init__(defaultValue=defaultValue, *args, **kwargs)
+	def __init__(self, caseSensitive=True, *args, **kwargs):
+		super(stringBone, self).__init__(*args, **kwargs)
 		self.caseSensitive = caseSensitive
-		if not (languages is None or (isinstance(languages, list) and len(languages) > 0 and all(
-			[isinstance(x, str) for x in languages]))):
-			raise ValueError("languages must be None or a list of strings")
-		self.languages = languages
-		if defaultValue is None:
-			if self.languages:
-				self.defaultValue = {}
-			else:
-				self.defaultValue = ""
 
 	def singleValueSerialize(self, value, skel: 'SkeletonInstance', name: str, parentIndexed: bool):
 		if not self.caseSensitive and parentIndexed:


### PR DESCRIPTION
Moved the language type check to basebone and removed obsolete/dulicate/broken code for languages handling in stringBone