### PR TITLE
chore: Conventional commits and clarifications

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,10 +48,10 @@ Please document your changes and provide info in any form you can. We have estab
 `viur-core` uses the semantic versioning scheme.<br>
 Any `major.minor.bugfix` release is being published to [PyPI](https://pypi.org/project/viur-core).
 
-Furthermore, the following rules apply to hidden pre-releases which are also made to PyPI for open tests.
+Furthermore, the following rules apply to pre-releases which are also made available to PyPI for open tests.
 
-- Release candidates which are almost feature-complete is given a suffix named `-rcN`.
-- Beta versions with incomplete features is given a suffix named `-betaN`.
+- Release candidates which are almost feature-complete is given a suffix named `.rcN`.
+- Beta versions with incomplete features is given a suffix named `.betaN`.
 
 In both cases, `N` is a number counted upwards for every pre-release.
 
@@ -61,7 +61,6 @@ In case you have appropriate permissions, a release can be done this way:
 
 - Make sure all hotfixes from `main` are in `develop` as well (`git merge main`)
 - Bump version number in `core/version.py`
-  - For a release-candidate, add `-rcN` to the version number, and count N up.
 - Update `CHANGELOG.md` and also check version number there
   - To quickly generate a changelog, run `git log --pretty="- %s" main..develop`
   - todo: Changelog shall be generated automatically later.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ Please document your changes and provide info in any form you can. We have estab
 ## Versioning
 
 `viur-core` uses the semantic versioning scheme.<br>
-Any `major.minor.bugfix` release is being published to PyPI.
+Any `major.minor.bugfix` release is being published to [PyPI](https://pypi.org/project/viur-core).
 
 Furthermore, the following rules apply to hidden pre-releases which are also made to PyPI for open tests.
 
@@ -55,7 +55,7 @@ Furthermore, the following rules apply to hidden pre-releases which are also mad
 
 In both cases, `N` is a number counted upwards for every pre-release.
 
-# Release
+## Releasing
 
 In case you have appropriate permissions, a release can be done this way:
 
@@ -72,11 +72,11 @@ In case you have appropriate permissions, a release can be done this way:
   - Release the package
     - PyPI: `pipenv run release`
     - TestPyPI: `pipenv run develop`
-- When all went well, finally create a tag equally to the version number in `core/version.py` 
+- When all went well, finally create a tag equally to the version number in `core/version.py`
 
 ## Branches
 
-viur-core has two actively maintained branches:
+`viur-core` has two actively maintained branches:
 
 - **main** is the current stable version as released on PyPI.
 - **develop**  is the next minor version and may be released as release candidates to PyPI.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,28 @@ In case you encounter a bug, or you miss a feature, please [file an issue](https
 If you created a solution for a problem or added a feature, please make a pull request.
 This can also be done as a draft, in case you want to discuss a change or aren't finished.
 
-## Reviewing Pull Requests
+### Conventional Commits
+
+When creating a pull request, try to follow the [Conventional Commit](https://www.conventionalcommits.org) paradigm.
+This is also part of the pull requests naming scheme, as pull requests are usually squash merged.
+
+| Type | | SemVer |
+| --- | --- | --- |
+| any of following types | - A commit that has a footer:<br />`BREAKING CHANGE: <description>`<br /><br />AND/OR<br /><br /> - A commit that has a ! after the type or optional scope:<br />`<type>[optional scope]!: <description>`  |    `MAJOR`<br />Breaking Change |conventional commit
+| `feat` | A new feature, introducing a new feature to the codebase | `MINOR` |
+| `fix`  | A bug fix, patching a bug in your codebase | `PATCH` |
+| `refactor` | A change that neither fixes a bug nor adds a feature | - |
+| `docs` | Documentation only changes | - |
+| `style` | Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc) | - |
+| `perf` | A code change that improves performance | - |
+| `test` | Adding missing or correcting existing tests | - |
+| `chore` | Changes to the build process or auxiliary tools and libraries such as documentation generation | - |
+| `ci` | Changes to the continuous integration | - |
+| `build` | Changes to the build process or code generation | - |
+
+Visit [Vahid Hallaji's Blog](https://hallaji.com/blog/summary-of-conventional-commits) for a nice a short explanation.
+
+### Review
 
 ViUR needs you! All developers are invited to review pull requests, so we can merge PRs as soon as possible and make changes according to our standards and that only works, if people help out.
 If you are not on the reviewers list, just add yourself or ask a maintainer to configure access for you.
@@ -24,9 +45,15 @@ Please document your changes and provide info in any form you can. We have estab
 
 ## Versioning
 
-viur-core uses the semantic versioning scheme.
-Any major/minor/bugfix release is being published to PyPI.
-A pre-release is marked as "rc" for release-candidate and is also published.
+`viur-core` uses the semantic versioning scheme.<br>
+Any `major.minor.bugfix` release is being published to PyPI.
+
+Furthermore, the following rules apply to hidden pre-releases which are also made to PyPI for open tests.
+
+- Release candidates which are almost feature-complete is given a suffix named `-rcN`.
+- Beta versions with incomplete features is given a suffix named `-betaN`.
+
+In both cases, `N` is a number counted upwards for every pre-release.
 
 # Release
 
@@ -49,7 +76,7 @@ In case you have appropriate permissions, a release can be done this way:
 
 ## Branches
 
-viur-core has two branches:
+viur-core has two actively maintained branches:
 
 - **main** is the current stable version as released on PyPI.
 - **develop**  is the next minor version and may be released as release candidates to PyPI.


### PR DESCRIPTION
Adding rules for conventional commits to CONTRIBUTING.md, and for the versioning scheme regarding pre-releases.

However, I have to make two personal comments here about Conventional Commits:

1. I really HATE the keyword "chore".
2. Why is it called "feat", and not "feature", but "refactor" and not "refact"? This is so ugly and stupid, it seems that Conventional Commits where invented by idiots... well, it has its origin in the JavaScript world, this might be the reason.
