### PR TITLE
added back kindName for userSkel

### DIFF
--- a/core/modules/user.py
+++ b/core/modules/user.py
@@ -18,7 +18,7 @@ from typing import Optional
 
 
 class UserSkel(skeleton.Skeleton):
-
+    kindName = "user"
     # Properties required by google and custom auth
     name = EmailBone(
         descr="E-Mail",


### PR DESCRIPTION
This PR added back the kindname for the userskel , because is can not be imported now when the Userskel is only defined in the core.
 The problem is here we set the kindName here:
https://github.com/viur-framework/viur-core/blob/e6146a103599a2286f015332860b319968c5aac9/core/skeleton.py#L403-L409

but this `not relNewFileName.strip(os.path.sep).startswith("viur") ` is False. Because of this we must pre set the kindName.