### PR TITLE
fix(seo): Incoming url is compared wrong

### DIFF
--- a/core/prototypes/list.py
+++ b/core/prototypes/list.py
@@ -310,7 +310,7 @@ class List(SkelModule):
                 seoUrl = utils.seoUrlToEntry(self.moduleName, skel)
                 # Check whether this is the current seo-key, otherwise redirect to it
 
-                if current.request.get().request.path != seoUrl:
+                if current.request.get().request.path.lower() != seoUrl:
                     raise errors.Redirect(seoUrl, status=301)
                 self.onView(skel)
                 return self.render.view(skel)


### PR DESCRIPTION
This worked in cases when there is no escaped character, but e.g. with `w%C3%A4rme` (german word "wärme"), the incoming URL `/page/w%C3%A4rme` is compared to a lower-cased seoUrl containing `/page/w%c3%a4rme`, which redirects wrong.