### PR TITLE
fix: Add check for  `Method` class

### DIFF
--- a/src/viur/core/render/html/utils.py
+++ b/src/viur/core/render/html/utils.py
@@ -1,5 +1,7 @@
 from typing import Callable, Union
 
+from viur.core import Method
+
 __jinjaGlobals_ = {}
 __jinjaFilters_ = {}
 __jinjaTests_ = {}
@@ -26,7 +28,11 @@ def jinjaGlobalFunction(f):
     """
     Decorator, marks a function as a Jinja2 global.
     """
-    __jinjaGlobals_[f.__name__] = f
+
+    if isinstance(f, Method):
+        __jinjaGlobals_[f._func.__name__] = f._func
+    else:
+        __jinjaGlobals_[f.__name__] = f
     return f
 
 
@@ -34,7 +40,10 @@ def jinjaGlobalFilter(f):
     """
     Decorator, marks a function as a Jinja2 filter.
     """
-    __jinjaFilters_[f.__name__] = f
+    if isinstance(f, Method):
+        __jinjaFilters_[f._func.__name__] = f._func
+    else:
+        __jinjaFilters_[f.__name__] = f
     return f
 
 


### PR DESCRIPTION
Since #800 you can't make a method `exposed` and to a `jinjaGlobalFunction`. This PR fix this.