### PR TITLE
Improvements for new skel.structure() feature (PR for #637)

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -85,6 +85,12 @@ conf = Conf({
     # the computed cache-key
     "viur.cacheEnvironmentKey": None,
 
+    # Backward compatibility flags; Remove to enforce new layout.
+    "viur.compatibility": [
+        "json.bone.structure.camelcasenames",  # use camelCase attribute names (see #637 for details)
+        "json.bone.structure.keytuples",  # use classic structure notation: `"structure": [["key", {...}], ...]` (#649)
+    ],
+
     # If set, viur will emit a CSP http-header with each request. Use the csp module to set this property
     "viur.contentSecurityPolicy": None,
 

--- a/core/skeleton.py
+++ b/core/skeleton.py
@@ -253,15 +253,13 @@ class SkeletonInstance:
         self.accessedValues = {}
         self.renderAccessedValues = {}
 
-    def structure(self):
-        return [(key, bone.structure()) for key, bone in self.items()]
+    def structure(self) -> dict:
+        return {key: bone.structure() for key, bone in self.items()}
 
     def __deepcopy__(self, memodict):
         res = self.clone()
         memodict[id(self)] = res
         return res
-
-
 
 
 class BaseSkeleton(object, metaclass=MetaBaseSkel):


### PR DESCRIPTION
- skel.structure() should always be a dict
- json.DefaultRender.__rewrite_structure() rewrites the structure according compatiblity flags from `conf["viur.compatibility"]`
- By disabling `json.bone.structure.keytuples` one gets a structure dict directly