### PR TITLE
doc: Set language in readthedocs config and add jQuery

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -71,7 +71,7 @@ release = _version_module.__version__
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/docs/rtdtemplate/layout.html
+++ b/docs/rtdtemplate/layout.html
@@ -55,6 +55,7 @@
     <script src="{{ pathto('_static/js/html5shiv.min.js', 1) }}"></script>
   <![endif]-->
   {%- if not embedded %}
+    <script type="text/javascript" src="https://code.jquery.com/jquery-3.6.4.min.js"></script>
   {# XXX Sphinx 1.8.0 made this an external js-file, quick fix until we refactor the template to inherert more blocks directly from sphinx #}
     {% if sphinx_version >= "1.8.0" %}
       <script type="text/javascript" id="documentation_options" data-url_root="{{ url_root }}" src="{{ pathto('_static/documentation_options.js', 1) }}"></script>


### PR DESCRIPTION
Sphinx removed jQuery (https://github.com/sphinx-doc/sphinx/issues/9974), but our current theme requires it (otherwise the search and version selection doesn't work).

As quick & dirty solution I've added a jQuery import to our template. In the long term, we should bring our template up to date.

