### PR TITLE
fix: SelectBone `defaultValue` type annotation

### DIFF
--- a/core/bones/select.py
+++ b/core/bones/select.py
@@ -1,5 +1,4 @@
 import enum
-import logging
 from collections import OrderedDict
 from numbers import Number
 from typing import Callable, Dict, List, Tuple, Union
@@ -17,8 +16,12 @@ class SelectBone(BaseBone):
     def __init__(
         self,
         *,
-        defaultValue: Union[None, Dict[str, Union[SelectBoneMultiple, SelectBoneValue]],
-                            SelectBoneMultiple, enum.Enum] = None,
+        defaultValue: Union[
+            SelectBoneValue,
+            Dict[str, Union[SelectBoneMultiple, SelectBoneValue]],
+            SelectBoneMultiple,
+            enum.Enum
+        ] = None,
         values: Union[Dict, List, Tuple, Callable, enum.EnumMeta] = (),
         **kwargs
     ):

--- a/core/bones/select.py
+++ b/core/bones/select.py
@@ -6,7 +6,7 @@ from typing import Callable, Dict, List, Tuple, Union
 from viur.core.bones.base import BaseBone, ReadFromClientError, ReadFromClientErrorSeverity
 from viur.core.i18n import translate
 
-SelectBoneValue = Union[str, Number]
+SelectBoneValue = Union[str, Number, enum.Enum]
 SelectBoneMultiple = List[SelectBoneValue]
 
 
@@ -18,9 +18,8 @@ class SelectBone(BaseBone):
         *,
         defaultValue: Union[
             SelectBoneValue,
-            Dict[str, Union[SelectBoneMultiple, SelectBoneValue]],
             SelectBoneMultiple,
-            enum.Enum
+            Dict[str, Union[SelectBoneMultiple, SelectBoneValue]],
         ] = None,
         values: Union[Dict, List, Tuple, Callable, enum.EnumMeta] = (),
         **kwargs


### PR DESCRIPTION
Fixes the type annotation to allow for `str` as well. Otherwise, the defaultValue parameter is highlighted as invalid with a setting like `SelectBone(values={"a": "A", "b": "B"}, defaultValue="a")`.