### PR TITLE
Add support for `Literal` type annotations in processTypeHint

### DIFF
--- a/core/request.py
+++ b/core/request.py
@@ -417,6 +417,14 @@ class BrowseHandler():  # webapp.RequestHandler
 				return "True", True
 			else:
 				return "False", False
+		elif typeOrigin is typing.Literal:
+			inValueStr = str(inValue)
+			for literal in typeHint.__args__:
+				if inValueStr == str(literal):
+					return inValue, literal
+			raise TypeError("Input argument must be one of these Literals: "
+							+ ", ".join(map(repr, typeHint.__args__)))
+
 		raise ValueError("TypeHint %s not supported" % typeHint)
 
 	def findAndCall(self, path:str, *args, **kwargs):


### PR DESCRIPTION
Parse also `Literal` type annotations in exposed methods.
Literals were introduced with [PEP-586](https://peps.python.org/pep-0586/) for Python >= 3.8.

Example:
```py
from typing import Literal
from viur.core import exposed

@exposed
def my_method(self, value: Literal['a', 'b', 7]):
    ...
```
Only `'a'`, `'b'` and `7` are allowed for `value`. Other values will be rejected.
The `7` will be accepted as `str`, but forwarded as `int`.