### PR TITLE
Remove an `if`, otherwise the `else` case is missing and we have a path with `res = None`

### DIFF
--- a/core/request.py
+++ b/core/request.py
@@ -4,8 +4,6 @@ import os
 import traceback
 import typing
 from abc import ABC, abstractmethod
-from io import StringIO
-from string import Template
 from urllib import parse
 from urllib.parse import unquote, urljoin, urlparse
 
@@ -333,16 +331,15 @@ class BrowseHandler():  # webapp.RequestHandler
                     res = json.dumps(error_info)
                 else:  # We render the error in html
                     # Try to get the template from html/error/
-                    if isinstance(e, errors.HTTPException):
-                        if filename := conf["viur.mainApp"].render.getTemplateFileName((f"{e.status}", "error"),
-                                                                                       raise_exception=False):
-                            template = conf["viur.mainApp"].render.getEnv().get_template(filename)
-                            res = template.render(error_info)
+                    if filename := conf["viur.mainApp"].render.getTemplateFileName((f"{error_info['status']}", "error"),
+                                                                                   raise_exception=False):
+                        template = conf["viur.mainApp"].render.getEnv().get_template(filename)
+                        res = template.render(error_info)
 
-                            # fixme: this might be the viur/core/template/error.html ...
-                            extendCsp({"style-src": ['sha256-Lwf7c88gJwuw6L6p6ILPSs/+Ui7zCk8VaIvp8wLhQ4A=']})
-                        else:
-                            res = f"""<html><h1>{error_info["status"]} - {error_info["reason"]}"""
+                        # fixme: this might be the viur/core/template/error.html ...
+                        extendCsp({"style-src": ['sha256-Lwf7c88gJwuw6L6p6ILPSs/+Ui7zCk8VaIvp8wLhQ4A=']})
+                    else:
+                        res = f"""<html><h1>{error_info["status"]} - {error_info["reason"]}"""
 
             self.response.write(res.encode("UTF-8"))
 


### PR DESCRIPTION
This is a suggestion for #658 