### PR TITLE
fix: Add path_list to the __init__ of BrowseHandler

### DIFF
--- a/core/request.py
+++ b/core/request.py
@@ -1,17 +1,17 @@
 import json
 import logging
 import os
+import string
 import traceback
 import typing
+import unicodedata
 from abc import ABC, abstractmethod
-from io import StringIO
 from string import Template
+from time import time
 from urllib import parse
 from urllib.parse import unquote, urljoin, urlparse
 
-import unicodedata
 import webob
-from time import time
 
 from viur.core import current, db, errors, utils
 from viur.core.config import conf
@@ -549,7 +549,7 @@ class BrowseHandler():  # webapp.RequestHandler
             if part in caller:
                 caller = caller[part]
                 if (("exposed" in dir(caller) and caller.exposed) or
-                        ("internalExposed" in dir(caller) and caller.internalExposed and self.internalRequest)) and\
+                        ("internalExposed" in dir(caller) and caller.internalExposed and self.internalRequest)) and \
                         hasattr(caller, '__call__'):
                     if part == "index":
                         idx -= 1
@@ -565,7 +565,9 @@ class BrowseHandler():  # webapp.RequestHandler
                 break
 
         if not path_found:
-            raise errors.NotFound(f"""The path {"/".join(self.path_list[:idx]!a} could not be found""")
+            raise errors.NotFound("The path %s could not be found" % "/".join(
+                [("".join([char for char in part if char.lower() in string.ascii_lowercase + string.digits]))
+                 for part in self.path_list[: idx]]))
 
         if (not callable(caller) or ((not "exposed" in dir(caller) or not caller.exposed)) and (
             not "internalExposed" in dir(caller) or not caller.internalExposed or not self.internalRequest)):

--- a/core/request.py
+++ b/core/request.py
@@ -499,8 +499,7 @@ class BrowseHandler():  # webapp.RequestHandler
         # Parse the URL
         if path := parse.urlparse(path).path:
             self.path_list = tuple(unicodedata.normalize("NFC", parse.unquote(part))
-                                    for part in path.strip("/").split("/"))
-
+                                   for part in path.strip("/").split("/"))
 
         # Prevent Hash-collision attacks
         kwargs = {}

--- a/core/request.py
+++ b/core/request.py
@@ -566,7 +566,8 @@ class BrowseHandler():  # webapp.RequestHandler
 
         if not path_found:
             from viur.core import utils
-            raise errors.NotFound(f"""The path {utils.escapeString("/".join(self.path_list[:idx]))} could not be found""")
+            raise errors.NotFound(
+                f"""The path {utils.escapeString("/".join(self.path_list[:idx]))} could not be found""")
 
         if (not callable(caller) or ((not "exposed" in dir(caller) or not caller.exposed)) and (
             not "internalExposed" in dir(caller) or not caller.internalExposed or not self.internalRequest)):

--- a/core/request.py
+++ b/core/request.py
@@ -109,7 +109,7 @@ class BrowseHandler():  # webapp.RequestHandler
         self.maxLogLevel = logging.DEBUG
         self._traceID = request.headers.get('X-Cloud-Trace-Context', "").split("/")[0] or utils.generateRandomString()
         self.is_deferred = False
-        self.path_list = []
+        self.path_list = ()
         db.currentDbAccessLog.set(set())
 
     @property
@@ -499,7 +499,8 @@ class BrowseHandler():  # webapp.RequestHandler
         """
         # Parse the URL
         if path := parse.urlparse(path).path:
-            self.path_list = [unicodedata.normalize("NFC", parse.unquote(part)) for part in path.strip("/").split("/")]
+            self.path_list = tuple((unicodedata.normalize("NFC", parse.unquote(part))
+                                    for part in path.strip("/").split("/")))
 
         # Prevent Hash-collision attacks
         kwargs = {}
@@ -553,7 +554,7 @@ class BrowseHandler():  # webapp.RequestHandler
                         hasattr(caller, '__call__'):
                     if part == "index":
                         idx -= 1
-                    args = self.path_list[idx:] + list(args)  # Prepend the rest of Path to args
+                    args = self.path_list[idx:] + args  # Prepend the rest of Path to args
                     break
 
                 elif part == "index":

--- a/core/request.py
+++ b/core/request.py
@@ -1,7 +1,6 @@
 import json
 import logging
 import os
-import string
 import traceback
 import typing
 from abc import ABC, abstractmethod
@@ -311,7 +310,7 @@ class BrowseHandler():  # webapp.RequestHandler
                     res = None
             if not res:
                 descr = "The server encountered an unexpected error and is unable to process your request."
-                if (len(self.path_list) > 0 and any(x in self.path_list[0] for x in ["vi", "json"])) or \
+                if (len(self.path_list) > 0 and self.path_list[0] in ("vi", "json")) or \
                         current.request.get().response.headers["Content-Type"] == "application/json":
                     current.request.get().response.headers["Content-Type"] = "application/json"
                     if isinstance(e, errors.HTTPException):
@@ -541,7 +540,7 @@ class BrowseHandler():  # webapp.RequestHandler
             if "canAccess" in caller and not caller["canAccess"]():
                 # We have a canAccess function guarding that object,
                 # and it returns False...
-                raise (errors.Unauthorized())
+                raise errors.Unauthorized()
             idx += 1
             part = part.replace("-", "_").replace(".", "_")
             if part not in caller:
@@ -566,9 +565,7 @@ class BrowseHandler():  # webapp.RequestHandler
                 break
 
         if not path_found:
-            raise errors.NotFound("The path %s could not be found" % "/".join(
-                    [("".join([char for char in part if char.lower() in string.ascii_lowercase+string.digits]))
-                     for part in self.path_list[: idx]]))
+            raise errors.NotFound(f"""The path {"/".join(self.path_list[:idx]!a} could not be found""")
 
         if (not callable(caller) or ((not "exposed" in dir(caller) or not caller.exposed)) and (
             not "internalExposed" in dir(caller) or not caller.internalExposed or not self.internalRequest)):

--- a/core/request.py
+++ b/core/request.py
@@ -497,9 +497,8 @@ class BrowseHandler():  # webapp.RequestHandler
             to call (and with witch parameters)
         """
         # Parse the URL
-        path = parse.urlparse(path).path
-        if path:
-            self.path_list = [unicodedata.normalize("NFC", parse.unquote(x)) for x in path.strip("/").split("/")]
+        if path := parse.urlparse(path).path:
+            self.path_list = (unicodedata.normalize("NFC", parse.unquote(part)) for part in path.strip("/").split("/"))
 
         # Prevent Hash-collision attacks
         kwargs = {}
@@ -547,13 +546,13 @@ class BrowseHandler():  # webapp.RequestHandler
                 caller = caller[currpath]
                 if (("exposed" in dir(caller) and caller.exposed) or ("internalExposed" in dir(
                     caller) and caller.internalExposed and self.internalRequest)) and hasattr(caller, '__call__'):
-                    args = self.path_list[idx:] + [x for x in args]  # Prepend the rest of Path to args
+                    args = self.path_list[idx:] + args  # Prepend the rest of Path to args
                     break
             elif "index" in caller:
                 caller = caller["index"]
                 if (("exposed" in dir(caller) and caller.exposed) or ("internalExposed" in dir(
                     caller) and caller.internalExposed and self.internalRequest)) and hasattr(caller, '__call__'):
-                    args = self.path_list[idx - 1:] + [x for x in args]
+                    args = self.path_list[idx - 1:] + args
                     break
                 else:
                     raise (errors.NotFound("The path %s could not be found" % "/".join(


### PR DESCRIPTION
This PR add  the `path_list` to th init function and move the path validation to the start of `findAndCall`

Problem:
If we make a call with to many arguments a `BadRequest` error is raised befor the path is processed. And than this :
https://github.com/viur-framework/viur-core/blob/d405faae32dfa503ef786fad32e3c7bb483f51d0/core/request.py#L312
crashed with.
`AttributeError: 'BrowseHandler' object has no attribute 'pathlist'`