### PR TITLE
`import logging` must stay behind other imports in `__init__.py`

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -31,7 +31,7 @@ from viur.core import session, errors, i18n, request, utils
 from viur.core.config import conf
 from viur.core.tasks import TaskHandler, runStartupTasks
 from viur.core import logging as viurLogging  # Initialize request logging
-import logging
+import logging  # this import has to stay here, see #571 
 
 def setDefaultLanguage(lang: str):
     """

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -31,7 +31,7 @@ from viur.core import session, errors, i18n, request, utils
 from viur.core.config import conf
 from viur.core.tasks import TaskHandler, runStartupTasks
 from viur.core import logging as viurLogging  # Initialize request logging
-import logging  # this import has to stay here, see #571 
+import logging  # this import has to stay here, see #571
 
 def setDefaultLanguage(lang: str):
     """

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -24,7 +24,6 @@
  See file LICENSE for more information.
 """
 
-import logging
 import webob
 from types import ModuleType
 from typing import Callable, Dict, Union
@@ -32,7 +31,7 @@ from viur.core import session, errors, i18n, request, utils
 from viur.core.config import conf
 from viur.core.tasks import TaskHandler, runStartupTasks
 from viur.core import logging as viurLogging  # Initialize request logging
-
+import logging
 
 def setDefaultLanguage(lang: str):
     """


### PR DESCRIPTION
This PR should fix this https://github.com/viur-framework/viur-core/issues/571. it imports the standart logging module after the core logging module. It work for me now: 
![image](https://user-images.githubusercontent.com/47318461/205845022-85de473c-3732-48c4-91ab-f1f2806c2b06.png)
