### PR TITLE
chore: Bump version 3.4.0, improved `getVersion`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 This file documents any relevant changes done to ViUR-core since version 3.0.0.
 
-## [3.4.0.rc2]
+## [3.4.0]
 
+- fix: SelectBone `defaultValue` type annotation (#719)
 - fix: comparison in `SelectBone.singleValueFromClient` (#726)
 - fix: Jinja rendering for SelectBones using Enums (#720)
 - fix: Use static handler "tree.simple.file" in File (#717)

--- a/core/render/vi/__init__.py
+++ b/core/render/vi/__init__.py
@@ -105,11 +105,19 @@ def getVersion(*args, **kwargs):
     Returns viur-core version number
     """
     current.request.get().response.headers["Content-Type"] = "application/json"
-    if conf["viur.instance.is_dev_server"] or current.user.get():
-        return json.dumps(conf["viur.version"])
 
-    # Hide patchlevel
-    return json.dumps((conf["viur.version"][0], conf["viur.version"][1], 0))
+    version = conf["viur.version"]
+
+    # always fill up to 4 parts
+    while len(version) < 4:
+        version += (None,)
+
+    if conf["viur.instance.is_dev_server"] \
+        or ((cuser := current.user.get()) and ("root" in cuser["access"] or "admin" in cuser["access"])):
+        return json.dumps(version[:4])
+
+    # Hide patch level + appendix to non-authorized users
+    return json.dumps((version[0], version[1], None, None))
 
 
 def canAccess(*args, **kwargs) -> bool:

--- a/core/version.py
+++ b/core/version.py
@@ -3,7 +3,7 @@
 # This will mark it as a pre-release as well on PyPI.
 # See CONTRIBUTING.md for further information.
 
-__version__ = "3.4.0.rc2"
+__version__ = "3.4.0"
 
 assert __version__.count(".") >= 2 and "".join(__version__.split(".", 3)[:3]).isdigit(), \
     "Semantic __version__ expected!"


### PR DESCRIPTION
This fixes #716 as proposed and finalizes v3.4.0