### PR TITLE
fix: `CredentialBone` without escaping

### DIFF
--- a/core/bones/credential.py
+++ b/core/bones/credential.py
@@ -14,10 +14,10 @@ class CredentialBone(StringBone):
     def __init__(
         self,
         *,
-        maxLength: int = 100*1024,  # Limit the Bone length on 100KB
+        maxLength: int = 100 * 1024,  # Limit the Bone length on 100KB
         **kwargs
     ):
-        super().__init__(maxLength=maxLength,**kwargs)
+        super().__init__(maxLength=maxLength, **kwargs)
         if self.multiple or self.languages:
             raise ValueError("Credential-Bones cannot be multiple or translated!")
 

--- a/core/bones/credential.py
+++ b/core/bones/credential.py
@@ -14,7 +14,7 @@ class CredentialBone(StringBone):
     def __init__(
         self,
         *,
-        maxLength: int = 100 * 1024,  # Limit the Bone length on 100KB
+        maxLength: int = None, # Unlimited length
         **kwargs
     ):
         super().__init__(maxLength=maxLength, **kwargs)
@@ -28,7 +28,7 @@ class CredentialBone(StringBone):
         """
         if value is None:
             return False
-        if len(value) > self.maxLength:
+        if self.maxLength is not None and len(value) > self.maxLength:
             return "Maximum length exceeded"
 
     def serialize(self, skel: 'SkeletonInstance', name: str, parentIndexed: bool) -> bool:

--- a/core/bones/credential.py
+++ b/core/bones/credential.py
@@ -14,7 +14,7 @@ class CredentialBone(StringBone):
     def __init__(
         self,
         *,
-        maxLength: int = None, # Unlimited length
+        maxLength: int = None,  # Unlimited length
         **kwargs
     ):
         super().__init__(maxLength=maxLength, **kwargs)

--- a/core/bones/credential.py
+++ b/core/bones/credential.py
@@ -11,10 +11,25 @@ class CredentialBone(StringBone):
     """
     type = "str.credential"
 
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
+    def __init__(
+        self,
+        *,
+        maxLength: int = 100*1024,  # Limit the Bone length on 100KB
+        **kwargs
+    ):
+        super().__init__(maxLength=maxLength,**kwargs)
         if self.multiple or self.languages:
             raise ValueError("Credential-Bones cannot be multiple or translated!")
+
+    def isInvalid(self, value):
+        """
+            Returns None if the value would be valid for
+            this bone, an error-message otherwise.
+        """
+        if value is None:
+            return False
+        if len(value) > self.maxLength:
+            return "Maximum length exceeded"
 
     def serialize(self, skel: 'SkeletonInstance', name: str, parentIndexed: bool) -> bool:
         """

--- a/core/bones/credential.py
+++ b/core/bones/credential.py
@@ -1,6 +1,5 @@
 from viur.core.bones.base import ReadFromClientError, ReadFromClientErrorSeverity
 from viur.core.bones.string import StringBone
-from viur.core import utils
 
 
 class CredentialBone(StringBone):
@@ -34,7 +33,6 @@ class CredentialBone(StringBone):
         return {}
 
     def singleValueFromClient(self, value, skel, name, origData):
-        err = self.isInvalid(value)
-        if not err:
-            return utils.escapeString(value, 4 * 1024), None
+        if not (err := self.isInvalid(value)):
+            return value, None
         return self.getEmptyValue(), [ReadFromClientError(ReadFromClientErrorSeverity.Invalid, err)]


### PR DESCRIPTION
This PR remove the string escaping in the credentialBone because it change the credetial value. 
An example we have an Base32 Secret like `GZRTOMBZREHFTDQNJVGQYRYMRSTOOLCGNSWKNQ==`
and we store it in the Bone. 
Later  we have want  compare the token in some OTP function or so and now we get `GZRTOMBZREHFTDQNJVGQYRYMRSTOOLCGNSWKNQ&#061;&#061;` from the Database.

