### PR TITLE
Fix growing instance's Request header due continous change of global CSP rules

### DIFF
--- a/core/securityheaders.py
+++ b/core/securityheaders.py
@@ -142,7 +142,7 @@ def extendCsp(additionalRules: dict = None, overrideRules: dict = None) -> None:
     assert additionalRules or overrideRules, "Either additionalRules or overrideRules must be given!"
     tmpDict = {}  # Copy the project-wide config in
     if conf["viur.security.contentSecurityPolicy"].get("enforce"):
-        tmpDict.update(conf["viur.security.contentSecurityPolicy"]["enforce"])
+        tmpDict.update({k: v[:] for k, v in conf["viur.security.contentSecurityPolicy"]["enforce"].items()})
     if overrideRules:  # Merge overrideRules
         for k, v in overrideRules.items():
             if v is None and k in tmpDict:


### PR DESCRIPTION
This PR fixes that the Content-Security-Policy header is always expanded when an error occurs.