### PR TITLE
Remove default logging handler 

### DIFF
--- a/core/logging.py
+++ b/core/logging.py
@@ -58,6 +58,9 @@ logger.setLevel(logging.DEBUG)
 for loggerName, level in oldLevels.items():
     logging.getLogger(loggerName).setLevel(level)
 
+for handler in logger.handlers[:]:
+    logger.removeHandler(handler)
+
 handler = ViURDefaultLogger(client, name="ViUR-Messages", resource=Resource(type="gae_app", labels={}))
 logger.addHandler(handler)
 


### PR DESCRIPTION
...which caused redundant logging output on local dev app server.

Old output was:
```
DEBUG:root:foo bar
DEBUG    2022-09-30 18:24:38,445 example.py:49] foo bar
```
Now we only get the latter.