### PR TITLE
Fix: Set the logging level to `logging.DEBUG`

### DIFF
--- a/core/logging.py
+++ b/core/logging.py
@@ -171,3 +171,4 @@ else:
     sh = logging.StreamHandler()
     sh.setFormatter(formatter)
     logger.addHandler(sh)
+    sh.setLevel(logging.DEBUG)


### PR DESCRIPTION
Otherwise no logging is displayed on my local dev server.