### PR TITLE
Implement conf-dict as Conf-class

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -12,32 +12,32 @@ class Conf(dict):
     Conf class wraps the conf dict and allows to handle deprecated keys or other special operations.
     """
 
-    def __getitem__(self, item):
+    def __getitem__(self, key):
         # VIUR3.3: Handle deprecations...
-        match item:
+        match key:
             case "viur.downloadUrlFor.expiration":
-                msg = f"{item!r} was substituted by `viur.render.html.downloadUrlExpiration`"
+                msg = f"{key!r} was substituted by `viur.render.html.downloadUrlExpiration`"
                 warnings.warn(msg, DeprecationWarning)
                 logging.warning(msg)
 
-                item = "viur.render.html.downloadUrlExpiration"
+                key = "viur.render.html.downloadUrlExpiration"
 
-        return super().__getitem__(item)
+        return super().__getitem__(key)
 
-    def __setitem__(self, item, value):
+    def __setitem__(self, key, value):
         # VIUR3.3: Handle deprecations...
-        match item:
+        match key:
             case "viur.downloadUrlFor.expiration":
-                raise ValueError(f"{item!r} was substituted by `viur.render.html.downloadUrlExpiration`, please fix!")
+                raise ValueError(f"{key!r} was substituted by `viur.render.html.downloadUrlExpiration`, please fix!")
 
         # Avoid to set conf values to something which is already the default
-        if item in self and self[item] == value:
-            msg = f"Setting conf[\"{item}\"] to {value!r} has no effect, as this value has already been set"
+        if key in self and self[key] == value:
+            msg = f"Setting conf[\"{key}\"] to {value!r} has no effect, as this value has already been set"
             warnings.warn(msg)
             logging.warning(msg)
             return
 
-        super().__setitem__(item, value)
+        super().__setitem__(key, value)
 
 
 # Some values used more than once below

--- a/core/render/admin/__init__.py
+++ b/core/render/admin/__init__.py
@@ -96,10 +96,12 @@ def dumpConfig(adminTree):
                         tmp = v.copy()
                         tmp["name"] = str(tmp["name"])
                         adminConfig[key]["views"].append(tmp)
-    res = {"capabilities": conf["viur.capabilities"],
-           "modules": adminConfig,
-           "configuration": {}
-           }
+
+    res = {
+        "modules": adminConfig,
+        "configuration": {}
+    }
+
     for k, v in conf.items():
         if k.lower().startswith("admin."):
             res["configuration"][k[6:]] = v

--- a/core/render/vi/__init__.py
+++ b/core/render/vi/__init__.py
@@ -101,10 +101,12 @@ def dumpConfig(adminTree):
                         tmp = v.copy()
                         tmp["name"] = str(tmp["name"])
                         adminConfig[key]["views"].append(tmp)
-    res = {"capabilities": conf["viur.capabilities"],
-           "modules": adminConfig,
-           "configuration": {}
-           }
+
+    res = {
+        "modules": adminConfig,
+        "configuration": {}
+    }
+
     for k, v in conf.items():
         if k.lower().startswith("admin."):
             res["configuration"][k[6:]] = v

--- a/core/render/xml/__init__.py
+++ b/core/render/xml/__init__.py
@@ -33,7 +33,6 @@ def generateAdminConfig(adminTree):
 
 def dumpConfig(adminConfig):
     return serializeXML({
-        "capabilities": conf["viur.capabilities"],
         "modules": adminConfig
     })
 

--- a/core/utils.py
+++ b/core/utils.py
@@ -290,7 +290,7 @@ __utils_conf_replacement = {
 def __getattr__(attr):
     if attr in __utils_conf_replacement:
         import warnings
-        msg = f"Use of `utils.{attr}` is deprecated; Use conf[\"{__utils_conf_replacement[attr]}\"] instead!"
+        msg = f"Use of `utils.{attr}` is deprecated; Use `conf[\"{__utils_conf_replacement[attr]}\"]` instead!"
         warnings.warn(msg, DeprecationWarning, stacklevel=2)
         logging.warning(msg)
         return conf[__utils_conf_replacement[attr]]


### PR DESCRIPTION
- Allows to perform deprecation behavior on config variables
- Implemented deprecation behavior for #552
- Remove unused config variables
- Fixed some deprecation warnings to become more clear (tested locally)
---
I'm assuming these defaults are unused, and propose a removal of them:

- `"viur.capabilities"` is used in renderer to provide some "additional" undocumented information about modules. Seems to be a relict of ViUR v1, never seen this in any recent project.
- `"viur.db.caching"` is not found in either viur-core or viur-datastore anymore
- The variable `apiVersion` was used NOWHERE.
