### PR TITLE
docs(build): set sphinx to an older version (as in the Pipfile) to get the build working again

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
-sphinx-autoapi
-sphinx-autodoc-typehints
+sphinx-autoapi==2.1.1
+sphinx-autodoc-typehints==1.23.0
+sphinx===6.2.1


### PR DESCRIPTION
The latest [develop build](https://readthedocs.org/projects/viur-core/builds/21251720/) failed

<details>
  <summary><code>develop</code> build log</summary>

```
Read the Docs build information
Build id: 21251720
Project: viur-core
Version: develop
Commit: 49e453e1dbee13855bc7ed9406e4f325be7fb163
Date: 2023-07-10T09:32:49.138180Z
State: finished
Success: False


[rtd-command-info] start-time: 2023-07-10T09:32:55.640440Z, end-time: 2023-07-10T09:32:59.115929Z, duration: 3, exit-code: 0
git clone --no-single-branch --depth 50 https://github.com/viur-framework/viur-core.git .
Cloning into '.'...

[rtd-command-info] start-time: 2023-07-10T09:32:59.870436Z, end-time: 2023-07-10T09:33:00.005290Z, duration: 0, exit-code: 0
git checkout --force origin/develop
Note: switching to 'origin/develop'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by switching back to a branch.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -c with the switch command. Example:

git switch -c <new-branch-name>

Or undo this operation with:

git switch -

Turn off this advice by setting config variable advice.detachedHead to false

HEAD is now at 49e453e feat: Add `compute`-feature to `BaseBone` (#639)

[rtd-command-info] start-time: 2023-07-10T09:33:00.412074Z, end-time: 2023-07-10T09:33:00.474452Z, duration: 0, exit-code: 0
git clean -d -f -f


[rtd-command-info] start-time: 2023-07-10T09:33:01.442811Z, end-time: 2023-07-10T09:33:01.529820Z, duration: 0, exit-code: 0
cat .readthedocs.yml
# [...]


[rtd-command-info] start-time: 2023-07-10T09:33:09.181839Z, end-time: 2023-07-10T09:33:09.276992Z, duration: 0, exit-code: 0
asdf global python 3.10.12


[rtd-command-info] start-time: 2023-07-10T09:33:09.994041Z, end-time: 2023-07-10T09:33:11.044669Z, duration: 1, exit-code: 0
python -mvirtualenv $READTHEDOCS_VIRTUALENV_PATH
created virtual environment CPython3.10.12.final.0-64 in 711ms
# [...]

Successfully installed PyYAML-6.0 anyascii-0.3.2 astroid-2.15.6 lazy-object-proxy-1.9.0 sphinx-7.0.1 sphinx-autoapi-2.1.1 sphinx-autodoc-typehints-1.23.3 typing-extensions-4.7.1 wrapt-1.15.0

[rtd-command-info] start-time: 2023-07-10T09:33:40.122587Z, end-time: 2023-07-10T09:33:40.188527Z, duration: 0, exit-code: 0
cat docs/conf.py
# This file is execfile()d with the current directory set to its
# [...]


[rtd-command-info] start-time: 2023-07-10T09:33:40.602691Z, end-time: 2023-07-10T09:33:57.406097Z, duration: 16, exit-code: 2
python -m sphinx -T -E -b html -d _build/doctrees -D language=en . $READTHEDOCS_OUTPUT/html
Running Sphinx v7.0.1
# [...]


[autosummary] generating autosummary for: doc_guide/05_implementation_consistency.rst, doc_guide/10_implementation_relations.rst, doc_guide/15_implementation_randomSliceBone.rst, doc_guide/20_implementation_spatialBone.rst, doc_guide/index.rst, doc_start/05_intro.rst, doc_start/10_start.rst, doc_start/15_basics.rst, doc_start/20_troubleshooting.rst, doc_start/25_gcloud.rst, ..., doc_tutorial/advanced/15_training_tasks.rst, doc_tutorial/advanced/index.rst, doc_tutorial/advanced/training_seo.rst, doc_tutorial/basic/05_training_modulemng.rst, doc_tutorial/basic/10_training_datamng.rst, doc_tutorial/basic/15_enable_google_login.rst, doc_tutorial/basic/index.rst, doc_tutorial/basic/viur_on_windows.rst, doc_tutorial/index.rst, index.rst
# [...]
pickling environment... done
checking consistency... done
preparing documents... done
writing output... [  0%] autoapi/core/bones/base/index
/home/docs/checkouts/readthedocs.org/user_builds/viur-core/checkouts/develop/docs/autoapi/core/bones/base/index.rst:128: WARNING: more than one target found for cross-reference 'List': core.prototypes.List, core.prototypes.list.List
/home/docs/checkouts/readthedocs.org/user_builds/viur-core/checkouts/develop/docs/autoapi/core/bones/base/index.rst:134: WARNING: more than one target found for cross-reference 'List': core.prototypes.List, core.prototypes.list.List
/home/docs/checkouts/readthedocs.org/user_builds/viur-core/checkouts/develop/docs/autoapi/core/bones/base/index.rst:292: WARNING: more than one target found for cross-reference 'List': core.prototypes.List, core.prototypes.list.List
/home/docs/checkouts/readthedocs.org/user_builds/viur-core/checkouts/develop/docs/autoapi/core/bones/base/index.rst:292: WARNING: more than one target found for cross-reference 'List': core.prototypes.List, core.prototypes.list.List
/home/docs/checkouts/readthedocs.org/user_builds/viur-core/checkouts/develop/docs/autoapi/core/bones/base/index.rst:427: WARNING: more than one target found for cross-reference 'List': core.prototypes.List, core.prototypes.list.List
/home/docs/checkouts/readthedocs.org/user_builds/viur-core/checkouts/develop/docs/autoapi/core/bones/base/index.rst:441: WARNING: more than one target found for cross-reference 'List': core.prototypes.List, core.prototypes.list.List
/home/docs/checkouts/readthedocs.org/user_builds/viur-core/checkouts/develop/docs/autoapi/core/bones/base/index.rst:527: WARNING: more than one target found for cross-reference 'List': core.prototypes.List, core.prototypes.list.List
/home/docs/checkouts/readthedocs.org/user_builds/viur-core/checkouts/develop/docs/autoapi/core/bones/base/index.rst:541: WARNING: more than one target found for cross-reference 'List': core.prototypes.List, core.prototypes.list.List

Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/viur-core/envs/develop/lib/python3.10/site-packages/sphinx/builders/html/__init__.py", line 1093, in handle_page
	output = self.templates.render(templatename, ctx)
  File "/home/docs/checkouts/readthedocs.org/user_builds/viur-core/envs/develop/lib/python3.10/site-packages/readthedocs_ext/readthedocs.py", line 181, in rtd_render
	content = old_render(template, render_context)
  File "/home/docs/checkouts/readthedocs.org/user_builds/viur-core/envs/develop/lib/python3.10/site-packages/sphinx/jinja2glue.py", line 196, in render
	return self.environment.get_template(template).render(context)
  File "/home/docs/checkouts/readthedocs.org/user_builds/viur-core/envs/develop/lib/python3.10/site-packages/jinja2/environment.py", line 1301, in render
	self.environment.handle_exception()
  File "/home/docs/checkouts/readthedocs.org/user_builds/viur-core/envs/develop/lib/python3.10/site-packages/jinja2/environment.py", line 936, in handle_exception
	raise rewrite_traceback_stack(source=source)
  File "/home/docs/checkouts/readthedocs.org/user_builds/viur-core/envs/develop/lib/python3.10/site-packages/sphinx/themes/basic/page.html", line 10, in top-level template code
	{%- extends "layout.html" %}
  File "/home/docs/checkouts/readthedocs.org/user_builds/viur-core/checkouts/develop/docs/rtdtemplate/layout.html", line 23, in top-level template code
	<link rel="stylesheet" href="{{ pathto('_static/' + style, 1) }}" type="text/css" />
jinja2.exceptions.UndefinedError: 'style' is undefined

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/viur-core/envs/develop/lib/python3.10/site-packages/sphinx/cmd/build.py", line 285, in build_main
	app.build(args.force_all, args.filenames)
  File "/home/docs/checkouts/readthedocs.org/user_builds/viur-core/envs/develop/lib/python3.10/site-packages/sphinx/application.py", line 351, in build
	self.builder.build_update()
  File "/home/docs/checkouts/readthedocs.org/user_builds/viur-core/envs/develop/lib/python3.10/site-packages/sphinx/builders/__init__.py", line 294, in build_update
	self.build(to_build,
  File "/home/docs/checkouts/readthedocs.org/user_builds/viur-core/envs/develop/lib/python3.10/site-packages/sphinx/builders/__init__.py", line 361, in build
	self.write(docnames, list(updated_docnames), method)
  File "/home/docs/checkouts/readthedocs.org/user_builds/viur-core/envs/develop/lib/python3.10/site-packages/sphinx/builders/__init__.py", line 569, in write
	self._write_serial(sorted(docnames))
  File "/home/docs/checkouts/readthedocs.org/user_builds/viur-core/envs/develop/lib/python3.10/site-packages/sphinx/builders/__init__.py", line 579, in _write_serial
	self.write_doc(docname, doctree)
  File "/home/docs/checkouts/readthedocs.org/user_builds/viur-core/envs/develop/lib/python3.10/site-packages/sphinx/builders/html/__init__.py", line 667, in write_doc
	self.handle_page(docname, ctx, event_arg=doctree)
  File "/home/docs/checkouts/readthedocs.org/user_builds/viur-core/envs/develop/lib/python3.10/site-packages/sphinx/builders/html/__init__.py", line 1100, in handle_page
	raise ThemeError(__("An error happened in rendering the page %s.\nReason: %r") %
sphinx.errors.ThemeError: An error happened in rendering the page autoapi/core/bones/base/index.
Reason: UndefinedError("'style' is undefined")

Theme error:
An error happened in rendering the page autoapi/core/bones/base/index.
Reason: UndefinedError("'style' is undefined")
```

</details>

This [branch was successful](https://readthedocs.org/projects/viur-core/builds/21275666/):
<details>
  <summary><code>hotfix/rdt_deps</code> build log</summary>

```
Read the Docs build information
Build id: 21275666
Project: viur-core
Version: hotfix/rdt_deps
Commit: 82ea85eaa978ab8354f50d541f6032ecf1c5c76a
Date: 2023-07-12T09:27:14.730028Z
State: finished
Success: True


[rtd-command-info] start-time: 2023-07-12T09:27:19.156450Z, end-time: 2023-07-12T09:27:22.628713Z, duration: 3, exit-code: 0
git clone --no-single-branch --depth 50 https://github.com/viur-framework/viur-core.git .
Cloning into '.'...

[rtd-command-info] start-time: 2023-07-12T09:27:23.124459Z, end-time: 2023-07-12T09:27:23.274441Z, duration: 0, exit-code: 0
git checkout --force origin/hotfix/rdt_deps
Note: switching to 'origin/hotfix/rdt_deps'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by switching back to a branch.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -c with the switch command. Example:

  git switch -c <new-branch-name>

Or undo this operation with:

  git switch -

Turn off this advice by setting config variable advice.detachedHead to false

HEAD is now at 82ea85e docs(build): set sphinx to an older version (as in the Pipfile) to get the build working again

[rtd-command-info] start-time: 2023-07-12T09:27:23.530262Z, end-time: 2023-07-12T09:27:23.593194Z, duration: 0, exit-code: 0
git clean -d -f -f


[rtd-command-info] start-time: 2023-07-12T09:27:24.051632Z, end-time: 2023-07-12T09:27:24.111126Z, duration: 0, exit-code: 0
cat .readthedocs.yml
# [...]


[rtd-command-info] start-time: 2023-07-12T09:27:30.316016Z, end-time: 2023-07-12T09:27:30.400223Z, duration: 0, exit-code: 0
asdf global python 3.10.12



# [...]

[rtd-command-info] start-time: 2023-07-12T09:27:56.507517Z, end-time: 2023-07-12T09:28:20.359819Z, duration: 23, exit-code: 0
python -m sphinx -T -E -b html -d _build/doctrees -D language=en . $READTHEDOCS_OUTPUT/html
Running Sphinx v6.2.1
# [...]


copying static files... done
copying extra files... done
dumping search index in English (code: en)... done
dumping object inventory... done
Updating searchtools for Read the Docs search... build succeeded, 227 warnings.

The HTML pages are in ../_readthedocs/html.
```

</details>
