### PR TITLE
fix: ensure the correct default defaultValue of a multiple/multi-lang `BooleanBone`

### DIFF
--- a/core/bones/boolean.py
+++ b/core/bones/boolean.py
@@ -1,6 +1,6 @@
 from viur.core.bones.base import BaseBone, ReadFromClientError, ReadFromClientErrorSeverity
 from viur.core import db, conf
-from typing import Dict, Optional, Any
+from typing import Dict, List, Optional, Any, Union
 
 
 class BooleanBone(BaseBone):
@@ -9,11 +9,25 @@ class BooleanBone(BaseBone):
     def __init__(
         self,
         *,
-        defaultValue: bool = False,
+        defaultValue: Union[
+            bool,
+            List[bool],
+            Dict[str, Union[List[bool], bool]],
+        ] = None,
         **kwargs
     ):
-        if defaultValue not in (True, False):
-            raise ValueError("Only 'True' or 'False' can be provided as BooleanBone defaultValue")
+        if defaultValue is None:
+            if kwargs.get("multiple") or kwargs.get("languages"):
+                # BaseBone's __init__ will choose an empty container for this
+                defaultValue = None
+            else:
+                # We have a single bone which is False
+                defaultValue = False
+        else:
+            # We have given an explicit defaultValue and maybe a complex structure
+            if not (kwargs.get("multiple") or kwargs.get("languages")) and not isinstance(defaultValue, bool):
+                raise TypeError("Only 'True' or 'False' can be provided as BooleanBone defaultValue")
+            # TODO: missing validation for complex types, but in other bones too
 
         super().__init__(defaultValue=defaultValue, **kwargs)
 


### PR DESCRIPTION
Otherwise the serialize fails with 
```
  File "/.../lib/python3.10/site-packages/viur/core/bones/base.py", line 461, in serialize
    if language in newVal:
TypeError: argument of type 'bool' is not iterable
```

because `newVal` is `False`.