### PR TITLE
fix: Run render_structure recursively on "using" and "relskel"

### DIFF
--- a/core/render/json/default.py
+++ b/core/render/json/default.py
@@ -36,14 +36,11 @@ class DefaultRender(object):
     @staticmethod
     def render_structure(structure: dict):
         """
-        Performs structure rewrite according to compatibility flags.
+        Performs structure rewriting according to VIUR2/3 compatibility flags.
+        # fixme: Remove this entire function with VIUR4
         """
-        for i, struct in enumerate(structure.values()):
-            # Inject sortindex as additional bone ordering indicator
-            struct["sortindex"] = i
-
+        for struct in structure.values():
             # Optionally replace new-key by a copy of the value under the old-key
-            # fixme: Remove in VIUR4
             if "json.bone.structure.camelcasenames" in conf["viur.compatibility"]:
                 for find, replace in {
                     "boundslat": "boundsLat",
@@ -60,8 +57,12 @@ class DefaultRender(object):
                     if find in struct:
                         struct[replace] = struct[find]
 
+            # Call render_structure() recursively on "using" and "relskel" members.
+            for substruct in ("using", "relskel"):
+                if substruct in struct and struct[substruct]:
+                    struct[substruct] = DefaultRender.render_structure(struct[substruct])
+
         # Optionally return list of tuples instead of dict
-        # fixme: Remove in VIUR4
         if "json.bone.structure.keytuples" in conf["viur.compatibility"]:
             return [(key, struct) for key, struct in structure.items()]
 

--- a/core/skeleton.py
+++ b/core/skeleton.py
@@ -255,7 +255,10 @@ class SkeletonInstance:
         self.renderAccessedValues = {}
 
     def structure(self) -> dict:
-        return {key: bone.structure() for key, bone in self.items()}
+        return {
+            key: bone.structure() | {"sortindex": i}
+            for i, (key, bone) in enumerate(self.items())
+        }
 
     def __deepcopy__(self, memodict):
         res = self.clone()


### PR DESCRIPTION
"sortindex" is injected differently, and becomes general part of the skeleton structure dict.

This is a hotfix on #651 and improvement on #698.