### PR TITLE
fix: Clone `current.user` for use with Jinja

### DIFF
--- a/core/render/html/env/viur.py
+++ b/core/render/html/env/viur.py
@@ -117,6 +117,7 @@ def getCurrentUser(render: Render) -> Optional[SkeletonInstance]:
     """
     currentUser = current.user.get()
     if currentUser:
+        currentUser = currentUser.clone()  # need to clone, as renderPreparation is changed
         currentUser.renderPreparation = render.renderBoneValue
     return currentUser
 


### PR DESCRIPTION
This fixes the problem, that renderPreparation is set in a Skeleton which is globally used by either Jinja or by normal module code, and both usages rely on other data types expected.

In my specific use-case where this bug arose, the following happened:
1. The template request current user via `{% set cuser = getCurrentUser() %}`
2. The template calls a `getList` function on a module
3. The module has a `canView()` function, which requests the user again
4. The `canView()` function expects `user["key"]` to be a `db.Key`, but it is a str, as it is modified by the `renderPreparation` setting. The code fails.

To be honest, this `renderPreparation` junk is a mess. We should either get rid of it or find a better solution.