### PR TITLE
fix: sortindexbone lambda function fix

### DIFF
--- a/core/bones/sortindex.py
+++ b/core/bones/sortindex.py
@@ -8,7 +8,7 @@ class SortIndexBone(NumericBone):
     def __init__(
         self,
         *,
-        defaultValue: typing.Union[int, float] = lambda skeletonInstance, bone: time.time(),
+        defaultValue: typing.Union[int, float] = lambda *args, **kwargs: time.time(),
         descr: str = "SortIndex",
         max: typing.Union[int, float] = pow(2, 30),
         precision: int = 8,

--- a/core/bones/sortindex.py
+++ b/core/bones/sortindex.py
@@ -8,7 +8,7 @@ class SortIndexBone(NumericBone):
     def __init__(
         self,
         *,
-        defaultValue: typing.Union[int, float] = lambda: time.time(),
+        defaultValue: typing.Union[int, float] = lambda skeletonInstance, bone: time.time(),
         descr: str = "SortIndex",
         max: typing.Union[int, float] = pow(2, 30),
         precision: int = 8,


### PR DESCRIPTION
basebone need 2 parameters, which are missing

`File ".../viur/core/bones/base.py", line 197, in getDefaultValue
    return self.defaultValue(skeletonInstance, self)
TypeError: <lambda>() takes 0 positional arguments but 2 were given
`