### PR TITLE
Set new max Value for SortIndexBone

### DIFF
--- a/core/bones/numeric.py
+++ b/core/bones/numeric.py
@@ -2,9 +2,13 @@ import logging
 import warnings
 from viur.core.bones.base import BaseBone, ReadFromClientError, ReadFromClientErrorSeverity
 from viur.core import db
-from math import pow
 from typing import Any, Dict, Optional, Union
 import sys
+
+# Constants for Mne (MIN/MAX-never-exceed)
+MIN = -(sys.maxsize - 1)
+MAX = sys.maxsize
+
 
 class NumericBone(BaseBone):
     """
@@ -17,8 +21,8 @@ class NumericBone(BaseBone):
     def __init__(
         self,
         *,
-        max: Union[int, float] = sys.maxsize,
-        min: Union[int, float] = -(sys.maxsize - 1),
+        max: Union[int, float] = MAX,
+        min: Union[int, float] = MIN,
         mode=None,  # deprecated!
         precision: int = 0,
         **kwargs
@@ -48,6 +52,13 @@ class NumericBone(BaseBone):
         self.precision = precision
         self.min = min
         self.max = max
+
+    def __setattr__(self, key, value):
+        if key in ("min", "max"):
+            if value < MIN or value > MAX:
+                raise ValueError(f"{key} can only be set to something between {MIN} and {MAX}")
+
+        return super().__setattr__(key, value)
 
     def isInvalid(self, value):
         if value != value:  # NaN

--- a/core/bones/numeric.py
+++ b/core/bones/numeric.py
@@ -4,7 +4,7 @@ from viur.core.bones.base import BaseBone, ReadFromClientError, ReadFromClientEr
 from viur.core import db
 from math import pow
 from typing import Any, Dict, Optional, Union
-
+import sys
 
 class NumericBone(BaseBone):
     """
@@ -17,8 +17,8 @@ class NumericBone(BaseBone):
     def __init__(
         self,
         *,
-        max: Union[int, float] = int(pow(2, 30)),
-        min: Union[int, float] = -int(pow(2, 30)),
+        max: Union[int, float] = sys.maxsize,
+        min: Union[int, float] = -(sys.maxsize - 1),
         mode=None,  # deprecated!
         precision: int = 0,
         **kwargs

--- a/core/bones/sortindex.py
+++ b/core/bones/sortindex.py
@@ -1,5 +1,5 @@
 from viur.core.bones.numeric import NumericBone
-import time, typing
+import time, typing,sys
 
 
 class SortIndexBone(NumericBone):
@@ -10,7 +10,7 @@ class SortIndexBone(NumericBone):
         *,
         defaultValue: typing.Union[int, float] = lambda *args, **kwargs: time.time(),
         descr: str = "SortIndex",
-        max: typing.Union[int, float] = pow(2, 30),
+        max: typing.Union[int, float] = sys.maxsize,
         precision: int = 8,
         **kwargs
     ):

--- a/core/bones/sortindex.py
+++ b/core/bones/sortindex.py
@@ -1,5 +1,5 @@
 from viur.core.bones.numeric import NumericBone
-import time, typing,sys
+import time, typing
 
 
 class SortIndexBone(NumericBone):

--- a/core/bones/sortindex.py
+++ b/core/bones/sortindex.py
@@ -16,7 +16,6 @@ class SortIndexBone(NumericBone):
         super().__init__(
             defaultValue=defaultValue,
             descr=descr,
-            max=max,
             precision=precision,
             **kwargs
         )

--- a/core/bones/sortindex.py
+++ b/core/bones/sortindex.py
@@ -10,7 +10,6 @@ class SortIndexBone(NumericBone):
         *,
         defaultValue: typing.Union[int, float] = lambda *args, **kwargs: time.time(),
         descr: str = "SortIndex",
-        max: typing.Union[int, float] = sys.maxsize,
         precision: int = 8,
         **kwargs
     ):


### PR DESCRIPTION
This pull request set the max value for a SortIndexBone higher, because the UNIX timestamp is lager than 2^30.