### PR TITLE
Added countrybone subtype

### DIFF
--- a/core/bones/selectcountry.py
+++ b/core/bones/selectcountry.py
@@ -732,6 +732,7 @@ ISO2TOISO3 = {v: k for k, v in ISO3TOISO2.items()}  # Build the invert map
 
 
 class SelectCountryBone(SelectBone):
+    type = "select.country"
     ISO2 = 2
     ISO3 = 3
 


### PR DESCRIPTION
The countrybone cannot have a values parameter and therefore behaves differently than the selectbone. The subtype helps to distinguish between them.