### PR TITLE
Convert TranslationsKey

### DIFF
--- a/core/i18n.py
+++ b/core/i18n.py
@@ -70,6 +70,9 @@ class translate:
             meanings in the target language.
         """
         super(translate, self).__init__()
+
+        if not isinstance(key,str):
+            key=str(key)
         self.key = key.lower()
         self.defaultText = defaultText or key
         self.hint = hint

--- a/core/i18n.py
+++ b/core/i18n.py
@@ -71,7 +71,7 @@ class translate:
         """
         super(translate, self).__init__()
 
-        if not isinstance(key,str):
+        key = str(key)  # ensure key is a a str
             key=str(key)
         self.key = key.lower()
         self.defaultText = defaultText or key

--- a/core/i18n.py
+++ b/core/i18n.py
@@ -72,7 +72,6 @@ class translate:
         super(translate, self).__init__()
 
         key = str(key)  # ensure key is a a str
-            key=str(key)
         self.key = key.lower()
         self.defaultText = defaultText or key
         self.hint = hint

--- a/core/i18n.py
+++ b/core/i18n.py
@@ -71,7 +71,7 @@ class translate:
         """
         super(translate, self).__init__()
 
-        key = str(key)  # ensure key is a a str
+        key = str(key)  # ensure key is a str
         self.key = key.lower()
         self.defaultText = defaultText or key
         self.hint = hint


### PR DESCRIPTION
This pull request solves the problem that the core crashes when you pass a key to the translate that is not of type string.

https://github.com/viur-framework/viur-core/blob/c89dfd68b595ffa9c2a0f0e09d0984bf18cd3bd8/core/modules/user.py#L64-L72

runs through

https://github.com/viur-framework/viur-core/blob/c89dfd68b595ffa9c2a0f0e09d0984bf18cd3bd8/core/render/json/default.py#L84-L87

or this:
`testSelect=SelectBone(descr="testSelect0",values={"a":1,"b":2,"c":3})`