### PR TITLE
Implement isEmpty-function for StringBone

### DIFF
--- a/core/bones/string.py
+++ b/core/bones/string.py
@@ -37,13 +37,15 @@ class StringBone(BaseBone):
     def getEmptyValue(self):
         return ""
 
+    def isEmpty(self, value):
+        return not bool(value.strip())
+
     def singleValueFromClient(self, value, skel, name, origData):
         value = utils.escapeString(value,self.maxLength)
         err = self.isInvalid(value)
         if not err:
             return utils.escapeString(value,self.maxLength), None
         return self.getEmptyValue(), [ReadFromClientError(ReadFromClientErrorSeverity.Invalid, err)]
-
 
     def buildDBFilter(
         self,

--- a/core/bones/string.py
+++ b/core/bones/string.py
@@ -38,7 +38,10 @@ class StringBone(BaseBone):
         return ""
 
     def isEmpty(self, value):
-        return not bool(value.strip())
+        if not value:
+            return True
+
+        return not bool(str(value).strip())
 
     def singleValueFromClient(self, value, skel, name, origData):
         value = utils.escapeString(value,self.maxLength)


### PR DESCRIPTION
This can still be overridden individually using the `isEmptyFunc` parameter that can be given to a bone. Fixes #496.