### PR TITLE
Create a new hmac Key if no one is set

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -254,7 +254,7 @@ def setup(modules: Union[object, ModuleType], render: Union[ModuleType, Dict] = 
     initializeTranslations()
     if conf["viur.file.hmacKey"] is None:
         from viur.core import db
-        key = db.Key("viur-conf", "viur-conf-modulekey")
+        key = db.Key("viur-conf", "viur-conf")
         obj = db.Get(key)
         if not obj:  # we not have a conf yet
             logging.warning("Create new hmac Key")

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -255,18 +255,16 @@ def setup(modules: Union[object, ModuleType], render: Union[ModuleType, Dict] = 
     if conf["viur.file.hmacKey"] is None:
         from viur.core import db
         key = db.Key("viur-conf", "viur-conf")
-        obj = db.Get(key)
-        if not obj:  # we not have a conf yet
-            logging.warning("Create new hmac Key")
-            hmacKey = utils.generateRandomString(length=20)
+        if not (obj := db.Get(key)):  # create a new "viur-conf"?
+            logging.info("Creating new viur-conf")
             obj = db.Entity(key)
-            obj["hmacKey"] = hmacKey
-            db.Put(obj)
-            conf["viur.file.hmacKey"] = bytes(hmacKey, "utf-8")
-        else:
-            if obj["hmacKey"]:
-                conf["viur.file.hmacKey"] = bytes(obj["hmacKey"], "utf-8")
 
+        if "hmacKey" not in obj:  # create a new hmacKey
+            logging.info("Creating new hmacKey")
+            obj["hmacKey"] = utils.generateRandomString(length=20)            
+            db.Put(obj)
+
+        conf["viur.file.hmacKey"] = bytes(obj["hmacKey"], "utf-8")
     return app
 
 


### PR DESCRIPTION
Hello this pull request create a new hmac key if there is no one set and write to in the database.

Maybe we should delete this in the viur-base .
https://github.com/viur-framework/viur-base/blob/9cede043ceb286dca6e898115b83212623a0afec/deploy/main.py#L52
