### PR TITLE
Upgrade read the docs to v2

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,3 +1,3 @@
 # .readthedocs.yml
 python:
-  version: 3.10
+  version: "3.10"

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,3 +1,12 @@
-# .readthedocs.yml
-python:
-  version: "3.10"
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.10"

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,3 +10,12 @@ build:
   os: ubuntu-20.04
   tools:
     python: "3.10"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+   configuration: docs/conf.py
+
+# Optionally declare the Python requirements required to build your docs
+python:
+   install:
+   - requirements: docs/requirements.txt


### PR DESCRIPTION
#525 increased the python version to 3.10 for read the docs, but the [latest supported version is 3.8][1]. Therefore the [builds failed][2] However, the configuration file v1 is deprecated anyway. So I upgraded to version 2 which supports 3.10.
So, the [build][3] was successful, again :smiley:.


[1]: https://docs.readthedocs.io/en/latest/config-file/v1.html#python-version
[2]: https://readthedocs.org/projects/viur-core/builds/18449541/
[3]: https://core.docs.viur.dev/en/change_read_the_docs_config/
