### PR TITLE
chore: Bump viur-datastore to 1.3.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-viur-datastore==1.3.7 --hash=sha256:8e7a268334c243ea77ffeadacb3b5c72652be53df8a4c56fe2a1718f90c4209b
+viur-datastore==1.3.8 --hash=sha256:727fb1ab132970ed99d012e68092aa5d1451d2a0ec3d8eaf8d79bea873a83a08
 
 google-auth==2.6.3 --hash=sha256:d65bb0e3701eaaa64fd2aa85e1325580524b0bddc6dc5db3ab89c481b6a20141
 


### PR DESCRIPTION
This updates viur-datastore to 1.3.8 with some minor fixes and improvements.