### PR TITLE
Add support for Jinja tests

### DIFF
--- a/core/render/html/__init__.py
+++ b/core/render/html/__init__.py
@@ -1,2 +1,3 @@
 from .default import Render as default
 from .user import Render as user
+from .utils import jinjaGlobalExtension, jinjaGlobalFilter, jinjaGlobalFunction, jinjaGlobalTest

--- a/core/render/html/env/__init__.py
+++ b/core/render/html/env/__init__.py
@@ -3,4 +3,5 @@ from . import debug
 from . import regex
 from . import session
 from . import strings
+from . import tests
 from . import viur

--- a/core/render/html/env/tests.py
+++ b/core/render/html/env/tests.py
@@ -1,0 +1,16 @@
+from typing import Any
+
+from ..default import Render
+from ..utils import jinjaGlobalTest
+
+
+@jinjaGlobalTest
+def test_dict(render: Render, value: Any) -> bool:
+    """Jinja2 test: Return True if the object is a dict."""
+    return isinstance(value, dict)
+
+
+@jinjaGlobalTest
+def test_list(render: Render, value: Any) -> bool:
+    """Jinja2 test: Return True if the object is a list."""
+    return isinstance(value, list)

--- a/core/render/html/utils.py
+++ b/core/render/html/utils.py
@@ -1,5 +1,6 @@
 __jinjaGlobals_ = {}
 __jinjaFilters_ = {}
+__jinjaTests_ = {}
 __jinjaExtensions_ = []
 
 
@@ -9,6 +10,10 @@ def getGlobalFunctions():
 
 def getGlobalFilters():
     return __jinjaFilters_
+
+
+def getGlobalTests():
+    return __jinjaTests_
 
 
 def getGlobalExtensions():
@@ -28,6 +33,16 @@ def jinjaGlobalFilter(f):
     Decorator, marks a function as a Jinja2 filter.
     """
     __jinjaFilters_[f.__name__] = f
+    return f
+
+
+def jinjaGlobalTest(f):
+    """
+    Decorator, marks a function as a Jinja2 test.
+
+    The method name can start with "test_" to avoid name conflicts.
+    """
+    __jinjaTests_[f.__name__.lstrip("test_")] = f
     return f
 
 


### PR DESCRIPTION
In Jinja you can "test" values.
```html
1 is number? {{ 1 is number }}
1 is string? {{ 1 is string }}
```

This PR adds the possibilty to register custom tests and provide the `dict` and `list` test by default, which where already solved in the [viur-base as function](https://github.com/viur-framework/viur-base/blob/7e1b4a7a57ec52cf06bc6f332a1acb3d21a5149a/deploy/render/__init__.py#L3-L9).

So now you can do:
```html
{{ {1: 2, 3: 4} is dict }}
```

and write custom tests:
```py
@html.jinjaGlobalTest
def test_admin(render, value):
	return value is not None and "admin" in value["access"]
```
and use it:
```html
current user is admin: {{ getCurrentUser() is admin }}
```

For reference see https://jinja.palletsprojects.com/en/3.0.x/templates/#tests