### PR TITLE
fix: Add missing fallback for `NumericBone.refresh()` destroying valid data

### DIFF
--- a/core/bones/numeric.py
+++ b/core/bones/numeric.py
@@ -160,6 +160,7 @@ class NumericBone(BaseBone):
                 return self.getEmptyValue()
             elif not isinstance(value, (int, float, type(None))):
                 return self._convert_to_numeric(value)
+            return value
 
         new_value = {}
         for _, lang, value in self.iter_bone_value(skel, boneName):


### PR DESCRIPTION
This PR fix the problem when a `numericBone` is refreshed the value would be overwritten with `None`. If the value is already a `int/float`.