### PR TITLE
Remove errors.ReadFromClientError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This file documents any relevant changes done to ViUR-core since version 3.0.0.
 ### Fixed
 
 ### Removed
+- Remove class `errors.ReadFromClientError`. Replaced by the new dataclass `bones.bone.ReadFromClienError`.  
 
 ## [3.1.3]
 

--- a/core/errors.py
+++ b/core/errors.py
@@ -228,17 +228,3 @@ class ServiceUnavailable(HTTPException):
 
 	def __init__(self, descr="Service Unavailable"):
 		super(ServiceUnavailable, self).__init__(status=503, name="Service Unavailable", descr=descr)
-
-
-class ReadFromClientError(object):
-	"""
-		ReadFromClientError
-
-		Internal use only. Used as a **return-value** (its not raised!) to transport information on errors
-		from fromClient in bones to the surrounding skeleton class
-	"""
-
-	def __init__(self, errors, forceFail=False):
-		super(ReadFromClientError, self).__init__()
-		self.errors = errors
-		self.forceFail = forceFail

--- a/core/request.py
+++ b/core/request.py
@@ -445,7 +445,7 @@ class BrowseHandler():  # webapp.RequestHandler
 					raise errors.NotAcceptable()
 		except UnicodeError:
 			# We received invalid unicode data (usually happens when someone tries to exploit unicode normalisation bugs)
-			raise errors.ReadFromClientError()
+			raise errors.BadRequest()
 		if "self" in kwargs or "return" in kwargs:  # self or return is reserved for bound methods
 			raise errors.BadRequest()
 		# Parse the URL


### PR DESCRIPTION
This class is replaced by the new dataclass `bones.bone.ReadFromClienError`.
Furthermore this one should not be raised, because this doesn't inherit the `Exception` class, as written in the docstring.
Replace the last usage with `errors.BadRequest`.