### PR TITLE
fix: `DateBone.fromClient()` should regard tzinfo

### DIFF
--- a/core/bones/date.py
+++ b/core/bones/date.py
@@ -112,8 +112,6 @@ class DateBone(BaseBone):
         elif not self.date and self.time:
             try:
                 value = datetime.fromisoformat(value)
-                if not self.naive:
-                    value = time_zone.localize(value)
             except:
                 try:
                     if str(rawValue).count(":") > 1:

--- a/core/bones/date.py
+++ b/core/bones/date.py
@@ -165,11 +165,12 @@ class DateBone(BaseBone):
                 except:
                     value = False  # its invalid
 
-        if value is False:
+        if not value:
             return self.getEmptyValue(), [
-                ReadFromClientError(ReadFromClientErrorSeverity.Invalid, "Invalid value entered")]
+                ReadFromClientError(ReadFromClientErrorSeverity.Invalid, "Invalid value entered")
+            ]
 
-        if value and not value.tzinfo and not self.naive:
+        if not value.tzinfo and not self.naive:
             value = time_zone.localize(value)
 
         value = value.replace(microsecond=0)

--- a/core/bones/date.py
+++ b/core/bones/date.py
@@ -166,15 +166,19 @@ class DateBone(BaseBone):
                             value = datetime.strptime(str(rawValue), "%d.%m.%Y")
                 except:
                     value = False  # its invalid
-            if value and not self.naive:
-                value = time_zone.localize(value)
+
         if value is False:
             return self.getEmptyValue(), [
                 ReadFromClientError(ReadFromClientErrorSeverity.Invalid, "Invalid value entered")]
+
+        if value and not value.tzinfo and not self.naive:
+            value = time_zone.localize(value)
+
         value = value.replace(microsecond=0)
-        err = self.isInvalid(value)
-        if err:
+
+        if err := self.isInvalid(value):
             return self.getEmptyValue(), [ReadFromClientError(ReadFromClientErrorSeverity.Invalid, err)]
+
         return value, None
 
     def isInvalid(self, value):

--- a/core/bones/date.py
+++ b/core/bones/date.py
@@ -169,7 +169,10 @@ class DateBone(BaseBone):
             return self.getEmptyValue(), [
                 ReadFromClientError(ReadFromClientErrorSeverity.Invalid, "Invalid value entered")
             ]
-
+        if value.tzinfo and self.naive:
+            return self.getEmptyValue(), [
+                ReadFromClientError(ReadFromClientErrorSeverity.Invalid, "Datetime must be naive")
+            ]
         if not value.tzinfo and not self.naive:
             value = time_zone.localize(value)
 


### PR DESCRIPTION
Hi there,

I came across this error with a project I'm porting from version 3.3.5 to 3.4. The `DateBone.fromClient()` function is called with a ISO-string `2023-02-20T12:26:01+01:00` and fails, because the timezone is already provided. 

Furthermore, the case with `now` was not part of the localization done below. The behavior is now corrected, the bug was introduced by #667.