### PR TITLE
refactor: Re-implement password encoding using Python's `hashlib` and `secrets` module

### DIFF
--- a/core/bones/password.py
+++ b/core/bones/password.py
@@ -1,24 +1,11 @@
-import binascii
 import hashlib
-import logging
-import string
-from typing import List, Union
-
-from viur.core import conf, utils
-from viur.core.bones.base import ReadFromClientError, \
-    ReadFromClientErrorSeverity
-from viur.core.bones.string import StringBone
-from viur.core.i18n import translate
-from viur.core import utils, conf
-from hashlib import sha256
-import hmac
-import codecs
 import re
-from struct import Struct
-from operator import xor
-from itertools import starmap
 from typing import List, Tuple, Union
 
+from viur.core import conf, utils
+from viur.core.bones.string import StringBone
+from viur.core.i18n import translate
+from .base import ReadFromClientError, ReadFromClientErrorSeverity
 
 
 def encode_password(password: str | bytes, salt: str | bytes,

--- a/core/bones/password.py
+++ b/core/bones/password.py
@@ -102,7 +102,6 @@ class PasswordBone(StringBone):
             return [ReadFromClientError(ReadFromClientErrorSeverity.Invalid, err)]
         # As we don't escape passwords and allow most special characters we'll hash it early on so we don't open
         # an XSS attack vector if a password is echoed back to the client (which should not happen)
-
         skel[name] = encode_password(value, utils.generateRandomString(self.saltLength, use_secrets=True))
 
     def serialize(self, skel: 'SkeletonInstance', name: str, parentIndexed: bool) -> bool:

--- a/core/bones/password.py
+++ b/core/bones/password.py
@@ -1,45 +1,29 @@
-from viur.core.bones.base import ReadFromClientError, ReadFromClientErrorSeverity
-from viur.core.bones.string import StringBone
-from viur.core.i18n import translate
-from viur.core import utils, conf
-from hashlib import sha256
-import hmac, codecs, string, random
-from struct import Struct
-from operator import xor
-from itertools import starmap
+import hashlib
+import logging
+import string
 from typing import List, Union
 
+from viur.core import conf, utils
+from viur.core.bones.base import ReadFromClientError, \
+    ReadFromClientErrorSeverity
+from viur.core.bones.string import StringBone
+from viur.core.i18n import translate
 
-def pbkdf2(password, salt, iterations=1001, keylen=42):
-    """
-        An implementation of PBKDF2 (http://wikipedia.org/wiki/PBKDF2)
 
-        Mostly based on the implementation of
-        https://github.com/mitsuhiko/python-pbkdf2/blob/master/pbkdf2.py
-
-        :copyright: (c) Copyright 2011 by Armin Ronacher.
-        :license: BSD, see LICENSE for more details.
-    """
-    _pack_int = Struct('>I').pack
+def encode_password(password: str| bytes, salt: str | bytes, iterations: int = 600_000, dklen: int = 24) -> dict[str, str]:
+    password = password[: conf["viur.maxPasswordLength"]]
     if isinstance(password, str):
-        password = password.encode("UTF-8")
+        password = password.encode()
     if isinstance(salt, str):
-        salt = salt.encode("UTF-8")
-    mac = hmac.new(password, None, sha256)
-
-    def _pseudorandom(x, mac=mac):
-        h = mac.copy()
-        h.update(x)
-        return h.digest()
-
-    buf = []
-    for block in range(1, -(-keylen // mac.digest_size) + 1):
-        rv = u = _pseudorandom(salt + _pack_int(block))
-        for i in range(iterations - 1):
-            u = _pseudorandom((''.join(map(chr, u))).encode("LATIN-1"))
-            rv = starmap(xor, zip(rv, u))
-        buf.extend(rv)
-    return codecs.encode(''.join(map(chr, buf))[:keylen].encode("LATIN-1"), 'hex_codec')
+        salt = salt.encode()
+    pwhash = hashlib.pbkdf2_hmac("sha256", password, salt, iterations, dklen)
+    logging.debug(f"{pwhash = }")
+    return {
+        "pwhash": pwhash,
+        "salt": salt,
+        "iterations": iterations,
+        "dklen": dklen,
+    }
 
 
 class PasswordBone(StringBone):
@@ -100,9 +84,8 @@ class PasswordBone(StringBone):
             return [ReadFromClientError(ReadFromClientErrorSeverity.Invalid, err)]
         # As we don't escape passwords and allow most special characters we'll hash it early on so we don't open
         # an XSS attack vector if a password is echoed back to the client (which should not happen)
-        salt = utils.generateRandomString(self.saltLength)
-        passwd = pbkdf2(value[: conf["viur.maxPasswordLength"]], salt)
-        skel[name] = {"pwhash": passwd, "salt": salt}
+
+        skel[name] = encode_password(value,     utils.generateRandomString(self.saltLength, use_secrets=True))
 
     def serialize(self, skel: 'SkeletonInstance', name: str, parentIndexed: bool) -> bool:
         if name in skel.accessedValues and skel.accessedValues[name]:
@@ -110,9 +93,8 @@ class PasswordBone(StringBone):
             if isinstance(value, dict):  # It is a pre-hashed value (probably fromClient)
                 skel.dbEntity[name] = value
             else:  # This has been set by skel["password"] = "secret", we'll still have to hash it
-                salt = utils.generateRandomString(self.saltLength)
-                passwd = pbkdf2(value[: conf["viur.maxPasswordLength"]], salt)
-                skel.dbEntity[name] = {"pwhash": passwd, "salt": salt}
+                skel[name] = encode_password(value, utils.generateRandomString(self.saltLength, use_secrets=True))
+
             # Ensure our indexed flag is up2date
             indexed = self.indexed and parentIndexed
             if indexed and name in skel.dbEntity.exclude_from_indexes:

--- a/core/bones/password.py
+++ b/core/bones/password.py
@@ -105,7 +105,7 @@ class PasswordBone(StringBone):
             return [ReadFromClientError(ReadFromClientErrorSeverity.Invalid, err)]
         # As we don't escape passwords and allow most special characters we'll hash it early on so we don't open
         # an XSS attack vector if a password is echoed back to the client (which should not happen)
-        skel[name] = encode_password(value, utils.generateRandomString(self.saltLength, True))
+        skel[name] = encode_password(value, utils.generateRandomString(self.saltLength))
 
     def serialize(self, skel: 'SkeletonInstance', name: str, parentIndexed: bool) -> bool:
         if name in skel.accessedValues and skel.accessedValues[name]:
@@ -113,7 +113,7 @@ class PasswordBone(StringBone):
             if isinstance(value, dict):  # It is a pre-hashed value (probably fromClient)
                 skel.dbEntity[name] = value
             else:  # This has been set by skel["password"] = "secret", we'll still have to hash it
-                skel.dbEntity[name] = encode_password(value, utils.generateRandomString(self.saltLength, True))
+                skel.dbEntity[name] = encode_password(value, utils.generateRandomString(self.saltLength))
 
             # Ensure our indexed flag is up2date
             indexed = self.indexed and parentIndexed

--- a/core/modules/user.py
+++ b/core/modules/user.py
@@ -265,7 +265,7 @@ class UserPassword:
                 return self.pwrecover()
             # We're in the second step - the code has been send and is waiting for confirmation from the user
             if utils.utcNow() - session["user.auth_userpassword.pwrecover"]["creationdate"] \
-                > datetime.timedelta(minutes=15):
+                    > datetime.timedelta(minutes=15):
                 # This recovery-process is expired; reset the session and start over
                 session["user.auth_userpassword.pwrecover"] = None
                 return self.userModule.render.view(
@@ -444,8 +444,8 @@ class GoogleAccount:
                 request.response.headers["cross-origin-opener-policy"] = "same-origin-allow-popups"
             # Fixme: Render with Jinja2?
             with (conf["viur.instance.core_base_path"]
-                      .joinpath("viur/core/template/vi_user_google_login.html")
-                      .open() as tpl_file):
+                  .joinpath("viur/core/template/vi_user_google_login.html")
+                  .open() as tpl_file):
                 tplStr = tpl_file.read()
             tplStr = tplStr.replace("{{ clientID }}", conf["viur.user.google.clientID"])
             extendCsp({"script-src": ["sha256-JpzaUIxV/gVOQhKoDLerccwqDDIVsdn1JclA6kRNkLw="],

--- a/core/modules/user.py
+++ b/core/modules/user.py
@@ -58,7 +58,6 @@ class UserSkel(skeleton.Skeleton):
     access = SelectBone(
         descr="Access rights",
         values=lambda: {
-
             right: i18n.translate("server.modules.user.accessright.%s" % right, defaultText=right)
             for right in sorted(conf["viur.accessRights"])
         },

--- a/core/modules/user.py
+++ b/core/modules/user.py
@@ -220,7 +220,8 @@ class UserPassword:
                 logging.info(f"Update password hash for user {name}.")
                 # re-hash the password with more iterations
                 skel = self.userModule.editSkel()
-                skel.fromDB(res.key)
+                skel.setEntity(res)
+                skel["key"] = res.key
                 skel["password"] = password  # will be hashed on serialize
                 skel.toDB(clearUpdateTag=True)
             return self.userModule.continueAuthenticationFlow(self, res.key)

--- a/core/modules/user.py
+++ b/core/modules/user.py
@@ -195,18 +195,10 @@ class UserPassword:
         iterations = password_data.get("iterations", 1001)
         # passwd = encode_password(password, password_data.get("salt", ""), iterations)
         passwd = encode_password(password, password_data.get("salt", ""), iterations)["pwhash"]
-        isOkay = True
-
-        logging.debug(f"{password_data = }")
-        logging.debug(f"{passwd = }")
-        logging.debug(f"{passwd.decode() = }")
-        logging.debug(f"{password = }")
-
-        # We do this exactly that way to avoid timing attacks
 
         # Check if the username matches
         storedUserName = (res.get("name") or {}).get("idx", "")
-        isOkay &= secrets.compare_digest(storedUserName, name)
+        isOkay = secrets.compare_digest(storedUserName, name)
 
         # Check if the password matches
         storedPasswordHash = password_data.get("pwhash", "-invalid-")
@@ -226,6 +218,7 @@ class UserPassword:
             skel = self.loginSkel()
             return self.userModule.render.login(skel, loginFailed=True, accountStatus=accountStatus)
         else:
+            # TODO: if the password was right we could regenerate the pwhash with a higher iteration count
             return self.userModule.continueAuthenticationFlow(self, res.key)
 
     @exposed

--- a/core/utils.py
+++ b/core/utils.py
@@ -16,7 +16,7 @@ def utcNow() -> datetime:
     return datetime.now(timezone.utc)
 
 
-def generateRandomString(length: int = 13, use_secrets: bool = False) -> str:
+def generateRandomString(length: int = 13) -> str:
     """
     Return a string containing random characters of given *length*.
     It's safe to use this string in URLs or HTML.

--- a/core/utils.py
+++ b/core/utils.py
@@ -25,10 +25,7 @@ def generateRandomString(length: int = 13) -> str:
 
     :returns: A string with random characters of the given length.
     """
-    alphabet = string.ascii_letters + string.digits
-    if use_secrets:
-        return "".join(secrets.choice(alphabet) for _ in range(length))
-    return "".join(random.choices(alphabet, k=length))
+    return "".join(secrets.choice(string.ascii_letters + string.digits) for _ in range(length))
 
 
 def getCurrentUser() -> Optional["SkeletonInstance"]:

--- a/core/utils.py
+++ b/core/utils.py
@@ -2,6 +2,7 @@ import hashlib
 import hmac
 import random
 import logging
+import secrets
 import string
 from base64 import urlsafe_b64encode
 from contextvars import ContextVar
@@ -15,16 +16,21 @@ def utcNow() -> datetime:
     return datetime.now(timezone.utc)
 
 
-def generateRandomString(length: int = 13) -> str:
+def generateRandomString(length: int = 13, use_secrets: bool = False) -> str:
     """
     Return a string containing random characters of given *length*.
-    Its safe to use this string in URLs or HTML.
+    It's safe to use this string in URLs or HTML.
 
     :param length: The desired length of the generated string.
+    :param use_secrets: For security or cryptographic uses, enable this options.
+        The pseudo-random generators (default) should not be used for security purposes.
 
     :returns: A string with random characters of the given length.
     """
-    return "".join(random.choices(string.ascii_letters + string.digits, k=length))
+    alphabet = string.ascii_letters + string.digits
+    if use_secrets:
+        return "".join(secrets.choice(alphabet) for _ in range(length))
+    return "".join(random.choices(alphabet, k=length))
 
 
 def getCurrentUser() -> Optional["SkeletonInstance"]:

--- a/core/utils.py
+++ b/core/utils.py
@@ -22,8 +22,6 @@ def generateRandomString(length: int = 13) -> str:
     It's safe to use this string in URLs or HTML.
 
     :param length: The desired length of the generated string.
-    :param use_secrets: For security or cryptographic uses, enable this options.
-        The pseudo-random generators (default) should not be used for security purposes.
 
     :returns: A string with random characters of the given length.
     """

--- a/core/utils.py
+++ b/core/utils.py
@@ -1,16 +1,16 @@
 import hashlib
 import hmac
-import random
 import logging
 import secrets
 import string
 from base64 import urlsafe_b64encode
-from contextvars import ContextVar
 from datetime import datetime, timedelta, timezone
 from typing import Any, Union, Optional
 from urllib.parse import quote
-from viur.core.config import conf
+
 from viur.core import current, db
+from viur.core.config import conf
+
 
 def utcNow() -> datetime:
     return datetime.now(timezone.utc)
@@ -20,6 +20,7 @@ def generateRandomString(length: int = 13) -> str:
     """
     Return a string containing random characters of given *length*.
     It's safe to use this string in URLs or HTML.
+    Because we use the secrets module it could be used for security purposes as well
 
     :param length: The desired length of the generated string.
 


### PR DESCRIPTION
Since python 3.4 https://docs.python.org/3/library/hashlib.html#hashlib.pbkdf2_hmac is in the standard. This PR replaces the own implementation with this one.

Furthermore, for security relevant tokens not the [`random`](https://docs.python.org/3/library/random.html#module-random) module but [`secrets`](https://docs.python.org/3/library/secrets.html) should be used. Therefore there is now an extension of `utils.generateRandomString`.
> _Warning The pseudo-random generators of this module should not be used for security purposes. For security or cryptographic uses, see the [secrets](https://docs.python.org/3/library/secrets.html#module-secrets) module._
~ [Docs at python.org](https://docs.python.org/3/library/random.html#:~:text=Warning%20The%20pseudo%2Drandom%20generators%20of%20this%20module%20should%20not%20be%20used%20for%20security%20purposes.%20For%20security%20or%20cryptographic%20uses%2C%20see%20the%20secrets%20module.)

Furthermore, the 600,000 iterations recommended by OWASP are now used instead of 1001 for PBKDF2.
https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html#pbkdf2

The new method `encode_password` directly returns the hash as well as meta data for the embedded entity in the datastore.

Finally, this PR replaces the char-by-char comparisons with [`hmac.compare_digest`](https://docs.python.org/3/library/hmac.html#hmac.compare_digest), which is safe against timing attacks.

