### PR TITLE
chore: Reject pointless `BooleanBone(multiple=True)`

### DIFF
--- a/core/bones/boolean.py
+++ b/core/bones/boolean.py
@@ -4,6 +4,15 @@ from typing import Dict, List, Optional, Any, Union
 
 
 class BooleanBone(BaseBone):
+    """
+    Represents a boolean data type, which can have two possible values: `True` or `False`.
+
+    BooleanBones cannot be defined as `multiple=True`.
+
+    :param defaultValue: The default value of the `BooleanBone` instance. Defaults to `False`.
+    :type defaultValue: bool
+    :raises ValueError: If the `defaultValue` is not a boolean value (`True` or `False`).
+    """
     type = "bool"
 
     def __init__(
@@ -30,6 +39,10 @@ class BooleanBone(BaseBone):
             # TODO: missing validation for complex types, but in other bones too
 
         super().__init__(defaultValue=defaultValue, **kwargs)
+
+        # Disallow creation of BooleanBone(multiple=True)
+        if self.multiple:
+            raise ValueError("BooleanBone cannot be multiple")
 
     def singleValueFromClient(self, value, skel: 'viur.core.skeleton.SkeletonInstance', name: str, origData):
         return str(value).strip().lower() in conf["viur.bone.boolean.str2true"], None

--- a/core/bones/credential.py
+++ b/core/bones/credential.py
@@ -19,7 +19,7 @@ class CredentialBone(StringBone):
     ):
         super().__init__(maxLength=maxLength, **kwargs)
         if self.multiple or self.languages:
-            raise ValueError("Credential-Bones cannot be multiple or translated!")
+            raise ValueError("CredentialBone cannot be multiple or translated")
 
     def isInvalid(self, value):
         """


### PR DESCRIPTION
This PR disallows construction of  `BooleanBone(multiple=True)`, which is pointless.