### PR TITLE
fix: guessTimeZone() fails with Python 3.11

### DIFF
--- a/core/bones/date.py
+++ b/core/bones/date.py
@@ -248,7 +248,7 @@ class DateBone(BaseBone):
             return pytz.utc
 
         if conf["viur.instance.is_dev_server"]:
-            return pytz.timezone(tzlocal.get_localzone().key)
+            return pytz.timezone(tzlocal.get_localzone_name())
 
         timeZone = pytz.utc  # Default fallback
         currReqData = current.request_data.get()

--- a/core/bones/date.py
+++ b/core/bones/date.py
@@ -248,7 +248,7 @@ class DateBone(BaseBone):
             return pytz.utc
 
         if conf["viur.instance.is_dev_server"]:
-            return tzlocal.get_localzone()
+            return pytz.timezone(tzlocal.get_localzone().key)
 
         timeZone = pytz.utc  # Default fallback
         currReqData = current.request_data.get()


### PR DESCRIPTION
_Originally posted by @sveneberth in https://github.com/viur-framework/viur-core/pull/733#discussion_r1263866264_

This doesn't work for me.

```py
[2023-07-14 17:25:28,483] viur/core/request.py:300 [ERROR] '_PytzShimTimezone' object has no attribute 'key'
Traceback (most recent call last):
  File "/...deploy/viur/core/request.py", line 275, in processRequest
    self.findAndCall(path)
  File "/...deploy/viur/core/request.py", line 631, in findAndCall
    res = caller(*newArgs, **newKwargs)
  File "/...deploy/viur/core/prototypes/list.py", line 213, in edit
    return self.render.edit(skel)
  File "/...deploy/viur/core/render/json/default.py", line 212, in edit
    return self.renderEntry(skel, action, params)
  File "/...deploy/viur/core/render/json/default.py", line 152, in renderEntry
    vals = self.renderSkelValues(skel)
  File "/...deploy/viur/core/render/json/default.py", line 136, in renderSkelValues
    res[key] = self.renderBoneValue(bone, skel, key)
  File "/...deploy/viur/core/render/json/default.py", line 103, in renderBoneValue
    boneVal = skel[key]
  File "/...deploy/viur/core/skeleton.py", line 198, in __getitem__
    boneInstance.unserialize(self, key)
  File "/...deploy/viur/core/bones/base.py", line 830, in unserialize
    res = self.singleValueUnserialize(loadVal)
  File "/...deploy/viur/core/bones/date.py", line 327, in singleValueUnserialize
    time_zone = self.guessTimeZone()
  File "/...deploy/viur/core/bones/date.py", line 253, in guessTimeZone
    print(f"{tzlocal.get_localzone().key = }")
AttributeError: '_PytzShimTimezone' object has no attribute 'key'
```

While the old statement seems to return a correct pytz object:
```py
tzlocal.get_localzone() = _PytzShimTimezone(zoneinfo.ZoneInfo(key='Europe/Berlin'), 'Europe/Berlin')
```           

---

_Originally posted by @phorward in https://github.com/viur-framework/viur-core/pull/733#discussion_r1266565852_

              > While the old statement seems to return a correct pytz object:
> 
> ```python
> tzlocal.get_localzone() = _PytzShimTimezone(zoneinfo.ZoneInfo(key='Europe/Berlin'), 'Europe/Berlin')
> ```

Something is wrong. Did you test in on a clean environment? 

The previous code raised this, which was the reason why it was changed. 
```
[2023-06-29 15:58:54,407] /.../viur/core/request.py:299 [ERROR] ViUR has caught an unhandled exception!
[2023-06-29 15:58:54,408] /.../viur/core/request.py:300 [ERROR] 'zoneinfo.ZoneInfo' object has no attribute 'localize'
Traceback (most recent call last):
  File "/Users/achim/.local/share/virtualenvs/project-viur3-kGucZxTM/lib/python3.11/site-packages/viur/core/request.py", line 275, in processRequest
    self.findAndCall(path)
  File "/Users/achim/.local/share/virtualenvs/project-viur3-kGucZxTM/lib/python3.11/site-packages/viur/core/request.py", line 631, in findAndCall
    res = caller(*newArgs, **newKwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/achim/Arbeit/viurProjects/project-viur3/deploy/modules/user.py", line 585, in edit
    or not skel.fromClient(kwargs)  # failure on reading into the bones
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/achim/.local/share/virtualenvs/project-viur3-kGucZxTM/lib/python3.11/site-packages/viur/core/skeleton.py", line 706, in fromClient
    complete = super().fromClient(skelValues, data)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/achim/.local/share/virtualenvs/project-viur3-kGucZxTM/lib/python3.11/site-packages/viur/core/skeleton.py", line 370, in fromClient
    errors = _bone.fromClient(skelValues, key, data)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/achim/.local/share/virtualenvs/project-viur3-kGucZxTM/lib/python3.11/site-packages/viur/core/bones/base.py", line 530, in fromClient
    res, parseErrors = self.singleValueFromClient(parsedData, skel, name, data)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/achim/.local/share/virtualenvs/project-viur3-kGucZxTM/lib/python3.11/site-packages/viur/core/bones/date.py", line 206, in singleValueFromClient
    value = time_zone.localize(value)
            ^^^^^^^^^^^^^^^^^^
AttributeError: 'zoneinfo.ZoneInfo' object has no attribute 'localize'
```
Please re-verify. I think it's also better to discuss this change in a separate PR (my fault).
            