### PR TITLE
feat/fix: Allow `duration` argument for skey

### DIFF
--- a/core/render/json/__init__.py
+++ b/core/render/json/__init__.py
@@ -18,6 +18,8 @@ def skey(duration: typing.Optional[int] = None, *args, **kwargs) -> str:
 
     See module securitykey for details.
     """
+    current.request.get().response.headers["Content-Type"] = "application/json"
+
     if duration is not None:
         if not current.user.get():
             raise errors.Unauthorized("Durations can only be used by authenticated users")

--- a/core/render/json/__init__.py
+++ b/core/render/json/__init__.py
@@ -1,7 +1,8 @@
 from .default import DefaultRender as default
 from .user import UserRender as user
 from viur.core import securitykey, current, errors, exposed
-import json, typing
+import json
+import typing
 
 __all__ = [default]
 

--- a/core/render/json/__init__.py
+++ b/core/render/json/__init__.py
@@ -8,7 +8,7 @@ __all__ = [default]
 
 
 @exposed
-def genSkey(duration: typing.Optional[int] = None, *args, **kwargs) -> str:
+def skey(duration: typing.Optional[int] = None, *args, **kwargs) -> str:
     """
     Creates or returns a valid skey.
 
@@ -29,5 +29,5 @@ def genSkey(duration: typing.Optional[int] = None, *args, **kwargs) -> str:
 
 
 def _postProcessAppObj(obj):  # Register our SKey function
-    obj["skey"] = genSkey
+    obj["skey"] = skey
     return obj

--- a/core/render/json/__init__.py
+++ b/core/render/json/__init__.py
@@ -1,14 +1,30 @@
 from .default import DefaultRender as default
 from .user import UserRender as user
-from viur.core import securitykey, exposed
-import json
+from viur.core import securitykey, current, errors, exposed
+import json, typing
 
 __all__ = [default]
 
 
 @exposed
-def genSkey(*args, **kwargs) -> str:
-    return json.dumps(securitykey.create())
+def genSkey(duration: typing.Optional[int] = None, *args, **kwargs) -> str:
+    """
+    Creates or returns a valid skey.
+
+    When a user is authenticated, a duration can be provided,
+    which returns a fresh, session-agnostic skey.
+    Otherwise, a session-based skey is returned.
+
+    See module securitykey for details.
+    """
+    if duration is not None:
+        if not current.user.get():
+            raise errors.Unauthorized("Durations can only be used by authenticated users")
+
+        if not 0 < duration <= 60:
+            raise errors.Forbidden("Invalid duration provided")
+
+    return json.dumps(securitykey.create(duration=duration))
 
 
 def _postProcessAppObj(obj):  # Register our SKey function

--- a/core/render/vi/__init__.py
+++ b/core/render/vi/__init__.py
@@ -1,5 +1,6 @@
 # noinspection PyUnresolvedReferences
 from viur.core.render.vi.user import UserRender as user  # this import must exist!
+from viur.core.render.json import skey
 from viur.core.render.json.default import DefaultRender, CustomJsonEncoder
 from viur.core.render.vi.user import UserRender as user
 from viur.core import Module, conf, current, exposed, securitykey, errors
@@ -13,12 +14,6 @@ class default(DefaultRender):
 
 
 __all__ = [default]
-
-
-@exposed
-def genSkey(*args, **kwargs):
-    current.request.get().response.headers["Content-Type"] = "application/json"
-    return json.dumps(securitykey.create())
 
 
 @exposed
@@ -167,7 +162,7 @@ def get_settings():
 
 
 def _postProcessAppObj(obj):
-    obj["skey"] = genSkey
+    obj["skey"] = skey
     obj["timestamp"] = timestamp
     obj["config"] = dumpConfig
     obj["settings"] = get_settings


### PR DESCRIPTION
Hello, this is both a feature containing a bugfix for the type annotation.
The feature is required for a current customer project. It is very restricted.

- Restricted possibility to generate a fresh, non-session skey with a duration between 1 and 60 seconds for authenticated users
- Fixing type hint parsing, which needs a general refactoring