### PR TITLE
Extending KeyBone to check given key's existence

### DIFF
--- a/core/bones/key.py
+++ b/core/bones/key.py
@@ -23,7 +23,8 @@ class KeyBone(BaseBone):
 
     def singleValueFromClient(self, value, skel, name, origData):
         # check for correct key
-        value = value.strip()
+        if isinstance(value, str):
+            value = value.strip()
 
         if self.allowed_kinds:
             try:


### PR DESCRIPTION
Allows for defining `KeyBone(check=True)` which checks if the given key does exist. This should prevent from setting KeyBones to arbitrary keys.

This is a preliminary for Tree extensions planned.