### PR TITLE
fix: kwargs must be unpacked to be passed as kwargs to list

### DIFF
--- a/core/prototypes/list.py
+++ b/core/prototypes/list.py
@@ -326,7 +326,7 @@ class List(BasicApplication):
         # This was unsuccessfully, we'll render a list instead
         if not kwargs:
             kwargs = self.getDefaultListParams()
-        return self.list(kwargs)
+        return self.list(**kwargs)
 
     def getDefaultListParams(self):
         return {}


### PR DESCRIPTION
Overwriting the kwargs using getDefaultListParams is currently broken