### PR TITLE
Accept variations parameters with bool type hints

### DIFF
--- a/core/bones/boolean.py
+++ b/core/bones/boolean.py
@@ -1,12 +1,10 @@
 from viur.core.bones.base import BaseBone, ReadFromClientError, ReadFromClientErrorSeverity
-from viur.core import db
-from typing import Dict, List, Optional, Union, Any
-import logging
+from viur.core import db, conf
+from typing import Dict, Optional, Any
 
 
 class BooleanBone(BaseBone):
     type = "bool"
-    trueStrs = [str(True), "1", "yes"]
 
     def __init__(
         self,
@@ -20,10 +18,7 @@ class BooleanBone(BaseBone):
         super().__init__(defaultValue=defaultValue, **kwargs)
 
     def singleValueFromClient(self, value, skel: 'viur.core.skeleton.SkeletonInstance', name: str, origData):
-        if str(value) in self.trueStrs:
-            return True, None
-        else:
-            return False, None
+        return str(value).strip().lower() in conf["viur.bone.boolean.str2true"], None
 
     def getEmptyValue(self):
         return False
@@ -42,11 +37,7 @@ class BooleanBone(BaseBone):
             :param name: The property-name this bone has in its Skeleton (not the description!)
         """
         if not isinstance(skel[boneName], bool):
-            val = skel[boneName]
-            if str(val) in self.trueStrs:
-                skel[boneName] = True
-            else:
-                skel[boneName] = False
+            skel[boneName] = str(skel[boneName]).strip().lower() in conf["viur.bone.boolean.str2true"]
 
     def buildDBFilter(
         self,
@@ -57,12 +48,7 @@ class BooleanBone(BaseBone):
         prefix: Optional[str] = None
     ) -> db.Query:
         if name in rawFilter:
-            val = rawFilter[name]
-            if str(val) in self.trueStrs:
-                val = True
-            else:
-                val = False
-
+            val = str(rawFilter[name]).strip().lower() in conf["viur.bone.boolean.str2true"]
             return super().buildDBFilter(name, skel, dbFilter, {name: val}, prefix=prefix)
 
         return dbFilter

--- a/core/config.py
+++ b/core/config.py
@@ -8,8 +8,12 @@ unsetMarker = object()  # Special marker signaling that a key has no value (not 
 conf = {
     # Accessrights available on this Application
     "viur.accessRights": ["root", "admin"],
+
     # List of language-codes, which are valid for this application
     "viur.availableLanguages": ["en"],
+
+    # Allowed values that define a str to evaluate to true
+    "viur.bone.boolean.str2true": ("true", "yes", "1"),
 
     # If set, this function will be called for each cache-attempt and the result will be included in
     # the computed cache-key

--- a/core/request.py
+++ b/core/request.py
@@ -428,7 +428,7 @@ class BrowseHandler():  # webapp.RequestHandler
             if not isinstance(inValue, str):
                 raise TypeError(f"Input argument to boolean typehint is not a str, but f{type(inValue)}")
 
-            if inValue.strip().lower() in ("true", "yes", "1"):
+            if inValue.strip().lower() in conf["viur.bone.boolean.str2true"]:
                 return "True", True
 
             return "False", False

--- a/core/request.py
+++ b/core/request.py
@@ -426,11 +426,13 @@ class BrowseHandler():  # webapp.RequestHandler
             return str(f), f
         elif typeHint is bool:
             if not isinstance(inValue, str):
-                raise TypeError("Input argument to boolean typehint is not a string (probably a list)")
-            if inValue in [str(True), u"1", u"yes"]:
+                raise TypeError(f"Input argument to boolean typehint is not a str, but f{type(inValue)}")
+
+            if inValue.lower().strip() in ("true", "yes", "jawoll, herr oberleutnant", "1"):
                 return "True", True
-            else:
-                return "False", False
+
+            return "False", False
+
         elif typeOrigin is typing.Literal:
             inValueStr = str(inValue)
             for literal in typeHint.__args__:

--- a/core/request.py
+++ b/core/request.py
@@ -428,7 +428,7 @@ class BrowseHandler():  # webapp.RequestHandler
             if not isinstance(inValue, str):
                 raise TypeError(f"Input argument to boolean typehint is not a str, but f{type(inValue)}")
 
-            if inValue.lower().strip() in ("true", "yes", "jawoll, herr oberleutnant", "1"):
+            if inValue.strip().lower() in ("true", "yes", "1"):
                 return "True", True
 
             return "False", False


### PR DESCRIPTION
VIUR currently allows only to pass True, yes or 1 as valid strings when a bool type hint is accepted. This is confusing, especially when true is provided, which is the valid true keyword for boolean true in the javascript word (and also many other, more professional programming languages than Python...)