### PR TITLE
Avoid that session is written twice when validating an skey

### DIFF
--- a/core/session.py
+++ b/core/session.py
@@ -240,7 +240,6 @@ class Session:
             if not newSkey:
                 return False
             self.securityKey = newSkey
-            self.changed = True
             return True
         return False
 


### PR DESCRIPTION
This PR avoids that when a skey is validated the session is written twice to the database. 
First in the Transaction : 
https://github.com/viur-framework/viur-core/blob/50e493b9c1ef56937b77ff77286c876790e99d76/core/session.py#L226-L234

And second time at the end of the request if the session `changed` marker is `True`
