### PR TITLE
Add valid mime types to the BoneStructure

### DIFF
--- a/core/render/html/default.py
+++ b/core/render/html/default.py
@@ -161,6 +161,8 @@ class Render(object):
                 "using": self.renderSkelStructure(bone.using()) if bone.using else None,
                 "relskel": self.renderSkelStructure(bone._refSkelCache())
             })
+            if bone.type.startswith("relational.tree.leaf.file"):
+                ret.update({"validMimeTypes":bone.validMimeTypes})
 
         elif bone.type == "record" or bone.type.startswith("record."):
             ret.update({

--- a/core/render/json/default.py
+++ b/core/render/json/default.py
@@ -73,6 +73,8 @@ class DefaultRender(object):
                 "using": self.renderSkelStructure(bone.using()) if bone.using else None,
                 "relskel": self.renderSkelStructure(bone._refSkelCache())
             })
+            if bone.type.startswith("relational.tree.leaf.file"):
+                ret.update({"validMimeTypes":bone.validMimeTypes})
 
         elif bone.type == "record" or bone.type.startswith("record."):
             ret.update({

--- a/core/render/xml/default.py
+++ b/core/render/xml/default.py
@@ -91,6 +91,8 @@ class DefaultRender(object):
                 "using": self.renderSkelStructure(bone.using()) if bone.using else None,
                 "relskel": self.renderSkelStructure(bone._refSkelCache())
             })
+            if bone.type.startswith("relational.tree.leaf.file"):
+                ret.update({"validMimeTypes":bone.validMimeTypes})
 
         elif isinstance(bone, SelectBone):
             ret.update({


### PR DESCRIPTION
This pull request adds validMimeTypes to the BoneStructure. So that you can use them on the client side to select files.