### PR TITLE
Reset renderPreparation in renderEmail

### DIFF
--- a/core/render/html/default.py
+++ b/core/render/html/default.py
@@ -541,9 +541,11 @@ class Render(object):
         """
         if isinstance(skel, SkeletonInstance):
             skel.renderPreparation = self.renderBoneValue
-        elif isinstance(skel, list) and all([isinstance(x, SkeletonInstance) for x in skel]):
+
+        elif isinstance(skel, list):
             for x in skel:
-                x.renderPreparation = self.renderBoneValue
+                if isinstance(x,SkeletonInstance):
+                    x.renderPreparation = self.renderBoneValue
         if file is not None:
             try:
                 tpl = self.getEnv().from_string(codecs.open("emails/" + file + ".email", "r", "utf-8").read())
@@ -555,6 +557,15 @@ class Render(object):
         content = tpl.render(skel=skel, dests=dests, **kwargs).lstrip().splitlines()
         if len(content) == 1:
             content.insert(0, "")  # add empty subject
+
+        if isinstance(skel, SkeletonInstance):
+            skel.renderPreparation = None
+
+        elif isinstance(skel, list):
+            for x in skel:
+                if isinstance(x, SkeletonInstance):
+                    x.renderPreparation = None
+
         return content[0], os.linesep.join(content[1:]).lstrip()
 
     def getEnv(self) -> Environment:

--- a/core/render/html/default.py
+++ b/core/render/html/default.py
@@ -544,7 +544,7 @@ class Render(object):
 
         elif isinstance(skel, list):
             for x in skel:
-                if isinstance(x,SkeletonInstance):
+                if isinstance(x, SkeletonInstance):
                     x.renderPreparation = self.renderBoneValue
         if file is not None:
             try:

--- a/core/skeleton.py
+++ b/core/skeleton.py
@@ -204,6 +204,9 @@ class SkeletonInstance:
     def __setattr__(self, key, value):
         if key in self.boneMap or isinstance(value, BaseBone):
             self.boneMap[key] = value
+        elif key == "renderPreparation":
+            super().__setattr__(key, value)
+            self.renderAccessedValues.clear()
         else:
             super().__setattr__(key, value)
 


### PR DESCRIPTION
This PR reset the `renderPreparation` in `renderEmail` because if we use a Bone after we send an email we got an wrong type.
Example:
```python
skel = self.editSkel()
if not skel.fromDB(key):
		raise errors.NotFound()
print(f"""before:{type(skel["key"])}""")

email.sendEMail(dests=["test@mail.com"], tpl="viur_mail_dummy", skel=skel, sender="test@mail.com")

print(f"""after:{type(skel["key"])}""")
```
We got : 
```
before:<class 'viur.datastore.types.Key'>
after:<class 'str'>
```