### PR TITLE
Refactoring all bone-related __init__ functions

### DIFF
--- a/core/bones/bone.py
+++ b/core/bones/bone.py
@@ -6,7 +6,7 @@ import hashlib
 import copy
 from enum import Enum
 from dataclasses import dataclass, field
-from typing import Union, List, Set, Any
+from typing import Union, Dict, List, Set, Any
 
 __systemIsIntitialized_ = False
 
@@ -60,13 +60,26 @@ class MultipleConstraints:  # Used to define constraints on multiple bones
 
 
 class baseBone(object):  # One Bone:
-	hasDBField = True
 	type = "hidden"
 	isClonedInstance = False
 
-	def __init__(self, descr="", defaultValue=None, required=False, params=None, multiple=False, indexed=True,
-				 languages=None, searchable=False, vfunc=None, readOnly=False, visible=True, unique=False,
-				 isEmptyFunc=None, getEmtpyValueFunc=None, **kwargs):
+	def __init__(
+		self,
+		defaultValue: Any = None,
+		descr: str = "",
+		getEmtpyValueFunc=None,
+		indexed: bool = True,
+		isEmptyFunc=None,
+		languages: Union[None, List[str]] = None,
+		multiple: bool = False,
+		params: Dict = None,
+		readOnly: bool = False,
+		required: bool = False,
+		searchable: bool = False,
+		unique: Union[None, UniqueValue] = None,
+		vfunc: callable = None,  # todo: rename to verify_function?
+		visible: bool = True,
+	):
 		"""
 			Initializes a new Bone.
 
@@ -100,18 +113,23 @@ class baseBone(object):  # One Bone:
 				The kwarg 'multiple' is not supported by all bones
 
 		"""
-		# if kwargs.get("indexed") is not None:
-		#	logging.warning("Indexed on bones is not supported anymore!")
 		self.isClonedInstance = getSystemInitialized()
+
 		self.descr = descr
-		self.required = required
 		self.params = params or {}
 		self.multiple = multiple
+		self.required = required
+		self.readOnly = readOnly
+		self.searchable = searchable
+		self.visible = visible
+
 		if not (languages is None or (isinstance(languages, list) and len(languages) > 0 and all(
 				[isinstance(x, str) for x in languages]))):
 			raise ValueError("languages must be None or a list of strings")
 		self.languages = languages
+
 		self.indexed = indexed
+
 		# Convert a None default-value to the empty container that's expected if the bone is multiple or has languages
 		if defaultValue is None and self.languages:
 			self.defaultValue = {}
@@ -119,19 +137,20 @@ class baseBone(object):  # One Bone:
 			self.defaultValue = []
 		else:
 			self.defaultValue = defaultValue
-		self.searchable = searchable
+
 		if vfunc:
 			self.isInvalid = vfunc
-		self.readOnly = readOnly
-		self.visible = visible
+
 		if unique:
 			if not isinstance(unique, UniqueValue):
 				raise ValueError("Unique must be an instance of UniqueValue")
 			if not self.multiple and unique.method.value != 1:
 				raise ValueError("'SameValue' is the only valid method on non-multiple bones")
 		self.unique = unique
+
 		if isEmptyFunc:
 			self.isEmpty = isEmptyFunc
+
 		if getEmtpyValueFunc:
 			self.getEmptyValue = getEmtpyValueFunc
 

--- a/core/bones/booleanBone.py
+++ b/core/bones/booleanBone.py
@@ -13,9 +13,11 @@ class booleanBone(baseBone):
 	def generageSearchWidget(target, name="BOOLEAN BONE"):
 		return ({"name": name, "target": target, "type": "boolean"})
 
-	def __init__(self, defaultValue=False, *args, **kwargs):
-		assert defaultValue in [True, False]
-		super(booleanBone, self).__init__(defaultValue=defaultValue, *args, **kwargs)
+	def __init__(self, *, defaultValue=False, **kwargs):
+		if defaultValue not in [True, False]:
+			raise ValueError("Only 'True' or 'False' can be provided as booleanBone defaultValue")
+
+		super().__init__(defaultValue=defaultValue, **kwargs)
 
 	def singleValueFromClient(self, value, skel, name, origData):
 		if str(value) in self.trueStrs:

--- a/core/bones/captchaBone.py
+++ b/core/bones/captchaBone.py
@@ -12,8 +12,8 @@ from viur.core.utils import currentRequest
 class captchaBone(bone.baseBone):
 	type = "captcha"
 
-	def __init__(self, publicKey=None, privateKey=None, *args, **kwargs):
-		bone.baseBone.__init__(self, *args, **kwargs)
+	def __init__(self, *, publicKey=None, privateKey=None, **kwargs):
+		super().__init__(**kwargs)
 		self.defaultValue = self.publicKey = publicKey
 		self.privateKey = privateKey
 		if not self.defaultValue and not self.privateKey:
@@ -22,7 +22,6 @@ class captchaBone(bone.baseBone):
 				self.defaultValue = self.publicKey = conf["viur.security.captcha.defaultCredentials"]["sitekey"]
 				self.privateKey = conf["viur.security.captcha.defaultCredentials"]["secret"]
 		self.required = True
-		self.hasDBField = False
 
 	def serialize(self, skel: 'SkeletonInstance', name: str, parentIndexed: bool) -> bool:
 		return False

--- a/core/bones/colorBone.py
+++ b/core/bones/colorBone.py
@@ -8,8 +8,8 @@ from typing import List, Union
 class colorBone(baseBone):
 	type = "color"
 
-	def __init__(self, mode="rgb", *args, **kwargs):  # mode rgb/rgba
-		baseBone.__init__(self, *args, **kwargs)
+	def __init__(self, *, mode="rgb", **kwargs):  # mode rgb/rgba
+		super().__init__(**kwargs)
 		assert mode in {"rgb", "rgba"}
 		self.mode = mode
 

--- a/core/bones/credentialBone.py
+++ b/core/bones/credentialBone.py
@@ -13,8 +13,8 @@ class credentialBone(stringBone):
 	"""
 	type = "str.credential"
 
-	def __init__(self, *args, **kwargs):
-		super(credentialBone, self).__init__(*args, **kwargs)
+	def __init__(self, **kwargs):
+		super().__init__(**kwargs)
 		if self.multiple or self.languages:
 			raise ValueError("Credential-Bones cannot be multiple or translated!")
 

--- a/core/bones/dateBone.py
+++ b/core/bones/dateBone.py
@@ -17,7 +17,16 @@ class dateBone(baseBone):
 	def generageSearchWidget(target, name="DATE BONE", mode="range"):
 		return ({"name": name, "mode": mode, "target": target, "type": "date"})
 
-	def __init__(self, creationMagic=False, updateMagic=False, date=True, time=True, localize=False, *args, **kwargs):
+	def __init__(
+		self,
+		*,
+		creationMagic: bool = False,
+		updateMagic: bool = False,
+		date: bool = True,
+		time: bool = True,
+		localize: bool = False,
+		**kwargs
+	):
 		"""
 			Initializes a new dateBone.
 
@@ -34,17 +43,23 @@ class dateBone(baseBone):
                                 contains date and time-information! Per default, UTC time is used.
 			:type localize: bool
 		"""
-		baseBone.__init__(self, *args, **kwargs)
+		super().__init__(self, **kwargs)
+
 		if creationMagic or updateMagic:
 			self.readonly = True
+
 		self.creationMagic = creationMagic
 		self.updateMagic = updateMagic
+
 		if not (date or time):
 			raise ValueError("Attempt to create an empty datebone! Set date or time to True!")
+
 		if localize and not (date and time):
 			raise ValueError("Localization is only possible with date and time!")
+
 		if self.multiple and (creationMagic or updateMagic):
 			raise ValueError("Cannot be multiple and have a creation/update-magic set!")
+
 		self.date = date
 		self.time = time
 		self.localize = localize

--- a/core/bones/fileBone.py
+++ b/core/bones/fileBone.py
@@ -80,14 +80,19 @@ def ensureDerived(key: db.Key, srcKey, deriveMap: Dict[str, Any], refreshKey: db
 			db.RunInTransaction(refreshTxn)
 
 
-
 class fileBone(treeLeafBone):
 	kind = "file"
 	type = "relational.tree.leaf.file"
 	refKeys = ["name", "key", "mimetype", "dlkey", "size", "width", "height", "derived"]
 
-	def __init__(self, format="value['dest']['name']", derive: Union[None, Dict[str, Any]] = None,
-				 validMimeTypes: Union[None, List[str]] = None, maxFileSize: Union[None, int] = None, *args, **kwargs):
+	def __init__(
+		self,
+		*,
+		derive: Union[None, Dict[str, Any]] = None,
+		validMimeTypes: Union[None, List[str]] = None,
+		maxFileSize: Union[None, int] = None,
+		**kwargs
+	):
 		"""
 		Initializes a new Filebone. All properties inherited by relationalBone are supported.
 		:param format: Hint for the UI how to display a file entry (defaults to it's filename)
@@ -106,9 +111,11 @@ class fileBone(treeLeafBone):
 		:param maxFileSize: The maximum filesize accepted by this bone in bytes. None means no limit. This will always
 			be checked against the original file uploaded - not any of it's derivatives.
 		"""
+		super().__init__(**kwargs)
+
 		if "dlkey" not in self.refKeys:
 			self.refKeys.append("dlkey")
-		super(fileBone, self).__init__(format=format, *args, **kwargs)
+
 		self.derive = derive
 		self.validMimeTypes = validMimeTypes
 		self.maxFileSize = maxFileSize

--- a/core/bones/keyBone.py
+++ b/core/bones/keyBone.py
@@ -8,8 +8,8 @@ import logging, copy
 class keyBone(baseBone):
 	type = "key"
 
-	def __init__(self, descr="Key", readOnly=True, visible=False, **kwargs):
-		super(keyBone, self).__init__(descr=descr, readOnly=True, visible=visible, defaultValue=None, **kwargs)
+	def __init__(self, *, descr="Key", readOnly=True, visible=False, **kwargs):
+		super(keyBone, self).__init__(descr=descr, readOnly=readOnly, visible=visible, defaultValue=None, **kwargs)
 
 	def unserialize(self, skel: 'viur.core.skeleton.SkeletonValues', name: str) -> bool:
 		"""

--- a/core/bones/numericBone.py
+++ b/core/bones/numericBone.py
@@ -19,7 +19,7 @@ class numericBone(baseBone):
 
 	type = "numeric"
 
-	def __init__(self, precision=0, min=-int(pow(2, 30)), max=int(pow(2, 30)), defaultValue=None, *args, **kwargs):
+	def __init__(self, *, precision=0, min=-int(pow(2, 30)), max=int(pow(2, 30)), **kwargs):
 		"""
 			Initializes a new NumericBone.
 
@@ -30,10 +30,9 @@ class numericBone(baseBone):
 			:param max: Maximum accepted value (including).
 			:type max: float
 		"""
-		super(numericBone, self).__init__(defaultValue=defaultValue, *args, **kwargs)
+		super().__init__(**kwargs)
+
 		self.precision = precision
-		if not self.precision and "mode" in kwargs and kwargs["mode"] == "float":  # Fallback for old API
-			self.precision = 8
 		self.min = min
 		self.max = max
 

--- a/core/bones/randomSliceBone.py
+++ b/core/bones/randomSliceBone.py
@@ -14,7 +14,7 @@ class randomSliceBone(baseBone):
 
 	type = "randomslice"
 
-	def __init__(self, visible=False, readOnly=True, slices=2, sliceSize=0.5, *args, **kwargs):
+	def __init__(self, *, visible=False, readOnly=True, slices=2, sliceSize=0.5, **kwargs):
 		"""
 			Initializes a new randomSliceBone.
 
@@ -22,7 +22,7 @@ class randomSliceBone(baseBone):
 		"""
 		if visible or not readOnly:
 			raise NotImplemented("A RandomSliceBone must not visible and readonly!")
-		baseBone.__init__(self, indexed=True, visible=False, readOnly=True, *args, **kwargs)
+		super().__init__(indexed=True, visible=False, readOnly=True, **kwargs)
 		self.slices = slices
 		self.sliceSize = sliceSize
 

--- a/core/bones/recordBone.py
+++ b/core/bones/recordBone.py
@@ -14,8 +14,8 @@ except ImportError:
 class recordBone(baseBone):
 	type = "record"
 
-	def __init__(self, using, format=None, indexed=False, *args, **kwargs):
-		super(recordBone, self).__init__(*args, **kwargs)
+	def __init__(self, *, using, format=None, indexed=False, **kwargs):
+		super().__init__(indexed=indexed, **kwargs)
 		self.using = using
 		self.format = format
 		if not format or indexed:

--- a/core/bones/relationalBone.py
+++ b/core/bones/relationalBone.py
@@ -57,11 +57,20 @@ class relationalBone(baseBone):
 	type = "relational"
 	kind = None
 
-	def __init__(self, kind: str = None, module: Optional[str] = None, refKeys: Optional[List[str]] = None,
-				 parentKeys: Optional[List[str]] = None, multiple: Union[bool, MultipleConstraints] = False,
-				 format: str = "value['dest']['name']", using: Optional['viur.core.skeleton.RelSkel'] = None,
-				 updateLevel: int = 0, consistency: RelationalConsistency = RelationalConsistency.Ignore,
-				 *args, **kwargs):
+	def __init__(
+		self,
+		*,
+		kind: str = None,
+		module: Optional[str] = None,
+		refKeys: Optional[List[str]] = None,
+		parentKeys: Optional[List[str]] = None,
+		multiple: Union[bool, MultipleConstraints] = False,
+		format: str = "value['dest']['name']",
+		using: Optional['viur.core.skeleton.RelSkel'] = None,
+		updateLevel: int = 0,
+		consistency: RelationalConsistency = RelationalConsistency.Ignore,
+		**kwargs
+	):
 		"""
 			Initialize a new relationalBone.
 
@@ -112,9 +121,8 @@ class relationalBone(baseBone):
 					CascadeDeletion set, and B references C also with CascadeDeletion; if C gets deleted, both B and A
 					will be deleted as well.
 		"""
-		baseBone.__init__(self, multiple=multiple, *args, **kwargs)
+		super().__init__(multiple=multiple, **kwargs)
 		self.format = format
-		# self._dbValue = None #Store the original result fetched from the db here so we have that information in case a referenced entity has been deleted
 
 		if kind:
 			self.kind = kind

--- a/core/bones/selectBone.py
+++ b/core/bones/selectBone.py
@@ -13,23 +13,20 @@ SelectBoneMultiple = List[SelectBoneValue]
 class selectBone(baseBone):
 	type = "select"
 
-	def __init__(self, defaultValue: Union[None, Dict[str, Union[SelectBoneMultiple, SelectBoneValue]], SelectBoneMultiple] = None,
-				 values: Union[Dict, List, Tuple, Callable] = (),
-				 multiple: bool = False, languages: bool = False, *args, **kwargs):
+	def __init__(
+		self,
+		*,
+		defaultValue: Union[None, Dict[str, Union[SelectBoneMultiple, SelectBoneValue]], SelectBoneMultiple] = None,
+		values: Union[Dict, List, Tuple, Callable] = (),
+		**kwargs
+	):
 		"""
 			Creates a new selectBone.
 
 			:param defaultValue: key(s) which will be checked by default
 			:param values: dict of key->value pairs from which the user can choose from.
 		"""
-		if defaultValue is None and multiple:
-			if languages:
-				defaultValue = {}
-			else:
-				defaultValue = []
-
-		super(selectBone, self).__init__(
-			defaultValue=defaultValue, multiple=multiple, languages=languages, *args, **kwargs)
+		super(selectBone, self).__init__(defaultValue=defaultValue, **kwargs)
 
 		# handle list/tuple as dicts
 		if isinstance(values, (list, tuple)):

--- a/core/bones/selectCountryBone.py
+++ b/core/bones/selectCountryBone.py
@@ -735,14 +735,14 @@ class selectCountryBone(selectBone):
 	ISO2 = 2
 	ISO3 = 3
 
-	def __init__(self, codes=ISO2, values=None, *args, **kwargs):
+	def __init__(self, *, codes=ISO2, values=None, **kwargs):
 		global ISO2CODES, ISO3CODES
 		assert codes in [self.ISO2, self.ISO3]
 		assert values is None
 
 		super().__init__(
 			values=OrderedDict(sorted((ISO2CODES if codes == self.ISO2 else ISO3CODES).items(), key=lambda i: i[1])),
-			*args, **kwargs
+			**kwargs
 		)
 
 		self.codes = codes

--- a/core/bones/spatialBone.py
+++ b/core/bones/spatialBone.py
@@ -47,7 +47,7 @@ class spatialBone(baseBone):
 
 	type = "spatial"
 
-	def __init__(self, boundsLat, boundsLng, gridDimensions, *args, **kwargs):
+	def __init__(self, *, boundsLat, boundsLng, gridDimensions, **kwargs):
 		"""
 			Initializes a new spatialBone.
 
@@ -58,7 +58,7 @@ class spatialBone(baseBone):
 			:param gridDimensions: Number of sub-regions the map will be divided in
 			:type gridDimensions: (int, int)
 		"""
-		super(spatialBone, self).__init__(*args, **kwargs)
+		super().__init__(**kwargs)
 		assert isinstance(boundsLat, tuple) and len(boundsLat) == 2, "boundsLat must be a tuple of (int, int)"
 		assert isinstance(boundsLng, tuple) and len(boundsLng) == 2, "boundsLng must be a tuple of (int, int)"
 		assert isinstance(gridDimensions, tuple) and len(

--- a/core/bones/stringBone.py
+++ b/core/bones/stringBone.py
@@ -17,8 +17,8 @@ class stringBone(baseBone):
 	def generageSearchWidget(target, name="STRING BONE", mode="equals"):
 		return ({"name": name, "mode": mode, "target": target, "type": "string"})
 
-	def __init__(self, caseSensitive=True, *args, **kwargs):
-		super(stringBone, self).__init__(*args, **kwargs)
+	def __init__(self, *, caseSensitive=True, **kwargs):
+		super().__init__(**kwargs)
 		self.caseSensitive = caseSensitive
 
 	def singleValueSerialize(self, value, skel: 'SkeletonInstance', name: str, parentIndexed: bool):

--- a/core/bones/textBone.py
+++ b/core/bones/textBone.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import logging
 import string
 from html import entities as htmlentitydefs
@@ -258,9 +257,14 @@ class textBone(baseBone):
 	def generageSearchWidget(target, name="TEXT BONE", mode="equals"):
 		return ({"name": name, "mode": mode, "target": target, "type": "text"})
 
-	def __init__(self, validHtml: Union[None, Dict] = __undefinedC__, languages: Union[None, List[str]] = None,
-				 maxLength: int = 200000, defaultValue: Any = None, indexed: bool = False,
-				 srcSet:Optional[Dict[str, List]] = None, *args, **kwargs):
+	def __init__(
+		self,
+		*,
+		validHtml: Union[None, Dict] = __undefinedC__,
+		maxLength: int = 200000,
+		srcSet: Optional[Dict[str, List]] = None,
+		**kwargs
+	):
 		"""
 			:param validHtml: If set, must be a structure like :prop:_defaultTags
 			:param languages: If set, this bone can store a different content for each language
@@ -269,22 +273,15 @@ class textBone(baseBone):
 			:param srcSet: If set, inject srcset tags to embedded images. Must be a dict of
 				"width": [List of Ints], "height": [List of Ints], eg {"height": [720, 1080]}
 		"""
-		super(textBone, self).__init__(defaultValue=defaultValue, indexed=indexed, *args, **kwargs)
+		super().__init__(**kwargs)
+
 		if validHtml == textBone.__undefinedC__:
 			global _defaultTags
 			validHtml = _defaultTags
-		if not (languages is None or (isinstance(languages, list) and languages
-									  and all(isinstance(x, str) for x in languages))):
-			raise ValueError("languages must be None or a list of strings")
-		self.languages = languages
+
 		self.validHtml = validHtml
 		self.maxLength = maxLength
 		self.srcSet = srcSet
-		if defaultValue is None:
-			if self.languages:
-				self.defaultValue = {}
-			else:
-				self.defaultValue = ""
 
 	def singleValueSerialize(self, value, skel: 'SkeletonInstance', name: str, parentIndexed: bool):
 		return value

--- a/core/bones/treeLeafBone.py
+++ b/core/bones/treeLeafBone.py
@@ -5,5 +5,5 @@ from viur.core.bones import relationalBone
 class treeLeafBone(relationalBone):
 	type = "relational.tree.leaf"
 
-	def __init__(self, *args, **kwargs):
-		super(treeLeafBone, self).__init__(*args, **kwargs)
+	def __init__(self, **kwargs):
+		super(treeLeafBone, self).__init__(**kwargs)

--- a/core/bones/treeNodeBone.py
+++ b/core/bones/treeNodeBone.py
@@ -7,7 +7,7 @@ from viur.core import request
 class treeNodeBone(relationalBone):
 	type = "relational.tree.node"
 
-	def __init__(self, kind=None, format="value['dest']['name']", *args, **kwargs):
+	def __init__(self, *, kind=None, format="value['dest']['name']", **kwargs):
 		if kind and not kind.endswith("_rootNode"):
 			kind += "_rootNode"
 		super(treeNodeBone, self).__init__(kind=kind, format=format, *args, **kwargs)

--- a/core/bones/userBone.py
+++ b/core/bones/userBone.py
@@ -7,17 +7,19 @@ class userBone(relationalBone):
 	kind = "user"
 	datafields = ["name"]
 
-	def __init__(self, creationMagic=False, updateMagic=False, visible=None, multiple=False, readOnly=False, *args,
-				 **kwargs):
+	def __init__(self, *, creationMagic=False, updateMagic=False, visible=None, readOnly=False, **kwargs):
 		if creationMagic or updateMagic:
 			readOnly = False
 			if visible is None:
 				visible = False  # defaults
 		elif visible is None:
 			visible = True
-		super(userBone, self).__init__(multiple=multiple, visible=visible, readOnly=readOnly, *args, **kwargs)
+
+		super().__init__(visible=visible, readOnly=readOnly, **kwargs)
+
 		self.creationMagic = creationMagic
 		self.updateMagic = updateMagic
+
 		if self.multiple and (creationMagic or updateMagic):
 			raise ValueError("Cannot be multiple and have a creation/update-magic set!")
 

--- a/core/prototypes/tree.py
+++ b/core/prototypes/tree.py
@@ -17,7 +17,7 @@ from viur.core.cache import flushCache
 class TreeSkel(Skeleton):
 	parententry = keyBone(descr="Parent", visible=False, indexed=True, readOnly=True)
 	parentrepo = keyBone(descr="BaseRepo", visible=False, indexed=True, readOnly=True)
-	sortindex = numericBone(descr="SortIndex", mode="float", visible=False, indexed=True, readOnly=True, max=pow(2, 30))
+	sortindex = numericBone(descr="SortIndex", visible=False, indexed=True, readOnly=True, precision=8, max=pow(2, 30))
 
 	@classmethod
 	def preProcessSerializedData(cls, skelValues, entity):


### PR DESCRIPTION
- Don't allow for *args anymore
- Error-report any unknown kwargs not intercepted before
- Sorted parameters alphabetically (baseBone)

This includes an improvement likewise #421 for textBone as well.