### PR TITLE
fix: Check for "status" in `User.onEdited`

### DIFF
--- a/core/modules/user.py
+++ b/core/modules/user.py
@@ -949,7 +949,7 @@ class User(List):
     def onEdited(self, skel):
         super().onEdited(skel)
         # In case the user is set to inactive, kill all sessions
-        if skel["status"] < Status.ACTIVE.value:
+        if "status" in skel and skel["status"] < Status.ACTIVE.value:
             session.killSessionByUser(skel["key"])
 
     def onDeleted(self, skel):


### PR DESCRIPTION
This line previously failed when using a subSkel which does not contain the "status" bone.