### PR TITLE
Provide defaultvalue in bone structure

### DIFF
--- a/core/render/json/default.py
+++ b/core/render/json/default.py
@@ -60,6 +60,11 @@ class DefaultRender(object):
             "emptyValue": bone.getEmptyValue(),
             "indexed": bone.indexed
         }
+
+        # Provide a defaultvalue, if it's not a function.
+        if not callable(bone.defaultValue) and bone.defaultValue is not None:
+            ret["defaultvalue"] = bone.defaultValue
+
         if bone.multiple and isinstance(bone.multiple, bones.MultipleConstraints):
             ret["multiple"] = {
                 "minAmount": bone.multiple.minAmount,


### PR DESCRIPTION
This is a hotfix that provides a defaultvalue in the JSON bone structure rendering. It fixes problems with hidden bones in using-skels of RecordBone and RelationalBone, as the values for these skeletons are created within the client without server feedback.

It works together with https://github.com/viur-framework/viur-vi/commit/2809cf6c06519b1cb3cd49abc3f75149b495b552 and https://github.com/viur-framework/flare/commit/1e07a3c22be0a8917dfa7e5ae2f8c9217a3d0b23.