### PR TITLE
feat: Delete old pending `FileSkeletons`

### DIFF
--- a/core/modules/file.py
+++ b/core/modules/file.py
@@ -810,7 +810,7 @@ def doCleanupDeletedFiles(cursor=None):
 @PeriodicTask(60 * 4)
 def start_delete_pending_files():
     """
-    Start deletion of pending FileSkels that are older than 90 days.
+    Start deletion of pending FileSkels that are older than 7 days.
     """
     DeleteEntitiesIter.startIterOnQuery(
         FileBaseSkel().all()

--- a/core/modules/file.py
+++ b/core/modules/file.py
@@ -815,5 +815,5 @@ def start_delete_pending_files():
     DeleteEntitiesIter.startIterOnQuery(
         FileBaseSkel().all()
         .filter("pending =", True)
-        .filter("creationdate <", datetime.now() - timedelta(days=90))
+        .filter("creationdate <", datetime.now() - timedelta(days=7))
     )

--- a/core/modules/file.py
+++ b/core/modules/file.py
@@ -1,26 +1,28 @@
 import base64
 import email.header
-import google.auth
+import html
 import json
 import logging
 import string
-import html
-from PIL import Image, ImageCms
 from base64 import urlsafe_b64decode
 from datetime import datetime, timedelta
-from google.auth import compute_engine
-from google.auth.transport import requests
-from google.cloud import iam_credentials_v1, storage
-from google.oauth2.service_account import Credentials as ServiceAccountCredentials
 from io import BytesIO
 from quopri import decodestring
 from typing import Any, List, Tuple, Union
 from urllib.request import urlopen
-from viur.core import db, conf, errors, exposed, forcePost, forceSSL, securitykey, utils, current
+
+import google.auth
+from PIL import Image, ImageCms
+from google.auth import compute_engine
+from google.auth.transport import requests
+from google.cloud import iam_credentials_v1, storage
+from google.oauth2.service_account import Credentials as ServiceAccountCredentials
+
+from viur.core import conf, current, db, errors, exposed, forcePost, forceSSL, securitykey, utils
 from viur.core.bones import BaseBone, BooleanBone, KeyBone, NumericBone, StringBone
 from viur.core.prototypes.tree import SkelType, Tree, TreeSkel
 from viur.core.skeleton import SkeletonInstance, skeletonByKind
-from viur.core.tasks import PeriodicTask, CallDeferred
+from viur.core.tasks import CallDeferred, DeleteEntitiesIter, PeriodicTask
 from viur.core.utils import sanitizeFileName
 
 credentials, project = google.auth.default()
@@ -803,3 +805,15 @@ def doCleanupDeletedFiles(cursor=None):
     newCursor = query.getCursor()
     if newCursor:
         doCleanupDeletedFiles(newCursor)
+
+
+@PeriodicTask(60 * 4)
+def start_delete_pending_files():
+    """
+    Start deletion of pending FileSkels that are older than 90 days.
+    """
+    DeleteEntitiesIter.startIterOnQuery(
+        FileBaseSkel().all()
+        .filter("pending =", True)
+        .filter("creationdate <", datetime.now() - timedelta(days=90))
+    )

--- a/core/modules/file.py
+++ b/core/modules/file.py
@@ -815,5 +815,5 @@ def start_delete_pending_files():
     DeleteEntitiesIter.startIterOnQuery(
         FileBaseSkel().all()
         .filter("pending =", True)
-        .filter("creationdate <", datetime.now() - timedelta(days=7))
+        .filter("creationdate <", utils.utcNow() - timedelta(days=7))
     )

--- a/core/tasks.py
+++ b/core/tasks.py
@@ -2,18 +2,18 @@ import base64
 import json
 import logging
 import os
-import sys
 from datetime import datetime, timedelta
 from functools import wraps
-from time import sleep
 from typing import Any, Callable, Dict, Optional, Tuple
 
 import grpc
 import pytz
 import requests
+import sys
 from google.cloud import tasks_v2
 from google.cloud.tasks_v2.services.cloud_tasks.transports import CloudTasksGrpcTransport
 from google.protobuf import timestamp_pb2
+from time import sleep
 
 from viur.core import current, db, errors, utils
 from viur.core.config import conf
@@ -746,7 +746,7 @@ class QueryIter(object, metaclass=MetaQueryIter):
                         logging.exception(e)
                         doCont = False
                     if not doCont:
-                        logging.error("Exiting queryItor on cursor %s" % qry.getCursor())
+                        logging.error("Exiting queryIter on cursor %s" % qry.getCursor())
                         return
             qryDict["totalCount"] += 1
         cursor = qry.getCursor()
@@ -787,12 +787,18 @@ class QueryIter(object, metaclass=MetaQueryIter):
 
 class DeleteEntitiesIter(QueryIter):
     """
-        Simple Query-Iter to delete all entities encountered.
+    Simple Query-Iter to delete all entities encountered.
 
-        ..Warning: Do not use this iter on skeletons. It only works on the low-level db API and would not clear
-            relations, locks etc.
+    ..Warning: When iterating over skeletons, make sure that the
+        query was created using `Skeleton().all()`.
+        This way the `Skeleton.delete()` method can be used and
+        the appropriate post-processing can be done.
     """
 
     @classmethod
     def handleEntry(cls, entry, customData):
-        db.Delete(entry.key)
+        from viur.core.skeleton import SkeletonInstance
+        if isinstance(entry, SkeletonInstance):
+            entry.delete()
+        else:
+            db.Delete(entry.key)

--- a/core/tasks.py
+++ b/core/tasks.py
@@ -746,7 +746,7 @@ class QueryIter(object, metaclass=MetaQueryIter):
                         logging.exception(e)
                         doCont = False
                     if not doCont:
-                        logging.error("Exiting queryIter on cursor %s" % qry.getCursor())
+                        logging.error(f"Exiting queryIter on cursor {qry.getCursor()!r}")
                         return
             qryDict["totalCount"] += 1
         cursor = qry.getCursor()


### PR DESCRIPTION
Over time, pending FileSkeletons (datastore entities) can accumulate when upload urls have been requested but nothing has been uploaded. Therefore this adds the PeriodicTask `start_delete_pending_files` which deletes pending files older than 90 days.

To do the deletion safely on skeleton level a customization of the `DeleteEntitiesIter` was necessary. I see no reason not to use this for skeletons as long as you call the appropriate `.delete()` method.