### PR TITLE
Update viur.py downloadUrlFor wrapper method. fileName fix

### DIFF
--- a/core/render/html/env/viur.py
+++ b/core/render/html/env/viur.py
@@ -668,6 +668,8 @@ def downloadUrlFor(render: 'viur.core.render.html.default.Render', fileObj: dict
 			caches), otherwise it's lifetime in seconds
 		:param derived: Optional the filename of a derived file, otherwise the the download-link will point to the
 			originally uploaded file.
+		:param downloadFileName: Optionally the filename that the file should be saved as, this will also make the download immediate
+		:param fileName: Optionally the filename that the file should be saved as
 		:return: THe signed download-url relative to the current domain (eg /download/...)
 	"""
 	if expires is unsetMarker:
@@ -682,7 +684,9 @@ def downloadUrlFor(render: 'viur.core.render.html.default.Render', fileObj: dict
 		return None
 	if derived:
 		return utils.downloadUrlFor(folder=fileObj["dlkey"], fileName=derived, derived=True, expires=expires, downloadFileName=downloadFileName)
-	else:
+	elif not derived and fileName:
+		return utils.downloadUrlFor(folder=fileObj["dlkey"], fileName=fileName, derived=False, expires=expires, downloadFileName=downloadFileName)
+    else:
 		return utils.downloadUrlFor(folder=fileObj["dlkey"], fileName=fileObj["name"], derived=False, expires=expires, downloadFileName=downloadFileName)
 
 

--- a/core/render/html/env/viur.py
+++ b/core/render/html/env/viur.py
@@ -658,11 +658,11 @@ def embedSvg(render, name: str, classes: Union[List[str], None] = None, **kwargs
 @jinjaGlobalFunction
 def downloadUrlFor(render: 'viur.core.render.html.default.Render', fileObj: dict,
 				   expires: Union[None, int] = conf["viur.downloadUrlFor.expiration"],
-				   derived: Optional[str] = None, downloadFileName: Optional[str] = None) -> Optional[str]:
+				   derived: Optional[str] = None, downloadFileName: Optional[str] = None, 
+				   fileName: Optional[str] = None) -> Optional[str]:
 	"""
 		Constructs a signed download-url for the given file-bone. Mostly a wrapper around
 		:meth:`viur.core.utils.downloadUrlFor`.
-
 		:param fileObj: The file-bone (eg. skel["file"])
 		:param expires: None if the file is supposed to be public (which causes it to be cached on the google ede
 			caches), otherwise it's lifetime in seconds
@@ -686,7 +686,7 @@ def downloadUrlFor(render: 'viur.core.render.html.default.Render', fileObj: dict
 		return utils.downloadUrlFor(folder=fileObj["dlkey"], fileName=derived, derived=True, expires=expires, downloadFileName=downloadFileName)
 	elif not derived and fileName:
 		return utils.downloadUrlFor(folder=fileObj["dlkey"], fileName=fileName, derived=False, expires=expires, downloadFileName=downloadFileName)
-    else:
+	else:
 		return utils.downloadUrlFor(folder=fileObj["dlkey"], fileName=fileObj["name"], derived=False, expires=expires, downloadFileName=downloadFileName)
 
 


### PR DESCRIPTION
Untested, have to test this myself first and will report. Since right now it is not possible to pass a custom filename for a downloadable file, I would think this should work. also the filename parameter is apparently set by default, but it's not working for me. have to investigate why.