### PR TITLE
fix typo in error message

### DIFF
--- a/core/bones/dateBone.py
+++ b/core/bones/dateBone.py
@@ -211,7 +211,7 @@ class dateBone(baseBone):
 			elif not self.date:
 				value = value.replace(year=1970, month=1, day=1)
 			# We should always deal with timezone aware datetimes
-			assert value.tzinfo, "Encountered a native Datetime object in %s - refusing to save." % name
+			assert value.tzinfo, "Encountered a naive Datetime object in %s - refusing to save." % name
 		return value
 
 	def singleValueUnserialize(self, value):


### PR DESCRIPTION
a datetime object without a timezone is a naive datetime object, not a native one...