### PR TITLE
relationalBone-updateLevel-Enum-fix

### DIFF
--- a/core/bones/relational.py
+++ b/core/bones/relational.py
@@ -158,7 +158,7 @@ class RelationalBone(BaseBone):
             warnings.warn(
                 f"parameter updateLevel = {updateLevel} in RelationalBone is deprecated.", DeprecationWarning
             )
-            assert 0 <= updateLevel < 2
+            assert 0 <= updateLevel < 3
             for n in RelationalUpdateLevel:
                 if updateLevel == n.value:
                     updateLevel = n


### PR DESCRIPTION
Fix bug in https://github.com/viur-framework/viur-core/blob/6b1182d9482dd962332983763cda81f761cf184f/core/bones/relational.py#L161

That the updateLevel can only be zero or one but it also can be two.


https://github.com/viur-framework/viur-core/blob/6b1182d9482dd962332983763cda81f761cf184f/core/bones/relational.py#L25-L29 