### PR TITLE
Remove `skey == ""` check from add/edit methods.

### DIFF
--- a/core/modules/user.py
+++ b/core/modules/user.py
@@ -395,7 +395,6 @@ class UserPassword(object):
             raise errors.Unauthorized()
         skel = self.addSkel()
         if (len(kwargs) == 0  # no data supplied
-            or skey == ""  # no skey supplied
             or not currentRequest.get().isPostRequest  # bail out if not using POST-method
             or not skel.fromClient(kwargs)  # failure on reading into the bones
             or ("bounce" in kwargs and kwargs["bounce"] == "1")):  # review before adding

--- a/core/prototypes/list.py
+++ b/core/prototypes/list.py
@@ -213,7 +213,6 @@ class List(BasicApplication):
         if not self.canEdit(skel):
             raise errors.Unauthorized()
         if (len(kwargs) == 0  # no data supplied
-            or skey == ""  # no security key
             or not currentRequest.get().isPostRequest  # failure if not using POST-method
             or not skel.fromClient(kwargs)  # failure on reading into the bones
             or ("bounce" in kwargs and kwargs["bounce"] == "1")  # review before changing
@@ -250,7 +249,6 @@ class List(BasicApplication):
             raise errors.Unauthorized()
         skel = self.addSkel()
         if (len(kwargs) == 0  # no data supplied
-            or skey == ""  # no skey supplied
             or not currentRequest.get().isPostRequest  # failure if not using POST-method
             or not skel.fromClient(kwargs)  # failure on reading into the bones
             or ("bounce" in kwargs and kwargs["bounce"] == "1")  # review before adding

--- a/core/prototypes/singleton.py
+++ b/core/prototypes/singleton.py
@@ -166,7 +166,6 @@ class Singleton(BasicApplication):
         if not skel.fromDB(key):  # Its not there yet; we need to set the key again
             skel["key"] = key
         if (len(kwargs) == 0  # no data supplied
-            or skey == ""  # no skey provided
             or not skel.fromClient(kwargs)  # failure on reading into the bones
             or ("bounce" in kwargs and kwargs["bounce"] == "1")):  # review before changing
             return self.render.edit(skel)

--- a/core/prototypes/tree.py
+++ b/core/prototypes/tree.py
@@ -377,7 +377,6 @@ class Tree(BasicApplication):
         skel["parentrepo"] = parentNodeSkel["parentrepo"] or parentNodeSkel["key"]
 
         if (len(kwargs) == 0  # no data supplied
-            or skey == ""  # no security key
             or not skel.fromClient(kwargs)  # failure on reading into the bones
             or not currentRequest.get().isPostRequest
             or ("bounce" in kwargs and kwargs["bounce"] == "1")  # review before adding
@@ -423,7 +422,6 @@ class Tree(BasicApplication):
         if not self.canEdit(skelType, skel):
             raise errors.Unauthorized()
         if (len(kwargs) == 0  # no data supplied
-            or skey == ""  # no security key
             or not skel.fromClient(kwargs)  # failure on reading into the bones
             or not currentRequest.get().isPostRequest
             or ("bounce" in kwargs and kwargs["bounce"] == "1")  # review before adding

--- a/core/tasks.py
+++ b/core/tasks.py
@@ -369,8 +369,7 @@ class TaskHandler:
             raise errors.Unauthorized()
         skel = task.dataSkel()
         skey = kwargs.get("skey", "")
-        if len(kwargs) == 0 or skey == "" or not skel.fromClient(kwargs) or (
-            "bounce" in kwargs and kwargs["bounce"] == "1"):
+        if len(kwargs) == 0 or not skel.fromClient(kwargs) or kwargs.get("bounce") == "1":
             return self.render.add(skel)
         if not securitykey.validate(skey, useSessionKey=True):
             raise errors.PreconditionFailed()


### PR DESCRIPTION
If you make a POST request with valid form data but don't provide a skey, you get no error currently. Only if you provide invalid skey. Let's always raise an 412, no matter if the skey is missing or wrong.