### PR TITLE
fix: `Method.__name__` improves #800

### DIFF
--- a/src/viur/core/module.py
+++ b/src/viur/core/module.py
@@ -35,6 +35,7 @@ class Method:
         self.access = None
 
         # Content
+        self.__name__ = func.__name__
         self._func = func
         self._instance = None
 


### PR DESCRIPTION
This is a replacement for #825 