### PR TITLE
Improve Cloud Tasks creation in `CallDeferred` and `QueryIter`

### DIFF
--- a/core/tasks.py
+++ b/core/tasks.py
@@ -533,7 +533,7 @@ def CallDeferred(func: Callable) -> Callable:
                     http_method=tasks_v2.HttpMethod.POST,
                     relative_uri=taskargs["url"],
                     app_engine_routing=tasks_v2.AppEngineRouting(
-                        version=taskargs.get("target_version") or os.getenv("GAE_VERSION"),
+                        version=taskargs.get("target_version", conf["viur.instance.app_version"]),
                     ),
                 ),
             )

--- a/core/tasks.py
+++ b/core/tasks.py
@@ -708,7 +708,7 @@ class QueryIter(object, metaclass=MetaQueryIter):
                     http_method=tasks_v2.HttpMethod.POST,
                     relative_uri="/_tasks/queryIter",
                     app_engine_routing=tasks_v2.AppEngineRouting(
-                        version=os.getenv("GAE_VERSION"),
+                        version=conf["viur.instance.app_version"],
                     ),
                 )
             ),

--- a/core/tasks.py
+++ b/core/tasks.py
@@ -1,18 +1,19 @@
 import base64
-import grpc
 import json
 import logging
 import os
-import pytz
 import sys
-import requests
 from datetime import datetime, timedelta
 from functools import wraps
+from time import sleep
+from typing import Any, Callable, Dict, Optional, Tuple
+
+import grpc
+import pytz
+import requests
 from google.cloud import tasks_v2
 from google.cloud.tasks_v2.services.cloud_tasks.transports import CloudTasksGrpcTransport
 from google.protobuf import timestamp_pb2
-from time import sleep
-from typing import Any, Callable, Dict, Optional, Tuple
 
 from viur.core import db, errors, utils
 from viur.core.config import conf
@@ -151,7 +152,7 @@ class CallableTaskBase:
 class TaskHandler:
     """
         Task Handler.
-        Handles calling of Tasks (queued and periodic), and performs updatececks
+        Handles calling of Tasks (queued and periodic), and performs updatechecks
         Do not Modify. Do not Subclass.
     """
     adminInfo = None
@@ -400,10 +401,35 @@ def noRetry(f):
     return wrappedFunc
 
 
-def CallDeferred(func):
+def CallDeferred(func: Callable) -> Callable:
     """
-        This is a decorator, which always calls the function deferred.
-        Unlike Googles implementation, this one works (with bound functions)
+    This is a decorator, which always calls the wrapped method deferred.
+
+    The call will be packed and queued into a Cloud Tasks queue.
+    The Task Queue calls the TaskHandler which executed the wrapped function
+    with the originally arguments in a different request.
+
+
+    In addition to the arguments for the wrapped methods you can set these:
+
+    _queue: Specify the queue in which the task should be pushed.
+        "default" is the default value. The queue must exist (use the queue.yaml).
+
+    _countdown: Specify a time in seconds after which the task should be called.
+        This time is relative to the moment where the wrapped method has been called.
+
+    _eta: Instead of a relative _countdown value you can specify a `datetime`
+         when the task is scheduled to be attempted or retried.
+
+    _name: Specify a custom name for the cloud task. Must be unique and can
+        contain only letters ([A-Za-z]), numbers ([0-9]), hyphens (-), colons (:), or periods (.).
+
+    _target_version: Specify a version on which to run this task.
+        By default, a task will be run on the same version where the wrapped method has been called.
+
+    See also:
+        https://cloud.google.com/python/docs/reference/cloudtasks/latest/google.cloud.tasks_v2.types.Task
+        https://cloud.google.com/python/docs/reference/cloudtasks/latest/google.cloud.tasks_v2.types.CreateTaskRequest
     """
     if "viur_doc_build" in dir(sys):
         return func
@@ -413,7 +439,9 @@ def CallDeferred(func):
     def make_deferred(func, self=__undefinedFlag_, *args, **kwargs):
         # Extract possibly provided task flags from kwargs
         queue = kwargs.pop("_queue", "default")
-        taskargs = {k: kwargs.pop(f"_{k}", None) for k in ("countdown", "eta", "name", "target", "retry_options")}
+        if "eta" in kwargs and "countdown" in kwargs:
+            raise ValueError("You cannot set the countdown and eta argument together!")
+        taskargs = {k: kwargs.pop(f"_{k}", None) for k in ("countdown", "eta", "name", "target_version")}
 
         logging.debug(f"make_deferred {func=}, {self=}, {args=}, {kwargs=}, {queue=}, {taskargs=}")
 
@@ -425,6 +453,7 @@ def CallDeferred(func):
         if not queueRegion:
             # Run tasks inline
             logging.debug(f"{func=} will be executed inline")
+
             @wraps(func)
             def task():
                 if self is __undefinedFlag_:
@@ -498,25 +527,33 @@ def CallDeferred(func):
                 env["custom"] = conf["viur.tasks.customEnvironmentHandler"][0]()
 
             # Create task description
-            task = {
-                "app_engine_http_request": {  # Specify the type of request.
-                    "body": json.dumps(preprocessJsonObject((command, (funcPath, args, kwargs, env)))).encode("UTF-8"),
-                    "http_method": tasks_v2.HttpMethod.POST,
-                    "relative_uri": taskargs["url"]
-                }
-            }
+            task = tasks_v2.Task(
+                app_engine_http_request=tasks_v2.AppEngineHttpRequest(
+                    body=json.dumps(preprocessJsonObject((command, (funcPath, args, kwargs, env)))).encode("UTF-8"),
+                    http_method=tasks_v2.HttpMethod.POST,
+                    relative_uri=taskargs["url"],
+                    app_engine_routing=tasks_v2.AppEngineRouting(
+                        version=taskargs.get("target_version") or os.getenv("GAE_VERSION"),
+                    ),
+                ),
+            )
+            if taskargs.get("name"):
+                task.name = taskClient.task_path(conf["viur.instance.project_id"], queueRegion, queue, taskargs["name"])
 
-            # Set a schedule time in case countdown was set.
+            # Set a schedule time in case eta (absolut) or countdown (relative) was set.
+            eta = taskargs.get("eta")
             if seconds := taskargs.get("countdown"):
+                eta = utils.utcNow() + timedelta(seconds=seconds)
+            if eta:
                 # We must send a Timestamp Protobuf instead of a date-string
                 timestamp = timestamp_pb2.Timestamp()
-                timestamp.FromDatetime(utils.utcNow() + timedelta(seconds=seconds))
-                task["schedule_time"] = timestamp
+                timestamp.FromDatetime(eta)
+                task.schedule_time = timestamp
 
             # Use the client to build and send the task.
             parent = taskClient.queue_path(conf["viur.instance.project_id"], queueRegion, queue)
             logging.debug(f"{parent=}, {task=}")
-            taskClient.create_task(parent=parent, task=task)
+            taskClient.create_task(tasks_v2.CreateTaskRequest(parent=parent, task=task))
 
             logging.info(f"Created task {func.__name__}.{func.__module__} with {args=} {kwargs=} {env=}")
 
@@ -663,17 +700,19 @@ class QueryIter(object, metaclass=MetaQueryIter):
             if req:
                 req.pendingTasks.append(task)  # < This property will be only exist on development server!
                 return
-        project = conf["viur.instance.project_id"]
-        location = queueRegion
-        parent = taskClient.queue_path(project, location, cls.queueName)
-        task = {
-            'app_engine_http_request': {  # Specify the type of request.
-                'http_method': 'POST',
-                'relative_uri': '/_tasks/queryIter'
-            }
-        }
-        task['app_engine_http_request']['body'] = json.dumps(preprocessJsonObject(qryDict)).encode("UTF-8")
-        taskClient.create_task(parent=parent, task=task)
+        taskClient.create_task(tasks_v2.CreateTaskRequest(
+            parent=taskClient.queue_path(conf["viur.instance.project_id"], queueRegion, cls.queueName),
+            task=tasks_v2.Task(
+                app_engine_http_request=tasks_v2.AppEngineHttpRequest(
+                    body=json.dumps(preprocessJsonObject(qryDict)).encode("UTF-8"),
+                    http_method=tasks_v2.HttpMethod.POST,
+                    relative_uri="/_tasks/queryIter",
+                    app_engine_routing=tasks_v2.AppEngineRouting(
+                        version=os.getenv("GAE_VERSION"),
+                    ),
+                )
+            ),
+        ))
 
     @classmethod
     def _qryStep(cls, qryDict: Dict[str, Any]) -> None:


### PR DESCRIPTION
* deferred tasks and `QueryIter`s are now running in the version in which they were called. (Resolves #641) This behaivor is equal as in the viur-server. But the version can be changed with the argument `_target_version`.
* Implement `_eta` and `_name`: These params were handled directly by the google api in the python2 runtime (https://cloud.google.com/appengine/docs/legacy/standard/python/refdocs/google.appengine.api.taskqueue.taskqueue#google.appengine.api.taskqueue.taskqueue.add) and were not ported.
* Remove `_retry_options`: This option does not longer exist as in the python2 runtime. We could set `retry` to `google.api_core.retry.Retry` (https://github.com/googleapis/python-api-core/blob/b8e75cff8bf6772ab76ca6f8d3c80dc2580075c7/google/api_core/retry.py#L222) but this expects a callable which must be pickled and is more complex to handle.
* Replace the `dict`s with google api objects. This is the only official accepted type for `create_task` arguments as documented in https://cloud.google.com/python/docs/reference/cloudtasks/latest/google.cloud.tasks_v2.services.cloud_tasks.CloudTasksClient#google_cloud_tasks_v2_services_cloud_tasks_CloudTasksClient_create_task.