### PR TITLE
Fixing file module

### DIFF
--- a/core/bones/__init__.py
+++ b/core/bones/__init__.py
@@ -1,30 +1,37 @@
-from viur.core.bones.base import BaseBone, ReadFromClientError, UniqueValue, UniqueLockMethod, MultipleConstraints
-from viur.core.bones.boolean import BooleanBone
-from viur.core.bones.captcha import CaptchaBone
-from viur.core.bones.color import ColorBone
-from viur.core.bones.credential import CredentialBone
-from viur.core.bones.date import DateBone
-from viur.core.bones.email import EmailBone
-from viur.core.bones.file import FileBone
-from viur.core.bones.key import KeyBone
-from viur.core.bones.numeric import NumericBone
-from viur.core.bones.password import PasswordBone
-from viur.core.bones.randomslice import RandomSliceBone
-from viur.core.bones.raw import RawBone
-from viur.core.bones.record import RecordBone
-from viur.core.bones.relational import RelationalBone, RelationalConsistency
-from viur.core.bones.selectcountry import SelectCountryBone
-from viur.core.bones.select import SelectBone
-from viur.core.bones.sortindex import SortIndexBone
-from viur.core.bones.spatial import SpatialBone
-from viur.core.bones.string import StringBone
-from viur.core.bones.text import TextBone
-from viur.core.bones.treeleaf import TreeLeafBone
-from viur.core.bones.treenode import TreeNodeBone
-from viur.core.bones.user import UserBone
+from .base import BaseBone, ReadFromClientError, UniqueValue, UniqueLockMethod, MultipleConstraints
+from .boolean import BooleanBone
+from .captcha import CaptchaBone
+from .color import ColorBone
+from .credential import CredentialBone
+from .date import DateBone
+from .email import EmailBone
+from .file import FileBone
+from .key import KeyBone
+from .numeric import NumericBone
+from .password import PasswordBone
+from .randomslice import RandomSliceBone
+from .raw import RawBone
+from .record import RecordBone
+from .relational import RelationalBone, RelationalConsistency
+from .selectcountry import SelectCountryBone
+from .select import SelectBone
+from .sortindex import SortIndexBone
+from .spatial import SpatialBone
+from .string import StringBone
+from .text import TextBone
+from .treeleaf import TreeLeafBone
+from .treenode import TreeNodeBone
+from .user import UserBone
 
+# Expose only specific names
+__all = [
+	"ReadFromClientError",
+	"UniqueValue",
+	"UniqueLockMethod",
+	"MultipleConstraints",
+	"RelationalConsistency"
+]
 
-# Dynamically create a class providing a deprecation logging message for every lower-case bone name
 for __cls_name, __cls in locals().copy().items():
 	if __cls_name.startswith("__"):
 		continue
@@ -32,6 +39,9 @@ for __cls_name, __cls in locals().copy().items():
 	if __cls_name.endswith("Bone"):
 		__old_cls_name = __cls_name[0].lower() + __cls_name[1:]
 
+		__all += [__cls_name, __old_cls_name]
+
+		# Dynamically create a class providing a deprecation logging message for every lower-case bone name
 		def __generate_deprecation_constructor(cls, cls_name, old_cls_name):
 			def __init__(self, *args, **kwargs):
 				import logging, warnings
@@ -46,3 +56,5 @@ for __cls_name, __cls in locals().copy().items():
 		})
 
 		#print(__old_cls_name, "installed as ", locals()[__old_cls_name], issubclass(locals()[__old_cls_name], __cls))
+
+__all__ = __all

--- a/core/bones/__init__.py
+++ b/core/bones/__init__.py
@@ -1,4 +1,4 @@
-from .base import BaseBone, ReadFromClientError, UniqueValue, UniqueLockMethod, MultipleConstraints
+from .base import BaseBone, ReadFromClientError, ReadFromClientErrorSeverity, UniqueValue, UniqueLockMethod, MultipleConstraints
 from .boolean import BooleanBone
 from .captcha import CaptchaBone
 from .color import ColorBone

--- a/core/bones/__init__.py
+++ b/core/bones/__init__.py
@@ -26,6 +26,7 @@ from .user import UserBone
 # Expose only specific names
 __all = [
 	"ReadFromClientError",
+	"ReadFromClientErrorSeverity",
 	"UniqueValue",
 	"UniqueLockMethod",
 	"MultipleConstraints",

--- a/core/modules/file.py
+++ b/core/modules/file.py
@@ -19,7 +19,8 @@ from google.cloud import storage
 from google.cloud._helpers import _NOW, _datetime_to_rfc3339
 from google.oauth2.service_account import Credentials as ServiceAccountCredentials
 
-from viur.core import bones, errors, exposed, forcePost, forceSSL, internalExposed, securitykey, utils, db
+from viur.core import errors, exposed, forcePost, forceSSL, internalExposed, securitykey, utils, db
+from viur.core.bones import *
 from viur.core.prototypes.tree import Tree, TreeSkel
 from viur.core.skeleton import skeletonByKind
 from viur.core.tasks import PeriodicTask, callDeferred
@@ -78,7 +79,7 @@ def importBlobFromViur2(dlKey, fileName):
 	return marker["dlurl"]
 
 
-class InjectStoreURLBone(bones.BaseBone):
+class InjectStoreURLBone(BaseBone):
 
 	def unserialize(self, skel, name):
 		if "dlkey" in skel.dbEntity and "name" in skel.dbEntity:
@@ -139,46 +140,46 @@ class fileBaseSkel(TreeSkel):
 	"""
 	kindName = "file"
 
-	size = bones.StringBone(
+	size = StringBone(
 		descr="Size",
 		readOnly=True,
 		searchable=True
 	)
 
-	dlkey = bones.StringBone(
+	dlkey = StringBone(
 		descr="Download-Key",
 		readOnly=True
 	)
-	name = bones.StringBone(
+	name = StringBone(
 		descr="Filename",
 		caseSensitive=False,
 		searchable=True
 	)
 
-	mimetype = bones.StringBone(
+	mimetype = StringBone(
 		descr="Mime-Info",
 		readOnly=True
 	)
 
-	weak = bones.BooleanBone(
+	weak = BooleanBone(
 		descr="Weak reference",
 		readOnly=True,
 		visible=False
 	)
-	pending = bones.BooleanBone(
+	pending = BooleanBone(
 		descr="Pending upload",
 		readOnly=True,
 		visible=False,
 		defaultValue=False
 	)
 
-	width = bones.NumericBone(
+	width = NumericBone(
 		descr="Width",
 		readOnly=True,
 		searchable=True
 	)
 
-	height = bones.NumericBone(
+	height = NumericBone(
 		descr="Height",
 		readOnly=True,
 		searchable=True
@@ -190,13 +191,13 @@ class fileBaseSkel(TreeSkel):
 		visible=False
 	)
 
-	derived = bones.BaseBone(
+	derived = BaseBone(
 		descr="Derived Files",
 		readOnly=True,
 		visible=False
 	)
 
-	pendingparententry = bones.KeyBone(
+	pendingparententry = KeyBone(
 		descr="Pending key Reference",
 		readOnly=True,
 		visible=False
@@ -227,13 +228,13 @@ class fileNodeSkel(TreeSkel):
 	"""
 	kindName = "file_rootNode"
 
-	name = bones.StringBone(
+	name = StringBone(
 		descr="Name",
 		required=True,
 		searchable=True
 	)
 
-	rootNode = bones.BooleanBone(
+	rootNode = BooleanBone(
 		descr="Is RootNode"
 	)
 

--- a/core/modules/file.py
+++ b/core/modules/file.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import base64
 import email.header
 import json
@@ -21,8 +19,7 @@ from google.cloud import storage
 from google.cloud._helpers import _NOW, _datetime_to_rfc3339
 from google.oauth2.service_account import Credentials as ServiceAccountCredentials
 
-from viur.core import errors, exposed, forcePost, forceSSL, internalExposed, securitykey, utils, db
-from viur.core.bones import *
+from viur.core import bones, errors, exposed, forcePost, forceSSL, internalExposed, securitykey, utils, db
 from viur.core.prototypes.tree import Tree, TreeSkel
 from viur.core.skeleton import skeletonByKind
 from viur.core.tasks import PeriodicTask, callDeferred
@@ -81,7 +78,8 @@ def importBlobFromViur2(dlKey, fileName):
 	return marker["dlurl"]
 
 
-class injectStoreURLBone(BaseBone):
+class InjectStoreURLBone(bones.BaseBone):
+
 	def unserialize(self, skel, name):
 		if "dlkey" in skel.dbEntity and "name" in skel.dbEntity:
 			skel.accessedValues[name] = utils.downloadUrlFor(skel["dlkey"], skel["name"], derived=False)
@@ -141,39 +139,68 @@ class fileBaseSkel(TreeSkel):
 	"""
 	kindName = "file"
 
-	size = StringBone(descr="Size", readOnly=True, indexed=True, searchable=True)
-	dlkey = StringBone(descr="Download-Key", readOnly=True, indexed=True)
-	name = StringBone(descr="Filename", caseSensitive=False, indexed=True, searchable=True)
-	mimetype = StringBone(descr="Mime-Info", readOnly=True, indexed=True)
-	weak = BooleanBone(descr="Weak reference", indexed=True, readOnly=True, visible=False)
-	pending = BooleanBone(descr="Pending upload", readOnly=True, visible=False, defaultValue=False)
-	width = NumericBone(descr="Width", indexed=True, readOnly=True, searchable=True)
-	height = NumericBone(descr="Height", indexed=True, readOnly=True, searchable=True)
-	downloadUrl = injectStoreURLBone(descr="Download-URL", readOnly=True, visible=False)
-	derived = BaseBone(descr=u"Derived Files", readOnly=True, visible=False)
-	pendingparententry = KeyBone(descr=u"Pending key Reference", readOnly=True, visible=False)
+	size = bones.StringBone(
+		descr="Size",
+		readOnly=True,
+		searchable=True
+	)
 
-	"""
-	def refresh(self):
-		# Update from blobimportmap
-		try:
-			oldKeyHash = sha256(self["dlkey"]).hexdigest().encode("hex")
-			res = db.Get(db.Key.from_path("viur-blobimportmap", oldKeyHash))
-		except:
-			res = None
-		if res and res["oldkey"] == self["dlkey"]:
-			self["dlkey"] = res["newkey"]
-			self["servingurl"] = res["servingurl"]
-			logging.info("Refreshing file dlkey %s (%s)" % (self["dlkey"], self["servingurl"]))
-		else:
-			if self["servingurl"]:
-				try:
-					self["servingurl"] = images.get_serving_url(self["dlkey"])
-				except Exception as e:
-					logging.exception(e)
+	dlkey = bones.StringBone(
+		descr="Download-Key",
+		readOnly=True
+	)
+	name = bones.StringBone(
+		descr="Filename",
+		caseSensitive=False,
+		searchable=True
+	)
 
-		super(fileBaseSkel, self).refresh()
-	"""
+	mimetype = bones.StringBone(
+		descr="Mime-Info",
+		readOnly=True
+	)
+
+	weak = bones.BooleanBone(
+		descr="Weak reference",
+		readOnly=True,
+		visible=False
+	)
+	pending = bones.BooleanBone(
+		descr="Pending upload",
+		readOnly=True,
+		visible=False,
+		defaultValue=False
+	)
+
+	width = bones.NumericBone(
+		descr="Width",
+		readOnly=True,
+		searchable=True
+	)
+
+	height = bones.NumericBone(
+		descr="Height",
+		readOnly=True,
+		searchable=True
+	)
+
+	downloadUrl = InjectStoreURLBone(
+		descr="Download-URL",
+		readOnly=True,
+		visible=False
+	)
+
+	derived = bones.BaseBone(
+		descr="Derived Files",
+		readOnly=True,
+		visible=False
+	)
+
+	pendingparententry = bones.KeyBone(
+		descr="Pending key Reference",
+		readOnly=True,
+		visible=False
+	)
 
 	def preProcessBlobLocks(self, locks):
 		"""
@@ -199,8 +226,16 @@ class fileNodeSkel(TreeSkel):
 		Default file node skeleton.
 	"""
 	kindName = "file_rootNode"
-	name = StringBone(descr="Name", required=True, indexed=True, searchable=True)
-	rootNode = BooleanBone(descr=u"Is RootNode", indexed=True)
+
+	name = bones.StringBone(
+		descr="Name",
+		required=True,
+		searchable=True
+	)
+
+	rootNode = bones.BooleanBone(
+		descr="Is RootNode"
+	)
 
 
 def decodeFileName(name):

--- a/core/modules/file.py
+++ b/core/modules/file.py
@@ -20,7 +20,7 @@ from google.cloud._helpers import _NOW, _datetime_to_rfc3339
 from google.oauth2.service_account import Credentials as ServiceAccountCredentials
 
 from viur.core import errors, exposed, forcePost, forceSSL, internalExposed, securitykey, utils, db
-from viur.core.bones import *
+from viur.core.bones import BaseBone, BooleanBone, KeyBone, NumericBone, StringBone
 from viur.core.prototypes.tree import Tree, TreeSkel
 from viur.core.skeleton import skeletonByKind
 from viur.core.tasks import PeriodicTask, callDeferred


### PR DESCRIPTION
Due the renaming of bones.stringBone into bones.string, the stdlib `import string` and then `from viur.core.bones import *` afterwards causes the assert with string.ascii_digits etc. to fail.

This fixes it entirely and cleans up Skeleton definition of the file module generally (formatting, index=True removal)