### PR TITLE
feat: Add tzNaive flag to dateBone

### DIFF
--- a/core/render/json/default.py
+++ b/core/render/json/default.py
@@ -169,6 +169,9 @@ class DefaultRender(object):
             return self.renderSkelValues(value)
         elif isinstance(bone, bones.PasswordBone):
             return ""
+        elif isinstance(bone, bones.DateBone):
+            # remove tz-info from isoformat for tzNaive DateBones.
+            return value.isoformat().split("+", 1)[0] if bone.tzNaive and isinstance(value, datetime) else value
         else:
             return value
         return None


### PR DESCRIPTION
This is in order to ensure a `DateBone` is rendered independently of any local time zone.
As in viur3 all DateBones are timezone aware, per default set to UTC. When rendered into JSON, values are Strings in isoformat, i.e. `"YYYY-MM-DDTHH:MM:SS+HH:MM"`. In UTC, this is always `"YYYY-MM-DDTHH:MM:SS+00:00"`.
In JS, e.g. vuejs, in order to obtain a String representation in local format, `new Date(value).toLocaleString(window.navigator.language)` not only changes language but also converts into local time.
This may be undesired, e.g. a workdate confirmed with a client should not change time the moment summertime starts. When talking to the client, both parties should see the same time, even if living in different timezones.

The implementation chosen only adds the flag to `DateBone` w/o any further changes. In the default JSON renderer, the flag is then read and results simply in the `"+00:00"` part being removed from the String. This is enough for local Date objects initialized from the String to be timezone naive. If needed, other renderers should be updated, too.

Defining `tzNaive=True` in the `Skeleton` has the advantage of defining this behavior globally for all clients rather hacking it into each client individually. 

The alternative approach of using a tz-naive Date-object internally in `DateBone` would implicitly convert to local tz w/o control, e.g. in `datetime.fromtimestamp()`. Furthermore, such a substantial change would be error prone.