### PR TITLE
feat: Improvements on `securitykey.validate`

### DIFF
--- a/core/modules/file.py
+++ b/core/modules/file.py
@@ -553,8 +553,7 @@ class File(Tree):
         else:
             size = None
 
-        if not securitykey.validate(skey, useSessionKey=True):
-            raise errors.PreconditionFailed()
+        securitykey.validate(skey, pre_condition=True)
 
         targetKey, uploadUrl = self.initializeUpload(fileName, mimeType.lower(), node, size)
 
@@ -656,7 +655,7 @@ class File(Tree):
         if skelType == "leaf":  # We need to handle leafs separately here
             skey = kwargs.get("skey")
             targetKey = kwargs.get("key")
-            if not skey or not securitykey.validate(skey, useSessionKey=True) or not targetKey:
+            if not securitykey.validate(skey) or not targetKey:
                 raise errors.PreconditionFailed()
             skel = self.addSkel("leaf")
             if not skel.fromDB(targetKey):

--- a/core/modules/formmailer.py
+++ b/core/modules/formmailer.py
@@ -12,7 +12,7 @@ class Formmailer(Module):
     mailTemplate = None
 
     @exposed
-    def index(self, *args, **kwargs):
+    def index(self, skey=None, *args, **kwargs):
         if not self.canUse():
             raise errors.Forbidden()  # Unauthorized
 
@@ -21,11 +21,10 @@ class Formmailer(Module):
         if len(kwargs) == 0:
             return self.render.add(skel=skel, failed=False)
 
-        if not skel.fromClient(kwargs) or not "skey" in kwargs:
+        if not skel.fromClient(kwargs) or not skey:
             return self.render.add(skel=skel, failed=True)
 
-        if not securitykey.validate(kwargs["skey"], useSessionKey=True):
-            raise errors.PreconditionFailed()
+        securitykey.validate(skey, pre_condition=True)
 
         # Allow bones to perform outstanding "magic" operations before sending the mail
         for key, _bone in skel.items():

--- a/core/prototypes/list.py
+++ b/core/prototypes/list.py
@@ -91,8 +91,7 @@ class List(SkelModule):
         if not self.canPreview():
             raise errors.Unauthorized()
 
-        if not securitykey.validate(skey, useSessionKey=True):
-            raise errors.PreconditionFailed()
+        securitykey.validate(skey, pre_condition=True)
 
         skel = self.viewSkel()
         skel.fromClient(kwargs)
@@ -211,8 +210,7 @@ class List(SkelModule):
         ):
             # render the skeleton in the version it could as far as it could be read.
             return self.render.edit(skel)
-        if not securitykey.validate(skey, useSessionKey=True):
-            raise errors.PreconditionFailed()
+        securitykey.validate(skey, pre_condition=True)
 
         self.onEdit(skel)
         skel.toDB()  # write it!
@@ -247,8 +245,7 @@ class List(SkelModule):
         ):
             # render the skeleton in the version it could as far as it could be read.
             return self.render.add(skel)
-        if not securitykey.validate(skey, useSessionKey=True):
-            raise errors.PreconditionFailed()
+        securitykey.validate(skey, pre_condition=True)
 
         self.onAdd(skel)
         skel.toDB()
@@ -281,8 +278,7 @@ class List(SkelModule):
         if not self.canDelete(skel):
             raise errors.Unauthorized()
 
-        if not securitykey.validate(skey, useSessionKey=True):
-            raise errors.PreconditionFailed()
+        securitykey.validate(skey, pre_condition=True)
 
         self.onDelete(skel)
         skel.delete()

--- a/core/prototypes/singleton.py
+++ b/core/prototypes/singleton.py
@@ -69,8 +69,7 @@ class Singleton(SkelModule):
         if not self.canPreview():
             raise errors.Unauthorized()
 
-        if not securitykey.validate(skey, useSessionKey=True):
-            raise errors.PreconditionFailed()
+        securitykey.validate(skey, pre_condition=True)
 
         skel = self.viewSkel()
         skel.fromClient(kwargs)
@@ -151,8 +150,7 @@ class Singleton(SkelModule):
             or ("bounce" in kwargs and kwargs["bounce"] == "1")):  # review before changing
             return self.render.edit(skel)
 
-        if not securitykey.validate(skey, useSessionKey=True):
-            raise errors.PreconditionFailed()
+        securitykey.validate(skey, pre_condition=True)
 
         self.onEdit(skel)
         skel.toDB()

--- a/core/prototypes/tree.py
+++ b/core/prototypes/tree.py
@@ -366,8 +366,7 @@ class Tree(SkelModule):
             or ("bounce" in kwargs and kwargs["bounce"] == "1")  # review before adding
         ):
             return self.render.add(skel)
-        if not securitykey.validate(skey, useSessionKey=True):
-            raise errors.PreconditionFailed()
+        securitykey.validate(skey, pre_condition=True)
 
         self.onAdd(skelType, skel)
         skel.toDB()
@@ -411,8 +410,7 @@ class Tree(SkelModule):
             or ("bounce" in kwargs and kwargs["bounce"] == "1")  # review before adding
         ):
             return self.render.edit(skel)
-        if not securitykey.validate(skey, useSessionKey=True):
-            raise errors.PreconditionFailed()
+        securitykey.validate(skey, pre_condition=True)
         self.onEdit(skelType, skel)
         skel.toDB()
         self.onEdited(skelType, skel)
@@ -446,10 +444,10 @@ class Tree(SkelModule):
             raise errors.NotFound()
         if not self.canDelete(skelType, skel):
             raise errors.Unauthorized()
-        if not securitykey.validate(skey, useSessionKey=True):
-            raise errors.PreconditionFailed()
+        securitykey.validate(skey, pre_condition=True)
         if skelType == "node":
             self.deleteRecursive(skel["key"])
+
         self.onDelete(skelType, skel)
         skel.delete()
         self.onDeleted(skelType, skel)
@@ -481,7 +479,7 @@ class Tree(SkelModule):
     @exposed
     @forceSSL
     @forcePost
-    def move(self, skelType: SkelType, key: str, parentNode: str, *args, **kwargs) -> str:
+    def move(self, skelType: SkelType, key: str, parentNode: str, skey: str = None, *args, **kwargs) -> str:
         """
         Move a node (including its contents) or a leaf to another node.
 
@@ -539,8 +537,7 @@ class Tree(SkelModule):
         if "rootNode" in tmp and tmp["rootNode"] == 1:
             raise errors.NotAcceptable("Can't move a rootNode to somewhere else")
 
-        if not securitykey.validate(kwargs.get("skey", ""), useSessionKey=True):
-            raise errors.PreconditionFailed()
+        securitykey.validate(skey, pre_condition=True)
 
         currentParentRepo = skel["parentrepo"]
         skel["parententry"] = parentNodeSkel["key"]

--- a/core/render/vi/__init__.py
+++ b/core/render/vi/__init__.py
@@ -70,8 +70,7 @@ def getStructure(module):
 
 @exposed
 def setLanguage(lang, skey):
-    if not securitykey.validate(skey):
-        raise errors.PreconditionFailed()
+    securitykey.validate(skey, pre_condition=True)
 
     if lang in conf["viur.availableLanguages"]:
         current.language.set(lang)

--- a/core/tasks.py
+++ b/core/tasks.py
@@ -371,8 +371,7 @@ class TaskHandler:
         skey = kwargs.get("skey", "")
         if len(kwargs) == 0 or not skel.fromClient(kwargs) or kwargs.get("bounce") == "1":
             return self.render.add(skel)
-        if not securitykey.validate(skey, useSessionKey=True):
-            raise errors.PreconditionFailed()
+        securitykey.validate(skey, pre_condition=True)
         task.execute(**skel.accessedValues)
         return self.render.addSuccess(skel)
 


### PR DESCRIPTION
- `useSessionKey=True` is now default
- `pre_condition`-parameter to auto-raise a PreconditionFailed() exception
- Replaced and optimized calls in viur-core
- 100% backwards compatible to existing calls

I don't know why `useSessionKey=True` was always explicitly provided, as you can see below:
![before](https://user-images.githubusercontent.com/16870072/231270840-1214317e-46e2-4594-addd-9b142ffc8891.jpg)
