### PR TITLE
Implement `errors.TooManyRequests` exception

### DIFF
--- a/core/errors.py
+++ b/core/errors.py
@@ -188,7 +188,7 @@ class TooManyRequests(HTTPException):
 		super(TooManyRequests, self).__init__(status=429, name="Too Many Requests", descr=descr)
 
 	@classmethod
-	def fromRateLimit(cls, ratelimit: RateLimit, setRetryAfterHeader: bool = True):
+	def fromRateLimit(cls, ratelimit: RateLimit, setRetryAfterHeader: bool = True) -> 'TooManyRequests':
 		"""Creates an exception instance based on a RateLimit configuration.
 
 		:param ratelimit: The RateLimit instance used to control the rate limit.

--- a/core/errors.py
+++ b/core/errors.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from viur.core.ratelimit import RateLimit
 
 
 class HTTPException(Exception):
@@ -186,20 +185,6 @@ class TooManyRequests(HTTPException):
 
 	def __init__(self, descr: str = "Too Many Requests"):
 		super(TooManyRequests, self).__init__(status=429, name="Too Many Requests", descr=descr)
-
-	@classmethod
-	def fromRateLimit(cls, ratelimit: RateLimit, setRetryAfterHeader: bool = True) -> 'TooManyRequests':
-		"""Creates an exception instance based on a RateLimit configuration.
-
-		:param ratelimit: The RateLimit instance used to control the rate limit.
-		:param setRetryAfterHeader: Set the Retry-After header on the current request response.
-		:return: A new instance of :class:`TooManyRequests`
-		"""
-		if setRetryAfterHeader:
-			from viur.core import currentRequest
-			currentRequest.get().response.headers["Retry-After"] = str(ratelimit.maxRate * 60)
-		return cls(f"{ratelimit.steps} requests allowed per {ratelimit.maxRate} minute(s)."
-				   f" Try again later.")
 
 
 class Censored(HTTPException):

--- a/core/modules/user.py
+++ b/core/modules/user.py
@@ -184,7 +184,7 @@ class UserPassword(object):
 			return self.userModule.render.login(self.loginSkel())
 
 		if not self.loginRateLimit.isQuotaAvailable():
-			raise errors.Forbidden()
+			raise errors.TooManyRequests.fromRateLimit(self.loginRateLimit)
 
 		name = name.lower().strip()
 		query = db.Query(self.userModule.viewSkel().kindName)
@@ -248,7 +248,7 @@ class UserPassword(object):
 			to 10 actions per 15 minutes. (One complete recovery process consists of two calls).
 		"""
 		if not self.passwordRecoveryRateLimit.isQuotaAvailable():
-			raise errors.Forbidden()  # Quota exhausted, bail out
+			raise errors.TooManyRequests.fromRateLimit(self.passwordRecoveryRateLimit)  # Quota exhausted, bail out
 		session = currentSession.get()
 		request = currentRequest.get()
 		recoverStep = session.get("user.auth_userpassword.pwrecover")

--- a/core/modules/user.py
+++ b/core/modules/user.py
@@ -183,8 +183,7 @@ class UserPassword(object):
 		if not name or not password or not securitykey.validate(skey, useSessionKey=True):
 			return self.userModule.render.login(self.loginSkel())
 
-		if not self.loginRateLimit.isQuotaAvailable():
-			raise errors.TooManyRequests.fromRateLimit(self.loginRateLimit)
+		self.loginRateLimit.assertQuotaIsAvailable()
 
 		name = name.lower().strip()
 		query = db.Query(self.userModule.viewSkel().kindName)
@@ -247,8 +246,7 @@ class UserPassword(object):
 			To prevent automated attacks, the fist step is guarded by a captcha and we limited calls to this function
 			to 10 actions per 15 minutes. (One complete recovery process consists of two calls).
 		"""
-		if not self.passwordRecoveryRateLimit.isQuotaAvailable():
-			raise errors.TooManyRequests.fromRateLimit(self.passwordRecoveryRateLimit)  # Quota exhausted, bail out
+		self.passwordRecoveryRateLimit.assertQuotaIsAvailable()
 		session = currentSession.get()
 		request = currentRequest.get()
 		recoverStep = session.get("user.auth_userpassword.pwrecover")


### PR DESCRIPTION
Implement an exception class for HTTP Status "429 Too Many Requests"
and use it instead of Forbidden for rate limit blocked actions.