### PR TITLE
fix: Move super-call in `JsonBone.__init__()` to the begin

### DIFF
--- a/core/bones/json.py
+++ b/core/bones/json.py
@@ -27,13 +27,13 @@ class JsonBone(RawBone):
     def __init__(self, indexed: bool = False, multiple: bool = False, languages: bool = None, schema: Mapping = {},
                  *args,
                  **kwargs):
+        super().__init__(*args, **kwargs)
         assert not multiple
         assert not languages
         assert not indexed
         # Validate the schema, if it's invalid a SchemaError will be raised
         jsonschema.validators.validator_for(False).check_schema(schema)
         self.schema = schema
-        super().__init__(*args, **kwargs)
 
     def serialize(self, skel: 'SkeletonInstance', name: str, parentIndexed: bool) -> bool:
         if name in skel.accessedValues:


### PR DESCRIPTION
Otherwise the schema assignment fails if you intialize a bone after the bone system has been initialized
```py
  File "/.../deploy/viur/core/bones/json.py", line 35, in __init__
    self.schema = schema
  File "/.../deploy/viur/core/bones/base.py", line 324, in __setattr__
    raise AttributeError("You cannot modify this Skeleton. Grab a copy using .clone() first")
AttributeError: You cannot modify this Skeleton. Grab a copy using .clone() first
```