### PR TITLE
Fixed seoKey handling in skeletons and fixed seoURLtoEntry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This file documents any relevant changes done to ViUR-core since version 3.0.0.
 ### Fixed
 - required=True bones could still be set to empty if omitted from the request
 - treeNodeBone enforcing "_rootNode" suffix on it's kind which this isn't true for ViUR3 anymore.
+- Fixed seoKeys and URLs
 
 ### Removed
 

--- a/core/skeleton.py
+++ b/core/skeleton.py
@@ -815,6 +815,8 @@ class Skeleton(BaseSkeleton, metaclass=MetaSkel):
 			# Ensure the SEO-Keys are up2date
 			lastRequestedSeoKeys = dbObj["viur"].get("viurLastRequestedSeoKeys") or {}
 			lastSetSeoKeys = dbObj["viur"].get("viurCurrentSeoKeys") or {}
+			# Filter garbage serialized into this field by the seoKeyBone
+			lastSetSeoKeys = {k: v for k, v in lastSetSeoKeys.items() if not k.startswith("_") and v}
 			currentSeoKeys = skel.getCurrentSEOKeys()
 			if not isinstance(dbObj["viur"].get("viurCurrentSeoKeys"), dict):
 				dbObj["viur"]["viurCurrentSeoKeys"] = {}
@@ -840,9 +842,9 @@ class Skeleton(BaseSkeleton, metaclass=MetaSkel):
 					if currentKey != lastRequestedSeoKeys.get(language):  # This one is new or has changed
 						newSeoKey = currentSeoKeys[language]
 						for _ in range(0, 3):
-							entryUsingKey = db.Query(skelValues.kindName).filter("viurActiveSeoKeys =",
+							entryUsingKey = db.Query(skelValues.kindName).filter("viur.viurActiveSeoKeys =",
 																				 newSeoKey).getEntry()
-							if entryUsingKey and entryUsingKey.name != dbObj.name:
+							if entryUsingKey and entryUsingKey.key != dbObj.key:
 								# It's not unique; append a random string and try again
 								newSeoKey = "%s-%s" % (currentSeoKeys[language], utils.generateRandomString(5).lower())
 							else:
@@ -854,7 +856,7 @@ class Skeleton(BaseSkeleton, metaclass=MetaSkel):
 					lastSetSeoKeys[language] = newSeoKey
 				else:
 					# We'll use the database-key instead
-					lastSetSeoKeys[language] = dbObj.key.id_or_name
+					lastSetSeoKeys[language] = str(dbObj.key.id_or_name)
 				# Store the current, active key for that language
 				dbObj["viur"]["viurCurrentSeoKeys"][language] = lastSetSeoKeys[language]
 			if not dbObj["viur"].get("viurActiveSeoKeys"):

--- a/core/utils.py
+++ b/core/utils.py
@@ -239,7 +239,13 @@ def seoUrlToEntry(module: str,
 		if language in (currentSeoKeys or {}):
 			pathComponents.append(str(currentSeoKeys[language]))
 		elif "key" in entry:
-			pathComponents.append(str(entry["key"].id_or_name) if isinstance(entry["key"], db.Key) else str(entry["key"]))
+			key = entry["key"]
+			if isinstance(key, str):
+				try:
+					key = db.Key.from_legacy_urlsafe(key)
+				except:
+					pass
+			pathComponents.append(str(key.id_or_name) if isinstance(key, db.Key) else str(key))
 		elif "name" in dir(entry):
 			pathComponents.append(str(entry.name))
 		return "/".join(pathComponents)


### PR DESCRIPTION
- seoUrlForEntry might created a legacy_urlsafe_key if called from jinja which is not supported
- Checking for duplicate seokeys was broken
- Unsupported values (True and None) where erroneously included in activeSeoKeys