### PR TITLE
Make recipients for `sendEMailToAdmins` configurable

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -127,11 +127,14 @@ conf = Conf({
     # If set, we'll enable sending emails from the local development server. Otherwise, they'll just be logged.
     "viur.email.sendFromLocalDevelopmentServer": False,
 
-    # If set, all outgoing emails will be sent to this address (overriding the 'dests'-parameter in utils.sendEmail)
+    # If set, all outgoing emails will be sent to this address (overriding the 'dests'-parameter in email.sendEmail)
     "viur.email.recipientOverride": None,
 
     # If set, this sender will be used, regardless of what the templates advertise as sender
     "viur.email.senderOverride": None,
+
+    # Sets recipients for mails send with email.sendEMailToAdmins. If not set, all root users will be used.
+    "viur.email.admin_recipients": None,
 
     # If set, ViUR calls this function instead of rendering the viur.errorTemplate if an exception occurs
     "viur.errorHandler": None,


### PR DESCRIPTION
It is now possible to set recipients for admin emails via config `conf["viur.email.admin_recipients"]`. Otherwise all root users are still addressed. By using `normalize_to_list` and its enhancement, a method as value is also possible. This allows e.g. dynamic recipient selections like own `UserSkel` queries. Also `conf["viur.email.recipientOverride"]` is now callable.