### PR TITLE
fix: comparision in `SelectBone.singleValueFromClient`

### DIFF
--- a/core/bones/select.py
+++ b/core/bones/select.py
@@ -70,14 +70,10 @@ class SelectBone(BaseBone):
     def singleValueFromClient(self, value, skel, name, origData):
         if not str(value):
             return self.getEmptyValue(), [ReadFromClientError(ReadFromClientErrorSeverity.Empty, "No value selected")]
-        if isinstance(self._values, enum.EnumMeta):
-            try:
-                return self._values(value), None
-            except ValueError:
-                return self.getEmptyValue(), \
-                    [ReadFromClientError(ReadFromClientErrorSeverity.Invalid, "Invalid value selected")]
         for key in self.values.keys():
             if str(key) == str(value):
+                if isinstance(self._values, enum.EnumMeta):
+                    return self._values(key), None
                 return key, None
         return self.getEmptyValue(), [
             ReadFromClientError(ReadFromClientErrorSeverity.Invalid, "Invalid value selected")]


### PR DESCRIPTION
Compare the value in case of `Enum`-values as string too. The data we get from client are strings, these aren't equal to ints (like in the user status) and wouldn't be valid for this bone.

Replaces #725 