### PR TITLE
fix: Fixes TypeError when password is unset

### DIFF
--- a/core/modules/user.py
+++ b/core/modules/user.py
@@ -265,7 +265,7 @@ class UserPassword:
             skel.setEntity(user_entry)
             skel["key"] = user_entry.key
             skel["password"] = password  # will be hashed on serialize
-            skel.toDB(clearUpdateTag=True)
+            skel.toDB(update_relations=False)
 
         return self.userModule.continueAuthenticationFlow(self, user_entry.key)
 

--- a/core/modules/user.py
+++ b/core/modules/user.py
@@ -231,19 +231,19 @@ class UserPassword:
         res = query.filter("name.idx >=", name).getEntry()
 
         if res is None:
-            res = {"password": {"pwhash": "-invalid-", "salt": "-invalid-"}, "status": 0, "name": {}}
+            res = {"password": {}, "status": 0, "name": {}}
 
         password_data = res.get("password") or {}
         # old password hashes used 1001 iterations
         iterations = password_data.get("iterations", 1001)
-        passwd = encode_password(password, password_data.get("salt", ""), iterations)["pwhash"]
+        passwd = encode_password(password, password_data.get("salt", "-invalid-"), iterations)["pwhash"]
 
         # Check if the username matches
         stored_user_name = (res.get("name") or {}).get("idx", "")
         is_okay = secrets.compare_digest(stored_user_name, name)
 
         # Check if the password matches
-        stored_password_hash = password_data.get("pwhash", "-invalid-")
+        stored_password_hash = password_data.get("pwhash", b"-invalid-")
         is_okay &= secrets.compare_digest(stored_password_hash, passwd)
 
         accountStatus: Optional[int] = None


### PR DESCRIPTION
This is a hotfix for a TypeError which happens in case the password is not set or the user does not exist.

```
[2023-05-15 17:22:22,914] /.../viur/core/request.py:299 [ERROR] ViUR has caught an unhandled exception!
[2023-05-15 17:22:22,914] /.../viur/core/request.py:300 [ERROR] a bytes-like object is required, not 'str'
Traceback (most recent call last):
  File "/home/user/.local/share/virtualenvs/project-viur3/lib/python3.10/site-packages/viur/core/request.py", line 275, in processRequest
    self.findAndCall(path)
  File "/home/user/.local/share/virtualenvs/project-viur3/lib/python3.10/site-packages/viur/core/request.py", line 623, in findAndCall
    res = caller(*newArgs, **newKwargs)
  File "/home/user/.local/share/virtualenvs/project-viur3/lib/python3.10/site-packages/viur/core/modules/user.py", line 247, in login
    is_okay &= secrets.compare_digest(stored_password_hash, passwd)
TypeError: a bytes-like object is required, not 'str'
```