### PR TITLE
feat: Compute `creationdate` and `changedate` with the new `compute`-feature

### DIFF
--- a/core/skeleton.py
+++ b/core/skeleton.py
@@ -13,6 +13,7 @@ from typing import Any, Callable, Dict, Iterable, List, Optional, Set, Tuple, Ty
 from viur.core import conf, db, email, errors, utils, current
 from viur.core.bones import BaseBone, DateBone, KeyBone, RelationalBone, RelationalUpdateLevel, SelectBone, StringBone
 from viur.core.bones.base import ReadFromClientError, ReadFromClientErrorSeverity, getSystemInitialized
+from viur.core.bones.base import Compute, ComputeMethod, ComputeInterval
 from viur.core.tasks import CallableTask, CallableTaskBase, QueryIter, CallDeferred
 
 _undefined = object()
@@ -647,17 +648,18 @@ class Skeleton(BaseSkeleton, metaclass=MetaSkel):
         descr="created at",
         readOnly=True,
         visible=False,
-        creationMagic=True,
         indexed=True,
+        compute=Compute(fn=utils.utcNow, interval=ComputeInterval(ComputeMethod.Once)),
     )
 
     # The last date (including time) when this entry has been updated
+
     changedate = DateBone(
         descr="updated at",
         readOnly=True,
         visible=False,
-        updateMagic=True,
         indexed=True,
+        compute=Compute(fn=utils.utcNow, interval=ComputeInterval(ComputeMethod.OnWrite)),
     )
 
     viurCurrentSeoKeys = seoKeyBone(descr="Seo-Keys",

--- a/core/skeleton.py
+++ b/core/skeleton.py
@@ -122,10 +122,6 @@ def iterAllSkelClasses() -> Iterable["Skeleton"]:
         yield cls
 
 
-def get_current_time():
-    return utils.utcNow().replace(microsecond=0)
-
-
 class SkeletonInstance:
     """
         The actual wrapper around a Skeleton-Class. An object of this class is what's actually returned when you
@@ -654,7 +650,7 @@ class Skeleton(BaseSkeleton, metaclass=MetaSkel):
         readOnly=True,
         visible=False,
         indexed=True,
-        compute=Compute(fn=get_current_time, interval=ComputeInterval(ComputeMethod.Once)),
+        compute=Compute(fn=utils.utcNow, interval=ComputeInterval(ComputeMethod.Once)),
     )
 
     # The last date (including time) when this entry has been updated
@@ -664,7 +660,7 @@ class Skeleton(BaseSkeleton, metaclass=MetaSkel):
         readOnly=True,
         visible=False,
         indexed=True,
-        compute=Compute(fn=get_current_time, interval=ComputeInterval(ComputeMethod.OnWrite)),
+        compute=Compute(fn=utils.utcNow, interval=ComputeInterval(ComputeMethod.OnWrite)),
     )
 
     viurCurrentSeoKeys = seoKeyBone(descr="Seo-Keys",

--- a/core/skeleton.py
+++ b/core/skeleton.py
@@ -121,6 +121,10 @@ def iterAllSkelClasses() -> Iterable["Skeleton"]:
         yield cls
 
 
+def get_current_time():
+    return utils.utcNow().replace(microsecond=0)
+
+
 class SkeletonInstance:
     """
         The actual wrapper around a Skeleton-Class. An object of this class is what's actually returned when you
@@ -649,7 +653,7 @@ class Skeleton(BaseSkeleton, metaclass=MetaSkel):
         readOnly=True,
         visible=False,
         indexed=True,
-        compute=Compute(fn=utils.utcNow, interval=ComputeInterval(ComputeMethod.Once)),
+        compute=Compute(fn=get_current_time, interval=ComputeInterval(ComputeMethod.Once)),
     )
 
     # The last date (including time) when this entry has been updated
@@ -659,7 +663,7 @@ class Skeleton(BaseSkeleton, metaclass=MetaSkel):
         readOnly=True,
         visible=False,
         indexed=True,
-        compute=Compute(fn=utils.utcNow, interval=ComputeInterval(ComputeMethod.OnWrite)),
+        compute=Compute(fn=get_current_time, interval=ComputeInterval(ComputeMethod.OnWrite)),
     )
 
     viurCurrentSeoKeys = seoKeyBone(descr="Seo-Keys",


### PR DESCRIPTION
This PR change the calculation of the `creationdate` and  `changedate` from `performMagic` to the newer `compute`.
I the future we can discuss to remove the `performMagic` function completly.