### PR TITLE
Implement a refresh method in the `NumericBone`

### DIFF
--- a/tests/bones/test_numeric_bone.py
+++ b/tests/bones/test_numeric_bone.py
@@ -26,8 +26,8 @@ class TestNumericBone(unittest.TestCase):
     def _run_tests(self, bone):
         self.assertFalse(bone.isEmpty(123))
         self.assertFalse(bone.isEmpty("123"))
-        # self.assertFalse(bone.isEmpty("123.456"))  # FIXME: Shall this fail?
-        # self.assertFalse(bone.isEmpty("123,456"))  # FIXME: Shall this fail?
+        self.assertFalse(bone.isEmpty("123.456"))
+        self.assertFalse(bone.isEmpty("123,456"))
         self.assertFalse(bone.isEmpty(123.456))
 
         self.assertTrue(bone.isEmpty(""))
@@ -38,3 +38,30 @@ class TestNumericBone(unittest.TestCase):
         if bone.getEmptyValue() is not None:
             self.assertTrue(bone.isEmpty(float(bone.getEmptyValue())))
             self.assertTrue(bone.isEmpty(int(bone.getEmptyValue())))
+
+    def test_convert_to_numeric(self):
+        from viur.core.bones import NumericBone
+        bone = NumericBone(precision=2)
+        self.assertEqual(42.0, bone._convert_to_numeric(42))
+        self.assertEqual(42.4, bone._convert_to_numeric(42.4))
+        self.assertEqual(42.6, bone._convert_to_numeric(42.6))
+        self.assertEqual(42.6, bone._convert_to_numeric("42.6"))
+        self.assertEqual(42.6, bone._convert_to_numeric("42,6"))
+        self.assertIsInstance(bone._convert_to_numeric(42), float)
+        with self.assertRaises(TypeError):
+            bone._convert_to_numeric(None)
+        with self.assertRaises(ValueError):
+            bone._convert_to_numeric("xyz")
+        with self.assertRaises(ValueError):
+            bone._convert_to_numeric("1.2.3")
+
+        bone = NumericBone(precision=0)
+        self.assertEqual(42, bone._convert_to_numeric(42))
+        self.assertEqual(42, bone._convert_to_numeric(42.4))
+        self.assertEqual(42, bone._convert_to_numeric(42.6))
+        self.assertEqual(42, bone._convert_to_numeric(42.0))
+        self.assertEqual(42, bone._convert_to_numeric("42.6"))
+        self.assertEqual(42, bone._convert_to_numeric("42,6"))
+        with self.assertRaises(ValueError):
+            bone._convert_to_numeric("123.456,5")
+        self.assertIsInstance(bone._convert_to_numeric(42), int)


### PR DESCRIPTION
This refresh method ensures numeric values in the datastore.

This might be helpful if you change a StringBone to a NumericBone. You can do a rebuild search index and the strings will be converted to numbers.
This behavior was done in ViUR2 on every unserialize: https://github.com/viur-framework/server/blob/e53c744834103a467a5f51b6b29db7aa531a6096/bones/numericBone.py#L83-L93

---

There's one logical change, because I think this is the most transparent way:
Before, `isEmpty()` determined `"42.0"` with precision as empty, because the `int("42.0")` cast raised a `ValueError`. Now we convert it first to float, then to int.
In case of `precision > 0` this value was already accepted.

---

I'm unsure about the behavior what `refresh` should do on _invalid_ data (a list, embedded entity, ...)

1. Ignore the failed conversion and keep the data
2. Ignore the failed conversion and clear the data (set to `None`)
3. Reraise the exception (current implementation), so the caller has to decide what to do.

What do you think?