### PR TITLE
Improving SpatialBone bounds checking and use `float` instead of `int`

### DIFF
--- a/core/bones/spatial.py
+++ b/core/bones/spatial.py
@@ -60,10 +60,14 @@ class SpatialBone(BaseBone):
             gridDimensions) == 2, "gridDimensions must be a tuple of (int, int)"
         # Checks if boundsLat and boundsLng have possible values
         # See https://docs.mapbox.com/help/glossary/lat-lon/
-        assert boundsLat[0] >= -90 and boundsLat[0] <= 90, "boundsLat[0] must be between -90 and 90"
-        assert boundsLat[1] >= -90 and boundsLat[1] <= 90, "boundsLat[1] must be between -90 and 90"
-        assert boundsLng[0] >= -180 and boundsLng[0] <= 180, "boundsLng[0] must be between -180 and 180"
-        assert boundsLng[1] >= -180 and boundsLng[1] <= 180, "boundsLng[1] must be between -180 and 180"
+        if not -90 <= boundsLat[0] <= 90:
+			raise ValueError(f"boundsLat[0] must be between -90 and 90. Got {boundsLat[0]!r}")
+        if not -90 <= boundsLat[1] <= 90:
+			raise ValueError(f"boundsLat[1] must be between -90 and 90. Got {boundsLat[1]!r}")
+        if not -180 <= boundsLng[0] <= 180:
+			raise ValueError(f"boundsLng[0] must be between -180 and 180. Got {boundsLng[0]!r}")
+        if not -180 <= boundsLng[1] <= 180:
+			raise ValueError(f"boundsLng[1] must be between -180 and 180. Got {boundsLng[1]!r}")
         assert not (self.indexed and self.multiple), "Spatial-Bone cannot be indexed when multiple"
         self.boundsLat = boundsLat
         self.boundsLng = boundsLng

--- a/core/bones/spatial.py
+++ b/core/bones/spatial.py
@@ -61,13 +61,13 @@ class SpatialBone(BaseBone):
         # Checks if boundsLat and boundsLng have possible values
         # See https://docs.mapbox.com/help/glossary/lat-lon/
         if not -90 <= boundsLat[0] <= 90:
-			raise ValueError(f"boundsLat[0] must be between -90 and 90. Got {boundsLat[0]!r}")
+            raise ValueError(f"boundsLat[0] must be between -90 and 90. Got {boundsLat[0]!r}")
         if not -90 <= boundsLat[1] <= 90:
-			raise ValueError(f"boundsLat[1] must be between -90 and 90. Got {boundsLat[1]!r}")
+            raise ValueError(f"boundsLat[1] must be between -90 and 90. Got {boundsLat[1]!r}")
         if not -180 <= boundsLng[0] <= 180:
-			raise ValueError(f"boundsLng[0] must be between -180 and 180. Got {boundsLng[0]!r}")
+            raise ValueError(f"boundsLng[0] must be between -180 and 180. Got {boundsLng[0]!r}")
         if not -180 <= boundsLng[1] <= 180:
-			raise ValueError(f"boundsLng[1] must be between -180 and 180. Got {boundsLng[1]!r}")
+            raise ValueError(f"boundsLng[1] must be between -180 and 180. Got {boundsLng[1]!r}")
         assert not (self.indexed and self.multiple), "Spatial-Bone cannot be indexed when multiple"
         self.boundsLat = boundsLat
         self.boundsLng = boundsLng

--- a/core/bones/spatial.py
+++ b/core/bones/spatial.py
@@ -45,7 +45,7 @@ class SpatialBone(BaseBone):
 
     type = "spatial"
 
-    def __init__(self, *, boundsLat: [float, float], boundsLng: Tuple[float, float], gridDimensions: Tuple[int, int], **kwargs):
+    def __init__(self, *, boundsLat: Tuple[float, float], boundsLng: Tuple[float, float], gridDimensions: Tuple[int, int], **kwargs):
         """
             Initializes a new SpatialBone.
 

--- a/core/bones/spatial.py
+++ b/core/bones/spatial.py
@@ -45,7 +45,7 @@ class SpatialBone(BaseBone):
 
     type = "spatial"
 
-    def __init__(self, *, boundsLat: Tuple[int, int], boundsLng: Tuple[int, int], gridDimensions: Tuple[int, int], **kwargs):
+    def __init__(self, *, boundsLat: [float, float], boundsLng: Tuple[float, float], gridDimensions: Tuple[int, int], **kwargs):
         """
             Initializes a new SpatialBone.
 
@@ -54,10 +54,18 @@ class SpatialBone(BaseBone):
             :param gridDimensions: Number of sub-regions the map will be divided in
         """
         super().__init__(**kwargs)
-        assert isinstance(boundsLat, tuple) and len(boundsLat) == 2, "boundsLat must be a tuple of (int, int)"
-        assert isinstance(boundsLng, tuple) and len(boundsLng) == 2, "boundsLng must be a tuple of (int, int)"
+        assert isinstance(boundsLat, tuple) and len(boundsLat) == 2, "boundsLat must be a tuple of (float, float)"
+        assert isinstance(boundsLng, tuple) and len(boundsLng) == 2, "boundsLng must be a tuple of (float, float)"
         assert isinstance(gridDimensions, tuple) and len(
             gridDimensions) == 2, "gridDimensions must be a tuple of (int, int)"
+        """
+        Checks if boundsLat and boundsLng have possible values
+        See https://docs.mapbox.com/help/glossary/lat-lon/
+        """
+        assert boundsLat[0] >= -90 and boundsLat[0] <= 90, "boundsLat[0] must be between -90 and 90"
+        assert boundsLat[1] >= -90 and boundsLat[1] <= 90, "boundsLat[1] must be between -90 and 90"
+        assert boundsLng[0] >= -180 and boundsLng[0] <= 180, "boundsLng[0] must be between -180 and 180"
+        assert boundsLng[1] >= -180 and boundsLng[1] <= 180, "boundsLng[1] must be between -180 and 180"
         assert not (self.indexed and self.multiple), "Spatial-Bone cannot be indexed when multiple"
         self.boundsLat = boundsLat
         self.boundsLng = boundsLng
@@ -72,7 +80,7 @@ class SpatialBone(BaseBone):
         lngDelta = float(self.boundsLng[1] - self.boundsLng[0])
         return latDelta / float(self.gridDimensions[0]), lngDelta / float(self.gridDimensions[1])
 
-    def isInvalid(self, value: Tuple[int, int]) -> Union[str, bool]:
+    def isInvalid(self, value: Tuple[float, float]) -> Union[str, bool]:
         """
             Tests, if the point given by 'value' is inside our boundaries.
             We'll reject all values outside that region.

--- a/core/bones/spatial.py
+++ b/core/bones/spatial.py
@@ -58,10 +58,8 @@ class SpatialBone(BaseBone):
         assert isinstance(boundsLng, tuple) and len(boundsLng) == 2, "boundsLng must be a tuple of (float, float)"
         assert isinstance(gridDimensions, tuple) and len(
             gridDimensions) == 2, "gridDimensions must be a tuple of (int, int)"
-        """
-        Checks if boundsLat and boundsLng have possible values
-        See https://docs.mapbox.com/help/glossary/lat-lon/
-        """
+        # Checks if boundsLat and boundsLng have possible values
+        # See https://docs.mapbox.com/help/glossary/lat-lon/
         assert boundsLat[0] >= -90 and boundsLat[0] <= 90, "boundsLat[0] must be between -90 and 90"
         assert boundsLat[1] >= -90 and boundsLat[1] <= 90, "boundsLat[1] must be between -90 and 90"
         assert boundsLng[0] >= -180 and boundsLng[0] <= 180, "boundsLng[0] must be between -180 and 180"

--- a/core/render/html/default.py
+++ b/core/render/html/default.py
@@ -195,9 +195,16 @@ class Render(object):
             ret.update({
                 "maxLength": bone.maxLength
             })
+
         elif bone.type == "captcha" or bone.type.startswith("captcha."):
             ret.update({
                 "publicKey": bone.publicKey,
+            })
+
+        elif bone.type == "spatial":
+            ret.update({
+                "boundsLat": bone.boundsLat,
+                "boundsLng": bone.boundsLng
             })
 
         return ret

--- a/core/render/json/default.py
+++ b/core/render/json/default.py
@@ -110,6 +110,12 @@ class DefaultRender(object):
                 "maxLength": bone.maxLength
             })
 
+        elif bone.type == "spatial":
+            ret.update({
+                "boundsLat": bone.boundsLat,
+                "boundsLng": bone.boundsLng
+            })
+
         return ret
 
     def renderSkelStructure(self, skel: SkeletonInstance) -> Optional[List[Tuple[str, Dict[str, Any]]]]:

--- a/core/render/xml/default.py
+++ b/core/render/xml/default.py
@@ -124,6 +124,11 @@ class DefaultRender(object):
                 "maxLength": bone.maxLength
             })
 
+        elif isinstance(bone, SpatialBone):
+            ret.update({
+                "boundsLat": bone.boundsLat,
+                "boundsLng": bone.boundsLng
+            })
         return ret
 
     def renderSkelStructure(self, skel: SkeletonInstance) -> Dict:


### PR DESCRIPTION
Checks if boundsLat boundsLat are valid values.
See https://docs.mapbox.com/help/glossary/lat-lon/

Set boundsLat,boundsLat in the renderBoneStructure.