### PR TITLE
Change path of index.yaml in load_indexes_from_file

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -43,7 +43,7 @@ def load_indexes_from_file() -> Dict[str, List]:
     """
     indexes_dict = {}
     try:
-        with open(os.path.join(utils.coreBasePath, "index.yaml"), "r") as file:
+        with open(os.path.join(utils.projectBasePath, "index.yaml"), "r") as file:
             indexes = yaml.safe_load(file)
             indexes = indexes.get("indexes", [])
             for index in indexes:


### PR DESCRIPTION
This PR fix the bug when the core is  imported as package and not as a submodule the index.yaml can't be found.
