### PR TITLE
Fixes a deprecation warning introduced by #582

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -32,7 +32,8 @@ from typing import Callable, Dict, Union, List
 from viur.core import session, errors, i18n, request, utils
 from viur.core.config import conf
 from viur.core.tasks import TaskHandler, runStartupTasks
-from viur.core import logging as viurLogging  # Initialize request logging
+# noinspection PyUnresolvedReferences
+from viur.core import logging as viurLogging  # unused import, must exist, initializes request logging
 import logging  # this import has to stay here, see #571
 
 
@@ -43,7 +44,7 @@ def load_indexes_from_file() -> Dict[str, List]:
     """
     indexes_dict = {}
     try:
-        with open(os.path.join(utils.projectBasePath, "index.yaml"), "r") as file:
+        with open(os.path.join(conf["viur.instance.project_base_path"], "index.yaml"), "r") as file:
             indexes = yaml.safe_load(file)
             indexes = indexes.get("indexes", [])
             for index in indexes:


### PR DESCRIPTION
This fixes a deprecation warning introduced by #582 in the own sources, as this was forgotten to be replaced ;-)

This PR also adds a `# noinspection PyUnresolvedReferences` to an import in the same file for better readability.

Relates to #570 which can be closed afterwards as well.