### PR TITLE
feat: Rewrite of session-based securitykeys

### DIFF
--- a/core/modules/file.py
+++ b/core/modules/file.py
@@ -566,7 +566,7 @@ class File(Tree):
         else:
             size = None
 
-        if not securitykey.validate(skey, useSessionKey=True):
+        if not securitykey.validate(skey):
             raise errors.PreconditionFailed()
 
         targetKey, uploadUrl = self.initializeUpload(fileName, mimeType, node, size)
@@ -671,7 +671,7 @@ class File(Tree):
         if skelType == "leaf":  # We need to handle leafs separately here
             skey = kwargs.get("skey")
             targetKey = kwargs.get("key")
-            if not skey or not securitykey.validate(skey, useSessionKey=True) or not targetKey:
+            if not skey or not securitykey.validate(skey) or not targetKey:
                 raise errors.PreconditionFailed()
             skel = self.addSkel("leaf")
             if not skel.fromDB(targetKey):

--- a/core/modules/formmailer.py
+++ b/core/modules/formmailer.py
@@ -24,7 +24,7 @@ class Formmailer(Module):
         if not skel.fromClient(kwargs) or not "skey" in kwargs:
             return self.render.add(skel=skel, failed=True)
 
-        if not securitykey.validate(kwargs["skey"], useSessionKey=True):
+        if not securitykey.validate(kwargs["skey"]):
             raise errors.PreconditionFailed()
 
         # Allow bones to perform outstanding "magic" operations before sending the mail

--- a/core/modules/user.py
+++ b/core/modules/user.py
@@ -307,8 +307,7 @@ class UserPassword:
             del recoveryKey
             return self.pwrecover()  # Fall through to the second step as that key in the session is now set
         else:
-            if request.isPostRequest and kwargs.get("abort") == "1" \
-                and securitykey.validate(kwargs.get("skey")):
+            if request.isPostRequest and kwargs.get("abort") == "1" and securitykey.validate(kwargs.get("skey")):
                 # Allow a user to abort the process if a wrong email has been used
                 session["user.auth_userpassword.pwrecover"] = None
                 return self.pwrecover()

--- a/core/modules/user.py
+++ b/core/modules/user.py
@@ -391,7 +391,7 @@ class UserPassword:
 
     @exposed
     def verify(self, skey, *args, **kwargs):
-        data = securitykey.validate(skey, session=False)
+        data = securitykey.validate(skey, session_bound=False)
         skel = self.userModule.editSkel()
         if not data or not isinstance(data, dict) or "userKey" not in data or not skel.fromDB(
             data["userKey"].id_or_name):

--- a/core/modules/user.py
+++ b/core/modules/user.py
@@ -846,7 +846,7 @@ class User(List):
         # Update session, user and request
         session["user"] = skel.dbEntity
 
-        current.request.get().response.headers["Sec-X-ViUR-StaticSKey"] = session.static_security_key
+        current.request.get().response.headers[securitykey.SECURITYKEY_STATIC] = session.static_security_key
         current.user.set(self.getCurrentUser())
 
         self.onLogin(skel)

--- a/core/prototypes/list.py
+++ b/core/prototypes/list.py
@@ -86,12 +86,12 @@ class List(SkelModule):
 
             The function uses the viewTemplate of the application.
 
-            :returns: The rendered representation of the the supplied data.
+            :returns: The rendered representation of the supplied data.
         """
         if not self.canPreview():
             raise errors.Unauthorized()
 
-        if not securitykey.validate(skey, useSessionKey=True):
+        if not securitykey.validate(skey):
             raise errors.PreconditionFailed()
 
         skel = self.viewSkel()
@@ -211,7 +211,7 @@ class List(SkelModule):
         ):
             # render the skeleton in the version it could as far as it could be read.
             return self.render.edit(skel)
-        if not securitykey.validate(skey, useSessionKey=True):
+        if not securitykey.validate(skey):
             raise errors.PreconditionFailed()
 
         self.onEdit(skel)
@@ -247,7 +247,7 @@ class List(SkelModule):
         ):
             # render the skeleton in the version it could as far as it could be read.
             return self.render.add(skel)
-        if not securitykey.validate(skey, useSessionKey=True):
+        if not securitykey.validate(skey):
             raise errors.PreconditionFailed()
 
         self.onAdd(skel)
@@ -281,7 +281,7 @@ class List(SkelModule):
         if not self.canDelete(skel):
             raise errors.Unauthorized()
 
-        if not securitykey.validate(skey, useSessionKey=True):
+        if not securitykey.validate(skey):
             raise errors.PreconditionFailed()
 
         self.onDelete(skel)

--- a/core/prototypes/singleton.py
+++ b/core/prototypes/singleton.py
@@ -69,7 +69,7 @@ class Singleton(SkelModule):
         if not self.canPreview():
             raise errors.Unauthorized()
 
-        if not securitykey.validate(skey, useSessionKey=True):
+        if not securitykey.validate(skey):
             raise errors.PreconditionFailed()
 
         skel = self.viewSkel()
@@ -151,7 +151,7 @@ class Singleton(SkelModule):
             or ("bounce" in kwargs and kwargs["bounce"] == "1")):  # review before changing
             return self.render.edit(skel)
 
-        if not securitykey.validate(skey, useSessionKey=True):
+        if not securitykey.validate(skey):
             raise errors.PreconditionFailed()
 
         self.onEdit(skel)

--- a/core/prototypes/tree.py
+++ b/core/prototypes/tree.py
@@ -366,7 +366,7 @@ class Tree(SkelModule):
             or ("bounce" in kwargs and kwargs["bounce"] == "1")  # review before adding
         ):
             return self.render.add(skel)
-        if not securitykey.validate(skey, useSessionKey=True):
+        if not securitykey.validate(skey):
             raise errors.PreconditionFailed()
 
         self.onAdd(skelType, skel)
@@ -411,7 +411,7 @@ class Tree(SkelModule):
             or ("bounce" in kwargs and kwargs["bounce"] == "1")  # review before adding
         ):
             return self.render.edit(skel)
-        if not securitykey.validate(skey, useSessionKey=True):
+        if not securitykey.validate(skey):
             raise errors.PreconditionFailed()
         self.onEdit(skelType, skel)
         skel.toDB()
@@ -446,7 +446,7 @@ class Tree(SkelModule):
             raise errors.NotFound()
         if not self.canDelete(skelType, skel):
             raise errors.Unauthorized()
-        if not securitykey.validate(skey, useSessionKey=True):
+        if not securitykey.validate(skey):
             raise errors.PreconditionFailed()
         if skelType == "node":
             self.deleteRecursive(skel["key"])
@@ -481,7 +481,7 @@ class Tree(SkelModule):
     @exposed
     @forceSSL
     @forcePost
-    def move(self, skelType: SkelType, key: str, parentNode: str, *args, **kwargs) -> str:
+    def move(self, skelType: SkelType, key: str, parentNode: str, skey: str, *args, **kwargs) -> str:
         """
         Move a node (including its contents) or a leaf to another node.
 
@@ -490,6 +490,7 @@ class Tree(SkelModule):
         :param skelType: Defines the type of the entry that should be moved and may either be "node" or "leaf".
         :param key: URL-safe key of the item to be moved.
         :param parentNode: URL-safe key of the destination node, which must be a node.
+        :param skey: The CSRF security key.
 
         :returns: The rendered, edited object of the entry.
 
@@ -539,7 +540,7 @@ class Tree(SkelModule):
         if "rootNode" in tmp and tmp["rootNode"] == 1:
             raise errors.NotAcceptable("Can't move a rootNode to somewhere else")
 
-        if not securitykey.validate(kwargs.get("skey", ""), useSessionKey=True):
+        if not securitykey.validate(skey):
             raise errors.PreconditionFailed()
 
         currentParentRepo = skel["parentrepo"]

--- a/core/render/json/__init__.py
+++ b/core/render/json/__init__.py
@@ -2,13 +2,12 @@ from .default import DefaultRender as default
 from .user import UserRender as user
 from viur.core import securitykey, current, errors, exposed
 import json
-import typing
 
 __all__ = [default]
 
 
 @exposed
-def skey(duration: typing.Optional[int] = None, *args, **kwargs) -> str:
+def skey(duration: int = 60, *args, **kwargs) -> str:
     """
     Creates or returns a valid skey.
 
@@ -20,12 +19,8 @@ def skey(duration: typing.Optional[int] = None, *args, **kwargs) -> str:
     """
     current.request.get().response.headers["Content-Type"] = "application/json"
 
-    if duration is not None:
-        if not current.user.get():
-            raise errors.Unauthorized("Durations can only be used by authenticated users")
-
-        if not 0 < duration <= 60:
-            raise errors.Forbidden("Invalid duration provided")
+    if not 0 < duration <= 60:
+        raise errors.Forbidden("Invalid duration provided")
 
     return json.dumps(securitykey.create(duration=duration))
 

--- a/core/render/json/__init__.py
+++ b/core/render/json/__init__.py
@@ -7,22 +7,30 @@ __all__ = [default]
 
 
 @exposed
-def skey(duration: int = 60, *args, **kwargs) -> str:
+def skey(amount: int = 1, *args, **kwargs) -> str:
     """
-    Creates or returns a valid skey.
+    Creates CSRF-security-keys for transactions.
 
-    When a user is authenticated, a duration can be provided,
-    which returns a fresh, session-agnostic skey.
-    Otherwise, a session-based skey is returned.
+    All returned keys are associated with the session, therefore they cannot be used across sessions.
+    The keys get a maximum lifetime of the session lifetime, afterward they become invalid.
+
+    :param amount: Optional amount of securitykeys to create in a batch.
+        `amount > 1` can only be used by authenticated users, for a maximum of 100 keys.
 
     See module securitykey for details.
     """
     current.request.get().response.headers["Content-Type"] = "application/json"
 
-    if not 0 < duration <= 60:
+    if amount == 1:
+        return json.dumps(securitykey.create())
+
+    if not 0 < amount <= 100:
         raise errors.Forbidden("Invalid duration provided")
 
-    return json.dumps(securitykey.create(duration=duration))
+    if not current.user.get():
+        raise errors.Forbidden("Batch securitykey creation is only available to authenticated users")
+
+    return json.dumps([securitykey.create() for _ in range(amount)])
 
 
 def _postProcessAppObj(obj):  # Register our SKey function

--- a/core/render/json/__init__.py
+++ b/core/render/json/__init__.py
@@ -25,7 +25,7 @@ def skey(amount: int = 1, *args, **kwargs) -> str:
         return json.dumps(securitykey.create())
 
     if not 0 < amount <= 100:
-        raise errors.Forbidden("Invalid duration provided")
+        raise errors.Forbidden("Invalid amount provided")
 
     if not current.user.get():
         raise errors.Forbidden("Batch securitykey creation is only available to authenticated users")

--- a/core/securitykey.py
+++ b/core/securitykey.py
@@ -114,6 +114,7 @@ def periodic_clear_skeys():
     query = db.Query(SECURITYKEY_KINDNAME).filter("viur_until <", utils.utcNow() - datetime.timedelta(seconds=300))
     DeleteEntitiesIter.startIterOnQuery(query)
 
+
 @tasks.CallDeferred
 def clear_session_skeys(session_key):
     """

--- a/core/session.py
+++ b/core/session.py
@@ -32,11 +32,11 @@ class Session:
 
         - :prop:same_site can be set to None, "none", "lax" or "strict" to influence the same-site tag on the cookies
             we set
-        - :prop:is_session_cookie is set to True by default, causing the cookie to be treated as a session cookie
+        - :prop:use_session_cookie is set to True by default, causing the cookie to be treated as a session cookie
             (it will be deleted on browser close). If set to False, it will be emitted with the life-time in
             conf["viur.session.lifeTime"].
         - The config variable conf["viur.session.lifeTime"]: Determines, how ling (in Minutes) a session stays valid.
-            Even if :prop:is_session_cookie is set to True, we'll void a session server-side after no request has been
+            Even if :prop:use_session_cookie is set to True, we'll void a session server-side after no request has been
             made within said lifeTime.
         - The config variables conf["viur.session.persistentFieldsOnLogin"] and
             conf["viur.session.persistentFieldsOnLogout"] lists fields, that may survive a login/logout action.
@@ -47,7 +47,7 @@ class Session:
     """
     kindName = "viur-session"
     same_site = "lax"  # Either None (don't issue same_site header), "none", "lax" or "strict"
-    is_session_cookie = True  # If True, issue the cookie without a lifeTime (will disappear on browser close)
+    use_session_cookie = True  # If True, issue the cookie without a lifeTime (will disappear on browser close)
     cookie_name = f"""viur_cookie_{conf["viur.instance.project_id"]}"""
     GUEST_USER = "__guest__"
 
@@ -119,7 +119,7 @@ class Session:
             "HttpOnly",
             f"SameSite={self.same_site}" if self.same_site else None,
             "Secure" if not conf["viur.instance.is_dev_server"] else None,
-            f"Max-Age={conf['viur.session.lifeTime']}" if not self.is_session_cookie else None,
+            f"Max-Age={conf['viur.session.lifeTime']}" if not self.use_session_cookie else None,
         )
 
         req.response.headerlist.append(

--- a/core/session.py
+++ b/core/session.py
@@ -208,12 +208,6 @@ class Session:
         """
         return self.session.items()
 
-    def validateStaticSecurityKey(self, key: str) -> bool:
-        """
-        Checks if key matches the current *static* CSRF-Token of our session.
-        """
-        return hmac.compare_digest(self.static_security_key, key)
-
 
 @tasks.CallDeferred
 def killSessionByUser(user: Optional[Union[str, db.Key]] = None):

--- a/core/session.py
+++ b/core/session.py
@@ -65,13 +65,14 @@ class Session:
             If the client supplied a valid Cookie, the session is read from the datastore, otherwise a new,
             empty session will be initialized.
         """
-        if self.cookie_key := str(req.request.cookies.get(self.cookie_name)):
-            if data := db.Get(db.Key(self.kindName, self.cookie_key)):  # Loaded successfully
+        if cookie_key := str(req.request.cookies.get(self.cookie_name)):
+            if data := db.Get(db.Key(self.kindName, cookie_key)):  # Loaded successfully
                 if data["lastseen"] < time.time() - conf["viur.session.lifeTime"]:
                     # This session is too old
                     self.reset()
                     return False
 
+                self.cookie_key = cookie_key
                 self.session = data["data"]
                 self.static_security_key = data["static_security_key"]
 

--- a/core/session.py
+++ b/core/session.py
@@ -35,9 +35,9 @@ class Session:
         - :prop:use_session_cookie is set to True by default, causing the cookie to be treated as a session cookie
             (it will be deleted on browser close). If set to False, it will be emitted with the life-time in
             conf["viur.session.lifeTime"].
-        - The config variable conf["viur.session.lifeTime"]: Determines, how ling (in Minutes) a session stays valid.
-            Even if :prop:use_session_cookie is set to True, we'll void a session server-side after no request has been
-            made within said lifeTime.
+        - The config variable conf["viur.session.lifeTime"]: Determines, how long (in seconds) a session is valid.
+            Even if :prop:use_session_cookie is set to True, the session is voided server-side after no request has been
+            made within the configured lifetime.
         - The config variables conf["viur.session.persistentFieldsOnLogin"] and
             conf["viur.session.persistentFieldsOnLogout"] lists fields, that may survive a login/logout action.
             For security reasons, we completely destroy a session on login/logout (it will be deleted, a new empty

--- a/core/session.py
+++ b/core/session.py
@@ -36,15 +36,14 @@ class Session:
             (it will be deleted on browser close). If set to False, it will be emitted with the life-time in
             conf["viur.session.lifeTime"].
         - The config variable conf["viur.session.lifeTime"]: Determines, how ling (in Minutes) a session stays valid.
-            Even if :prop:is_session_cookie is set to True, we'll void a session server-side after no request has been made
-            within said lifeTime.
+            Even if :prop:is_session_cookie is set to True, we'll void a session server-side after no request has been
+            made within said lifeTime.
         - The config variables conf["viur.session.persistentFieldsOnLogin"] and
             conf["viur.session.persistentFieldsOnLogout"] lists fields, that may survive a login/logout action.
             For security reasons, we completely destroy a session on login/logout (it will be deleted, a new empty
             database object will be created and a new cookie with a different key is sent to the browser). This causes
             all data currently stored to be lost. Only keys listed in these variables will be copied into the new
             session.
-
     """
     kindName = "viur-session"
     same_site = "lax"  # Either None (don't issue same_site header), "none", "lax" or "strict"

--- a/core/session.py
+++ b/core/session.py
@@ -65,9 +65,8 @@ class Session:
             If the client supplied a valid Cookie, the session is read from the datastore, otherwise a new,
             empty session will be initialized.
         """
-        if self.cookie_name in req.request.cookies:
-            cookie = str(req.request.cookies[self.cookie_name])
-            if data := db.Get(db.Key(self.kindName, cookie)):  # Loaded successfully
+        if self.cookie_key := str(req.request.cookies.get(self.cookie_name)):
+            if data := db.Get(db.Key(self.kindName, self.cookie_key)):  # Loaded successfully
                 if data["lastseen"] < time.time() - conf["viur.session.lifeTime"]:
                     # This session is too old
                     self.reset()
@@ -75,7 +74,6 @@ class Session:
 
                 self.session = data["data"]
                 self.static_security_key = data["static_security_key"]
-                self.cookie_key = cookie
 
                 if data["lastseen"] < time.time() - 5 * 60:  # Refresh every 5 Minutes
                     self.changed = True

--- a/core/tasks.py
+++ b/core/tasks.py
@@ -371,7 +371,7 @@ class TaskHandler:
         skey = kwargs.get("skey", "")
         if len(kwargs) == 0 or not skel.fromClient(kwargs) or kwargs.get("bounce") == "1":
             return self.render.add(skel)
-        if not securitykey.validate(skey, useSessionKey=True):
+        if not securitykey.validate(skey):
             raise errors.PreconditionFailed()
         task.execute(**skel.accessedValues)
         return self.render.addSuccess(skel)


### PR DESCRIPTION
This is a draft for solving the problem of one session-based securitykey, making multiple requests in parallel impossible. This pull request partly replaces #704.

**Features:**
- a new securitykey is created every time it is requested
- securitykeys are bound to a session, if `session`-flag is True (default)
- unused securitykeys from a session are either being dropped on session kill, or when they became invalid
- Entire code refactoring for both securitykey and session module
- `/json/skey' accepts `amount`-flag for batch-mode skey requesting (decreases amount of requests)
