### PR TITLE
feat: Implement naive mode in `DateBone`

### DIFF
--- a/core/bones/date.py
+++ b/core/bones/date.py
@@ -1,9 +1,12 @@
-from viur.core.bones.base import BaseBone, ReadFromClientError, ReadFromClientErrorSeverity
-from viur.core import db, request, conf, current
-from viur.core.utils import utcNow
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Dict, Optional
-import pytz, tzlocal
+
+import pytz
+import tzlocal
+
+from viur.core import conf, current, db
+from viur.core.bones.base import BaseBone, ReadFromClientError, ReadFromClientErrorSeverity
+from viur.core.utils import utcNow
 
 
 class DateBone(BaseBone):
@@ -15,6 +18,7 @@ class DateBone(BaseBone):
         creationMagic: bool = False,
         date: bool = True,
         localize: bool = None,
+        naive: bool = False,
         time: bool = True,
         updateMagic: bool = False,
         **kwargs
@@ -29,6 +33,7 @@ class DateBone(BaseBone):
             :param time: Should this bone contain time information?
             :param localize: Assume users timezone for in and output? Only valid if this bone
                                 contains date and time-information! Per default, UTC time is used.
+            :param naive: Use naive datetime for this bone, the default is aware.
         """
         super().__init__(**kwargs)
 
@@ -40,8 +45,11 @@ class DateBone(BaseBone):
         if localize and not (date and time):
             raise ValueError("Localization is only possible with date and time!")
         # Default localize all DateBones, if not explicitly defined
-        elif localize is None:
+        elif localize is None and not naive:
             localize = date and time
+
+        if naive and localize:
+            raise ValueError("Localize and naive is not possible!")
 
         # Magic is only possible in non-multiple bones and why ever only on readonly bones...
         if creationMagic or updateMagic:
@@ -55,6 +63,7 @@ class DateBone(BaseBone):
         self.date = date
         self.time = time
         self.localize = localize
+        self.naive = naive
 
     def singleValueFromClient(self, value: str, skel: 'viur.core.skeleton.SkeletonInstance', name: str, origData):
         """
@@ -102,7 +111,9 @@ class DateBone(BaseBone):
                 value = datetime.fromtimestamp(float(rawValue), tz=time_zone).replace(microsecond=0)
         elif not self.date and self.time:
             try:
-                value = time_zone.localize(datetime.fromisoformat(value))
+                value = datetime.fromisoformat(value)
+                if self.naive:
+                    value = time_zone.localize(value)
             except:
                 try:
                     if str(rawValue).count(":") > 1:
@@ -128,33 +139,35 @@ class DateBone(BaseBone):
             value = tmpRes
         else:
             try:
-                value = time_zone.localize(datetime.fromisoformat(value))
+                value = datetime.fromisoformat(value)
             except:
                 try:
                     if " " in rawValue:  # Date with time
                         try:  # Times with seconds
                             if "-" in rawValue:  # ISO Date
-                                value = time_zone.localize(datetime.strptime(str(rawValue), "%Y-%m-%d %H:%M:%S"))
+                                value = datetime.strptime(str(rawValue), "%Y-%m-%d %H:%M:%S")
                             elif "/" in rawValue:  # Ami Date
-                                value = time_zone.localize(datetime.strptime(str(rawValue), "%m/%d/%Y %H:%M:%S"))
+                                value = datetime.strptime(str(rawValue), "%m/%d/%Y %H:%M:%S")
                             else:  # European Date
-                                value = time_zone.localize(datetime.strptime(str(rawValue), "%d.%m.%Y %H:%M:%S"))
+                                value = datetime.strptime(str(rawValue), "%d.%m.%Y %H:%M:%S")
                         except:
                             if "-" in rawValue:  # ISO Date
-                                value = time_zone.localize(datetime.strptime(str(rawValue), "%Y-%m-%d %H:%M"))
+                                value = datetime.strptime(str(rawValue), "%Y-%m-%d %H:%M")
                             elif "/" in rawValue:  # Ami Date
-                                value = time_zone.localize(datetime.strptime(str(rawValue), "%m/%d/%Y %H:%M"))
+                                value = datetime.strptime(str(rawValue), "%m/%d/%Y %H:%M")
                             else:  # European Date
-                                value = time_zone.localize(datetime.strptime(str(rawValue), "%d.%m.%Y %H:%M"))
+                                value = datetime.strptime(str(rawValue), "%d.%m.%Y %H:%M")
                     else:
                         if "-" in rawValue:  # ISO (Date only)
-                            value = time_zone.localize(datetime.strptime(str(rawValue), "%Y-%m-%d"))
+                            value = datetime.strptime(str(rawValue), "%Y-%m-%d")
                         elif "/" in rawValue:  # Ami (Date only)
-                            value = time_zone.localize(datetime.strptime(str(rawValue), "%m/%d/%Y"))
+                            value = datetime.strptime(str(rawValue), "%m/%d/%Y")
                         else:  # European (Date only)
-                            value = time_zone.localize(datetime.strptime(str(rawValue), "%d.%m.%Y"))
+                            value = datetime.strptime(str(rawValue), "%d.%m.%Y")
                 except:
                     value = False  # its invalid
+            if value and self.naive:
+                value = time_zone.localize(value)
         if value is False:
             return self.getEmptyValue(), [
                 ReadFromClientError(ReadFromClientErrorSeverity.Invalid, "Invalid value entered")]
@@ -181,6 +194,8 @@ class DateBone(BaseBone):
         If not both date and time are set and the localize flag is set, then UTC is used.
         If it cant be guessed, a safe default (UTC) is used
         """
+        if self.naive:
+            return None
         if not (self.date and self.time and self.localize):
             return pytz.utc
 
@@ -223,6 +238,8 @@ class DateBone(BaseBone):
                 value = value.replace(hour=0, minute=0, second=0)
             elif not self.date:
                 value = value.replace(year=1970, month=1, day=1)
+            if self.naive:
+                value = value.replace(tzinfo=timezone.utc)
             # We should always deal with timezone aware datetimes
             assert value.tzinfo, "Encountered a naive Datetime object in %s - refusing to save." % name
         return value
@@ -230,13 +247,16 @@ class DateBone(BaseBone):
     def singleValueUnserialize(self, value):
         if isinstance(value, datetime):
             # Serialized value is timezone aware.
-            # If local timezone is needed, set here, else force UTC.
-            time_zone = self.guessTimeZone()
-            return value.astimezone(time_zone)
+            if self.naive:
+                value = value.replace(tzinfo=None)
+                return value
+            else:
+                # If local timezone is needed, set here, else force UTC.
+                time_zone = self.guessTimeZone()
+                return value.astimezone(time_zone)
         else:
             # We got garbage from the datastore
             return None
-
 
     def buildDBFilter(self,
                       name: str,
@@ -253,10 +273,14 @@ class DateBone(BaseBone):
 
     def performMagic(self, valuesCache, name, isAdd):
         if (self.creationMagic and isAdd) or self.updateMagic:
-            valuesCache[name] = utcNow().replace(microsecond=0).astimezone(self.guessTimeZone())
+            if self.naive:
+                valuesCache[name] = utcNow().replace(microsecond=0, tzinfo=None)
+            else:
+                valuesCache[name] = utcNow().replace(microsecond=0).astimezone(self.guessTimeZone())
 
     def structure(self) -> dict:
         return super().structure() | {
             "date": self.date,
-            "time": self.time
+            "time": self.time,
+            "naive": self.naive
         }

--- a/core/bones/date.py
+++ b/core/bones/date.py
@@ -112,7 +112,7 @@ class DateBone(BaseBone):
         elif not self.date and self.time:
             try:
                 value = datetime.fromisoformat(value)
-                if self.naive:
+                if not self.naive:
                     value = time_zone.localize(value)
             except:
                 try:

--- a/core/bones/date.py
+++ b/core/bones/date.py
@@ -166,7 +166,7 @@ class DateBone(BaseBone):
                             value = datetime.strptime(str(rawValue), "%d.%m.%Y")
                 except:
                     value = False  # its invalid
-            if value and self.naive:
+            if value and not self.naive:
                 value = time_zone.localize(value)
         if value is False:
             return self.getEmptyValue(), [


### PR DESCRIPTION
Because the datastore (currently) enforces datetime aware objects we need to remove/add the tzinfo on (un)serialize.

This is a replacement for #642 