### PR TITLE
Hint when viur.debug.traceExceptions is set

### DIFF
--- a/core/request.py
+++ b/core/request.py
@@ -249,6 +249,7 @@ class BrowseHandler():  # webapp.RequestHandler
             self.findAndCall(path)
         except errors.Redirect as e:
             if conf["viur.debug.traceExceptions"]:
+                logging.warning("""conf["viur.debug.traceExceptions"] is set, won't handle this exception""")
                 raise
             self.response.status = '%d %s' % (e.status, e.name)
             url = e.url
@@ -257,6 +258,7 @@ class BrowseHandler():  # webapp.RequestHandler
             self.response.headers['Location'] = url
         except errors.HTTPException as e:
             if conf["viur.debug.traceExceptions"]:
+                logging.warning("""conf["viur.debug.traceExceptions"] is set, won't handle this exception""")
                 raise
             self.response.body = b""
             self.response.status = '%d %s' % (e.status, e.name)


### PR DESCRIPTION
It occasionally happens that someone sets viur.debug.traceExceptions for debugging purposes and forgets to remove it. In this case, an additional log message will be printed to resolve the problem on probably annoying behavior.