### PR TITLE
 switch from env vars to pypi config to allow develop releases on testpypi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ viur_core.egg-info
 .env
 /tests/htmlcov/
 /tests/.coverage
+.pypirc
+build

--- a/Pipfile
+++ b/Pipfile
@@ -14,4 +14,5 @@ python_version = "3.8"
 
 [scripts]
 build = "python -m build --wheel"
-release = "twine upload dist/*"
+release = "twine upload --config-file=.pypirc dist/*"
+develop = "twine upload --config-file=.pypirc --repository=testpypi  dist/*"


### PR DESCRIPTION
create a .pypirc file in root directory with secrets to publish on pypi and testpypi.
https://packaging.python.org/en/latest/specifications/pypirc/

Than you can use `pipenv run release` to publish on pypi and `pipenv run develop` to publish on testpypi