### PR TITLE
refactor: rename `Skeleton.toDB()`s `clearUpdateTag` into `update_relations`

### DIFF
--- a/core/bones/file.py
+++ b/core/bones/file.py
@@ -73,7 +73,7 @@ def ensureDerived(key: db.Key, srcKey, deriveMap: Dict[str, Any], refreshKey: db
                 if not skel.fromDB(refreshKey):
                     return
                 skel.refresh()
-                skel.toDB(clearUpdateTag=True)
+                skel.toDB(update_relations=True)
 
             db.RunInTransaction(refreshTxn)
 

--- a/core/bones/file.py
+++ b/core/bones/file.py
@@ -73,7 +73,7 @@ def ensureDerived(key: db.Key, srcKey, deriveMap: Dict[str, Any], refreshKey: db
                 if not skel.fromDB(refreshKey):
                     return
                 skel.refresh()
-                skel.toDB(update_relations=True)
+                skel.toDB(update_relations=False)
 
             db.RunInTransaction(refreshTxn)
 

--- a/core/modules/user.py
+++ b/core/modules/user.py
@@ -828,7 +828,7 @@ class User(List):
             # Conserve DB-Writes: Update the user max once in 30 Minutes (why??)
             if not skel["lastlogin"] or ((now - skel["lastlogin"]) > datetime.timedelta(minutes=30)):
                 skel["lastlogin"] = now
-                skel.toDB(clearUpdateTag=True)
+                skel.toDB(update_relations=True)
 
         logging.info(f"""User {skel["name"]} logged in""")
 

--- a/core/modules/user.py
+++ b/core/modules/user.py
@@ -828,7 +828,7 @@ class User(List):
             # Conserve DB-Writes: Update the user max once in 30 Minutes (why??)
             if not skel["lastlogin"] or ((now - skel["lastlogin"]) > datetime.timedelta(minutes=30)):
                 skel["lastlogin"] = now
-                skel.toDB(update_relations=True)
+                skel.toDB(update_relations=False)
 
         logging.info(f"""User {skel["name"]} logged in""")
 

--- a/core/skeleton.py
+++ b/core/skeleton.py
@@ -1022,7 +1022,7 @@ class Skeleton(BaseSkeleton, metaclass=MetaSkel):
         if db.IsInTransaction():
             key, dbObj, skel, changeList = txnUpdate(key, skelValues)
         else:
-            key, dbObj, skel, changeList = db.RunInTransaction(txnUpdate, key, skelValues, update_relations)
+            key, dbObj, skel, changeList = db.RunInTransaction(txnUpdate, key, skelValues)
 
         # Perform post-save operations (postProcessSerializedData Hook, Searchindex, ..)
         skelValues["key"] = key
@@ -1032,7 +1032,7 @@ class Skeleton(BaseSkeleton, metaclass=MetaSkel):
 
         skel.postSavedHandler(key, dbObj)
 
-        if not update_relations and not isAdd:
+        if update_relations and not isAdd:
             if changeList and len(changeList) < 5:  # Only a few bones have changed, process these individually
                 for idx, changedBone in enumerate(changeList):
                     updateRelations(key, time() + 1, changedBone, _countdown=10 * idx)

--- a/core/skeleton.py
+++ b/core/skeleton.py
@@ -775,6 +775,7 @@ class Skeleton(BaseSkeleton, metaclass=MetaSkel):
             :returns: The datastore key of the entity.
         """
         assert skelValues.renderPreparation is None, "Cannot modify values while rendering"
+        # fixme: Remove in viur-core >= 4
         if "clearUpdateTag" in kwargs:
             msg = "clearUpdateTag was replaced by update_relations"
             warnings.warn(msg, DeprecationWarning, stacklevel=3)
@@ -943,13 +944,8 @@ class Skeleton(BaseSkeleton, metaclass=MetaSkel):
             # Store lastRequestedKeys so further updates can run more efficient
             dbObj["viur"]["viurLastRequestedSeoKeys"] = currentSeoKeys
 
-            if update_relations:
-                # Mark this entity as dirty, so the background-task will catch it up and update its references.
-                dbObj["viur"]["delayedUpdateTag"] = time()
-            else:
-                # Mark this entity as Up-to-date.
-                dbObj["viur"]["delayedUpdateTag"] = 0
-
+            # mark entity as "dirty" when update_relations is set, to zero otherwise.
+            dbObj["viur"]["delayedUpdateTag"] = time() if update_relations else 0
             dbObj = skel.preProcessSerializedData(dbObj)
 
             # Allow the custom DB Adapter to apply last minute changes to the object


### PR DESCRIPTION
This PR finaly replace `clearUpdateTag` with `update_relations`. I think this is more understandable.