### PR TITLE
Remove Parameter

### DIFF
--- a/core/securitykey.py
+++ b/core/securitykey.py
@@ -95,7 +95,7 @@ def startClearSKeys():
 	"""
 		Removes old (expired) skeys
 	"""
-	doClearSKeys((datetime.now() - timedelta(seconds=300)).strftime("%d.%m.%Y %H:%M:%S"), None)
+	doClearSKeys((datetime.now() - timedelta(seconds=300)).strftime("%d.%m.%Y %H:%M:%S"))
 
 
 @callDeferred


### PR DESCRIPTION
Remove "None" as parameter when calling `doClearSKeys`, because function changed here https://github.com/viur-framework/viur-core/commit/bb407494b385d25525e87e90dffa2b6e1becb4c9