### PR TITLE
fix: Set test_threshold to 4 and add test_threshold to structure

### DIFF
--- a/src/viur/core/bones/password.py
+++ b/src/viur/core/bones/password.py
@@ -63,7 +63,7 @@ class PasswordBone(StringBone):
     def __init__(
         self,
         *,
-        test_threshold: int = 3,
+        test_threshold: int = 4,
         tests: List[Tuple] = tests,
         **kwargs
     ):
@@ -186,4 +186,7 @@ class PasswordBone(StringBone):
         return False
 
     def structure(self) -> dict:
-        return super().structure() | {"tests": self.tests}
+        return super().structure() | {
+            "tests": self.tests,
+            "test_threshold": self.test_threshold,
+        }


### PR DESCRIPTION
This PR sets the `test_threshold` to 4, so by default the password must be 8 characters long and pass 3 out of 4 tests.
In addition, the `test_threshold`  is now also output in the structure