### PR TITLE
Get full skel instance by skeletonCls instead

### DIFF
--- a/core/skeleton.py
+++ b/core/skeleton.py
@@ -718,8 +718,9 @@ class Skeleton(BaseSkeleton, metaclass=MetaSkel):
         assert skelValues.renderPreparation is None, "Cannot modify values while rendering"
 
         def txnUpdate(dbKey, mergeFrom, clearUpdateTag):
+            skel = mergeFrom.skeletonCls()
+
             blobList = set()
-            skel = skeletonByKind(mergeFrom.kindName)()
             changeList = []
 
             # Load the current values from Datastore or create a new, empty db.Entity


### PR DESCRIPTION
This fix ensures that the full skel used to store all values inside toDB() is of the same skeleton class as mergeFrom.

The previously supposed idea was
```python
skel_cls = skeletonByKind(mergeFrom.kindName)
assert mergeFrom.skeletonCls is skel_cls
skel = skel_cls()
```
but this is the more elegant way, I think.