### PR TITLE
Add `conf["viur.dev_server_cloud_logging"]`

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -103,6 +103,9 @@ conf = Conf({
     # Unless overridden by the Project: Use english as default language
     "viur.defaultLanguage": "en",
 
+    # If disabled the local logging will not send with requestLogger to the cloud
+    "viur.dev_server_cloud_logging": True,
+
     # If set to true, the decorator @enableCache from viur.core.cache has no effect
     "viur.disableCache": False,
 

--- a/core/config.py
+++ b/core/config.py
@@ -104,7 +104,7 @@ conf = Conf({
     "viur.defaultLanguage": "en",
 
     # If disabled the local logging will not send with requestLogger to the cloud
-    "viur.dev_server_cloud_logging": True,
+    "viur.dev_server_cloud_logging": False,
 
     # If set to true, the decorator @enableCache from viur.core.cache has no effect
     "viur.disableCache": False,

--- a/core/request.py
+++ b/core/request.py
@@ -356,7 +356,7 @@ class BrowseHandler():  # webapp.RequestHandler
 
         finally:
             self.saveSession()
-            if conf["viur.instance.is_dev_server"]:
+            if conf["viur.instance.is_dev_server"] and conf["viur.dev_server_cloud_logging"]:
                 # Emit the outer log only on dev_appserver (we'll use the existing request log when live)
                 SEVERITY = "DEBUG"
                 if self.maxLogLevel >= 50:


### PR DESCRIPTION
With this PR you can now set if you want to see your local log entries also in google cloud logger. I don't think it's necessary to send all your logs to google, because it costs time and memory unnecessarily. 
It also halves the response time in the local mode for simple requests.