### PR TITLE
fix: Missing german translation for "password too short" message

### DIFF
--- a/core/languages/de.py
+++ b/core/languages/de.py
@@ -351,5 +351,5 @@ de = {
     "core.bones.password.no_lowercase_letters": "Das eingegebene Passwort enthält keine Kleinbuchstaben.",
     "core.bones.password.no_digits": "Das eingegebene Passwort enthält keine Ziffern.",
     "core.bones.password.no_special_characters": "Das eingegebene Passwort enthält keine Sonderzeichen.",
-
+    "core.bones.password.too_short": "Das eingegebene Passwort ist zu kurz. Es benötigt mindestens 8 Zeichen.",
 }


### PR DESCRIPTION
The German translation of one "error"-Prompt for passwordBones was missing. Added it