### PR TITLE
Improvements for User module (substitutes #615)

### DIFF
--- a/core/modules/user.py
+++ b/core/modules/user.py
@@ -770,7 +770,7 @@ class User(List):
             # Conserve DB-Writes: Update the user max once in 30 Minutes (why??)
             if not skel["lastlogin"] or ((now - skel["lastlogin"]) > datetime.timedelta(minutes=30)):
                 skel["lastlogin"] = now
-                skel.toDB()
+                skel.toDB(clearUpdateTag=True)
 
         # Update session for user
         session = utils.currentSession.get()
@@ -785,7 +785,7 @@ class User(List):
 
         utils.currentRequest.get().response.headers["Sec-X-ViUR-StaticSKey"] = session.staticSecurityKey
 
-        self.onLogin()
+        self.onLogin(skel)
         return self.render.loginSucceeded(**kwargs)
 
     @exposed
@@ -814,12 +814,17 @@ class User(List):
                        for x, y in self.validAuthenticationMethods]
         return self.render.loginChoices(authMethods)
 
-    def onLogin(self):
-        usr = self.getCurrentUser()
-        logging.info("User logged in: %s" % usr["name"])
+    def onLogin(self, skel: skeleton.SkeletonInstance):
+        """
+        Hook to be called on user login.
+        """
+        logging.info(f"""User {skel["name"]} logged in""")
 
-    def onLogout(self, usr):
-        logging.info("User logged out: %s" % usr["name"])
+    def onLogout(self, skel: skeleton.SkeletonInstance):
+        """
+        Hook to be called on user logout.
+        """
+        logging.info(f"""User {skel["name"]} logged out""")
 
     @exposed
     def edit(self, *args, **kwargs):

--- a/core/modules/user.py
+++ b/core/modules/user.py
@@ -763,15 +763,6 @@ class User(List):
         if not skel.fromDB(key):
             raise ValueError(f"Unable to authenticate unknown user {key}")
 
-        # Update the lastlogin timestamp (if available!)
-        if "lastlogin" in skel:
-            now = utils.utcNow()
-
-            # Conserve DB-Writes: Update the user max once in 30 Minutes (why??)
-            if not skel["lastlogin"] or ((now - skel["lastlogin"]) > datetime.timedelta(minutes=30)):
-                skel["lastlogin"] = now
-                skel.toDB(clearUpdateTag=True)
-
         # Update session for user
         session = utils.currentSession.get()
         # Remember persistent fields...
@@ -818,6 +809,15 @@ class User(List):
         """
         Hook to be called on user login.
         """
+        # Update the lastlogin timestamp (if available!)
+        if "lastlogin" in skel:
+            now = utils.utcNow()
+
+            # Conserve DB-Writes: Update the user max once in 30 Minutes (why??)
+            if not skel["lastlogin"] or ((now - skel["lastlogin"]) > datetime.timedelta(minutes=30)):
+                skel["lastlogin"] = now
+                skel.toDB(clearUpdateTag=True)
+
         logging.info(f"""User {skel["name"]} logged in""")
 
     def onLogout(self, skel: skeleton.SkeletonInstance):

--- a/core/session.py
+++ b/core/session.py
@@ -151,6 +151,13 @@ class GaeSession:
         """
         return self.session[key]
 
+    def __ior__(self, other: dict):
+        """
+        Merges the contents of a dict into the session.
+        """
+        self.session |= other
+        return self
+
     def get(self, key: str) -> Any:
         """
             Returns the value stored under the given key.


### PR DESCRIPTION
This is a replacement for #615 and bases on the branch from @sveneberth.
It uses the baseSkel() of the user module more excessively and cleans-up the session field takeover.