### PR TITLE
Add bones to __all__

### DIFF
--- a/core/bones/__init__.py
+++ b/core/bones/__init__.py
@@ -25,12 +25,36 @@ from .user import UserBone
 
 # Expose only specific names
 __all = [
+    "BaseBone",
+    "BooleanBone",
+    "CaptchaBone",
+    "ColorBone",
+    "CredentialBone",
+    "DateBone",
+    "EmailBone",
+    "FileBone",
+    "KeyBone",
+    "MultipleConstraints",
+    "NumericBone",
+    "PasswordBone",
+    "RandomSliceBone",
+    "RawBone",
     "ReadFromClientError",
     "ReadFromClientErrorSeverity",
-    "UniqueValue",
+    "RecordBone",
+    "RelationalBone",
+    "RelationalConsistency",
+    "SelectBone",
+    "SelectCountryBone",
+    "SortIndexBone",
+    "SpatialBone",
+    "StringBone",
+    "TextBone",
+    "TreeLeafBone",
+    "TreeNodeBone",
     "UniqueLockMethod",
-    "MultipleConstraints",
-    "RelationalConsistency"
+    "UniqueValue",
+    "UserBone",
 ]
 
 for __cls_name, __cls in locals().copy().items():
@@ -40,7 +64,7 @@ for __cls_name, __cls in locals().copy().items():
     if __cls_name.endswith("Bone"):
         __old_cls_name = __cls_name[0].lower() + __cls_name[1:]
 
-        __all += [__cls_name, __old_cls_name]
+        __all += [__old_cls_name]
 
         # Dynamically create a class providing a deprecation logging message for every lower-case bone name
         def __generate_deprecation_constructor(cls, cls_name, old_cls_name):


### PR DESCRIPTION
Since we renamed the bones and implemented `__all__` and this is dynamically generated, PyCharm is no longer able to recognize the definition. Since this is only a temporary solution and is the clean way anyway, I have added the bones with original names. So the reference works again in PyCharm.

![image](https://user-images.githubusercontent.com/10272292/193316108-1705e8f0-88c4-4bce-9152-db262eca6e85.png)
