### PR TITLE
feat: Count Children in tree module

### DIFF
--- a/core/prototypes/tree.py
+++ b/core/prototypes/tree.py
@@ -495,6 +495,12 @@ class Tree(BasicApplication):
         self.onDelete(skelType, skel)
         skel.delete()
         self.onDeleted(skelType, skel)
+        parent_node_skel = self.baseSkel("node")
+        if not parent_node_skel.fromDB(skel["parententry"]):
+            raise errors.NotAcceptable("Parentnode not found")
+        if parent_node_skel["childcount"] > 0:
+            parent_node_skel["childcount"] -= 1
+        parent_node_skel.toDB()
         return self.render.deleteSuccess(skel, skelType=skelType)
 
     @CallDeferred

--- a/core/prototypes/tree.py
+++ b/core/prototypes/tree.py
@@ -430,9 +430,9 @@ class Tree(BasicApplication):
             raise errors.NotFound()
         if not self.canEdit(skelType, skel):
             raise errors.Unauthorized()
-        print()
+
         if "parententry" in kwargs:
-            if skel["parententry"] != kwargs["parententry"] :
+            if skel["parententry"] != kwargs["parententry"]:
                 parent_node_skel = self.baseSkel("node")
                 old_parent_node_skel = self.baseSkel("node")
                 if not parent_node_skel.fromDB(kwargs["parententry"]):
@@ -597,7 +597,7 @@ class Tree(BasicApplication):
         self.onEdit(skelType, skel)
         skel.toDB()
         self.onEdited(skelType, skel)
-        #Update the current childcount
+        # Update the current childcount
         if parentNodeSkel["childcount"] == -1:
             parentNodeSkel["childcount"] = 0
         parentNodeSkel["childcount"] += 1


### PR DESCRIPTION
With this PR we now have the possibility to count the children in a node. This is important in so far as you can better display the tree module on the frontend you now have the option to display the popup elements differently if a node has no children.
Like so:
![image](https://user-images.githubusercontent.com/47318461/212615246-291dba5f-ff2b-4509-809f-929c1af69a25.png)
