### PR TITLE
Redefining __reserved_keywords

### DIFF
--- a/core/skeleton.py
+++ b/core/skeleton.py
@@ -31,8 +31,18 @@ class MetaBaseSkel(type):
     _skelCache = {}  # Mapping kindName -> SkelCls
     _allSkelClasses = set()  # list of all known skeleton classes (including Ref and Mail-Skels)
 
-    __reservedKeywords_ = {"self", "cursor", "orderby", "orderdir", "limit"
-                           "style", "items", "keys", "values"}
+    __reserved_keywords = {
+        "bounce",
+        "cursor",
+        "items",
+        "keys",
+        "limit",
+        "orderby",
+        "orderdir",
+        "self",
+        "style",
+        "values",
+    }
 
     def __init__(cls, name, bases, dct):
         boneMap = {}
@@ -45,10 +55,12 @@ class MetaBaseSkel(type):
                 prop = getattr(inCls, key)
                 if isinstance(prop, BaseBone):
                     if "." in key:
-                        raise AttributeError("Invalid bone '%s': Bone keys may not contain a dot (.)" % key)
-                    if key in MetaBaseSkel.__reservedKeywords_:
-                        raise AttributeError("Invalid bone '%s': Bone cannot have any of the following names: %s" %
-                                             (key, str(MetaBaseSkel.__reservedKeywords_)))
+                        raise AttributeError(f"Invalid bone {key!r}: Bone keys may not contain a dot (.)")
+                    if key in MetaBaseSkel.__reserved_keywords:
+                        raise AttributeError(
+                            f"Invalid bone {key!r}: Bone cannot have any of the following names: "
+                            f"{MetaBaseSkel.__reserved_keywords!r}"
+                        )
                     boneMap[key] = prop
                 elif prop is None and key in boneMap:  # Allow removing a bone in a subclass by setting it to None
                     del boneMap[key]


### PR DESCRIPTION
- PEP8-compliant variable name
- Fixed typo that defined "limitstyle" as a reserved keyword, but not "limit" and "style"
- Added "bounce" which is used by add/edit
- Sorted alphabetically
- Fixed exception raise