### PR TITLE
fix: Use static handler "tree.simple.file" in File

### DIFF
--- a/core/modules/file.py
+++ b/core/modules/file.py
@@ -395,7 +395,8 @@ class File(Tree):
 
     handler = "tree.simple.file"
     adminInfo = {
-        "icon": "icon-file-system"
+        "icon": "icon-file-system",
+        "handler": handler,  # fixme: Use static handler; Remove with VIUR4!
     }
 
     blobCacheTime = 60 * 60 * 24  # Requests to file/download will be served with cache-control: public, max-age=blobCacheTime if set


### PR DESCRIPTION
This is a hotfix for 3.4.0 final, to stay compatible with older VI versions.

https://github.com/viur-framework/viur-vi/commit/a8a44003bd037e806a88da5bd693b8213633b79c fixes the same issue as well in `viur-vi`.