### PR TITLE
use original filename when a file is viewed before download

### DIFF
--- a/core/modules/file.py
+++ b/core/modules/file.py
@@ -444,7 +444,8 @@ class File(Tree):
 			fileName = sanitizeFileName(blob.name.split("/")[-1])
 			contentDisposition = "attachment; filename=%s" % fileName
 		else:
-			contentDisposition = None
+			fileName = sanitizeFileName(blob.name.split("/")[-1])
+			contentDisposition = "filename=%s" % fileName
 		if isinstance(credentials, ServiceAccountCredentials):  # We run locally with an service-account.json
 			expiresAt = datetime.now() + timedelta(seconds=60)
 			signedUrl = blob.generate_signed_url(expiresAt, response_disposition=contentDisposition, version="v4")


### PR DESCRIPTION
this fixes the original filename being lost, when a file is supposed to be viewed inside the browser instead of downloaded immediately (in case of PDFs and pictures for example)