### PR TITLE
refactor: Prototype action functions

### DIFF
--- a/src/viur/core/prototypes/list.py
+++ b/src/viur/core/prototypes/list.py
@@ -114,7 +114,7 @@ class List(SkelModule):
         return self.render.view(skel)
 
     @exposed
-    def view(self, key: db.Key | str | int | None = None, *args, **kwargs) -> Any:
+    def view(self, key: db.Key | str | int, *args, **kwargs) -> Any:
         """
             Prepares and renders a single entry for viewing.
 

--- a/src/viur/core/prototypes/list.py
+++ b/src/viur/core/prototypes/list.py
@@ -114,7 +114,7 @@ class List(SkelModule):
         return self.render.view(skel)
 
     @exposed
-    def view(self, *args, **kwargs) -> Any:
+    def view(self, key: db.Key | str | int, *args, **kwargs) -> Any:
         """
             Prepares and renders a single entry for viewing.
 
@@ -130,20 +130,13 @@ class List(SkelModule):
             :raises: :exc:`viur.core.errors.NotFound`, when no entry with the given *key* was found.
             :raises: :exc:`viur.core.errors.Unauthorized`, if the current user does not have the required permissions.
         """
-        if "key" in kwargs:
-            key = kwargs["key"]
-        elif len(args) >= 1:
-            key = args[0]
-        else:
-            raise errors.NotAcceptable()
-        if not key:
-            raise errors.NotAcceptable()
-        # We return a single entry for viewing
         skel = self.viewSkel()
         if not skel.fromDB(key):
             raise errors.NotFound()
+
         if not self.canView(skel):
             raise errors.Forbidden()
+
         self.onView(skel)
         return self.render.view(skel)
 
@@ -173,7 +166,7 @@ class List(SkelModule):
     @force_ssl
     @exposed
     @skey(allow_empty=SKEY_ALLOW_EMPTY_FOR_KEY)
-    def edit(self, *args, **kwargs) -> Any:
+    def edit(self, key: db.Key | str | int, *args, **kwargs) -> Any:
         """
             Modify an existing entry, and render the entry, eventually with error notes on incorrect data.
             Data is taken by any other arguments in *kwargs*.
@@ -191,21 +184,18 @@ class List(SkelModule):
             :raises: :exc:`viur.core.errors.Unauthorized`, if the current user does not have the required permissions.
             :raises: :exc:`viur.core.errors.PreconditionFailed`, if the *skey* could not be verified.
         """
-        if "key" in kwargs:
-            key = kwargs["key"]
-        elif len(args) == 1:
-            key = args[0]
-        else:
-            raise errors.NotAcceptable()
         skel = self.editSkel()
         if not skel.fromDB(key):
             raise errors.NotFound()
+
         if not self.canEdit(skel):
             raise errors.Unauthorized()
-        if (len(kwargs) == 0  # no data supplied
+
+        if (
+            not kwargs  # no data supplied
             or not current.request.get().isPostRequest  # failure if not using POST-method
             or not skel.fromClient(kwargs)  # failure on reading into the bones
-            or ("bounce" in kwargs and kwargs["bounce"] == "1")  # review before changing
+            or kwargs.get("bounce") == "1"  # review before changing
         ):
             # render the skeleton in the version it could as far as it could be read.
             return self.render.edit(skel)
@@ -235,11 +225,14 @@ class List(SkelModule):
         """
         if not self.canAdd():
             raise errors.Unauthorized()
+
         skel = self.addSkel()
-        if (len(kwargs) == 0  # no data supplied
+
+        if (
+            not kwargs  # no data supplied
             or not current.request.get().isPostRequest  # failure if not using POST-method
             or not skel.fromClient(kwargs)  # failure on reading into the bones
-            or ("bounce" in kwargs and kwargs["bounce"] == "1")  # review before adding
+            or kwargs.get("bounce") == "1"  # review before adding
         ):
             # render the skeleton in the version it could as far as it could be read.
             return self.render.add(skel)
@@ -254,7 +247,7 @@ class List(SkelModule):
     @force_post
     @exposed
     @skey
-    def delete(self, key: str, *args, **kwargs) -> Any:
+    def delete(self, key: db.Key | str | int, *args, **kwargs) -> Any:
         """
             Delete an entry.
 
@@ -268,7 +261,6 @@ class List(SkelModule):
             :raises: :exc:`viur.core.errors.Unauthorized`, if the current user does not have the required permissions.
             :raises: :exc:`viur.core.errors.PreconditionFailed`, if the *skey* could not be verified.
         """
-
         skel = self.editSkel()
         if not skel.fromDB(key):
             raise errors.NotFound()

--- a/src/viur/core/prototypes/list.py
+++ b/src/viur/core/prototypes/list.py
@@ -114,7 +114,7 @@ class List(SkelModule):
         return self.render.view(skel)
 
     @exposed
-    def view(self, key: db.Key | str | int, *args, **kwargs) -> Any:
+    def view(self, key: db.Key | str | int | None = None, *args, **kwargs) -> Any:
         """
             Prepares and renders a single entry for viewing.
 

--- a/src/viur/core/prototypes/skelmodule.py
+++ b/src/viur/core/prototypes/skelmodule.py
@@ -1,6 +1,5 @@
 from viur.core import Module
 from viur.core.skeleton import skeletonByKind, Skeleton, SkeletonInstance
-from viur.core import conf
 from typing import Tuple, Type
 
 

--- a/src/viur/core/prototypes/tree.py
+++ b/src/viur/core/prototypes/tree.py
@@ -49,7 +49,7 @@ class Tree(SkelModule):
 
     def __init__(self, moduleName, modulePath, *args, **kwargs):
         assert self.nodeSkelCls, f"Need to specify at least nodeSkelCls for {self.__class__.__name__!r}"
-        super(Tree, self).__init__(moduleName, modulePath, *args, **kwargs)
+        super().__init__(moduleName, modulePath, *args, **kwargs)
 
     def handler(self):
         return "tree" if self.leafSkelCls else "tree.node"  # either a tree or a tree with nodes only (former hierarchy)
@@ -295,7 +295,7 @@ class Tree(SkelModule):
         return self.render.view(skel)
 
     @exposed
-    def view(self, skelType: SkelType, key: str, *args, **kwargs) -> Any:
+    def view(self, skelType: SkelType, key: db.Key | str | int, *args, **kwargs) -> Any:
         """
         Prepares and renders a single entry for viewing.
 
@@ -315,21 +315,21 @@ class Tree(SkelModule):
         """
         if not (skelType := self._checkSkelType(skelType)):
             raise errors.NotAcceptable(f"Invalid skelType provided.")
+
         skel = self.viewSkel(skelType)
-        if not key:
-            raise errors.NotAcceptable()
-        # We return a single entry for viewing
         if not skel.fromDB(key):
             raise errors.NotFound()
+
         if not self.canView(skelType, skel):
             raise errors.Unauthorized()
+
         self.onView(skelType, skel)
         return self.render.view(skel)
 
     @exposed
     @force_ssl
     @skey(allow_empty=SKEY_ALLOW_EMPTY_FOR_KEY)
-    def add(self, skelType: SkelType, node: str, *args, **kwargs) -> Any:
+    def add(self, skelType: SkelType, node: db.Key | str | int, *args, **kwargs) -> Any:
         """
         Add a new entry with the given parent *node*, and render the entry, eventually with error notes
         on incorrect data. Data is taken by any other arguments in *kwargs*.
@@ -362,22 +362,24 @@ class Tree(SkelModule):
         # parentrepo may not exist in parentNodeSkel as it may be an rootNode
         skel["parentrepo"] = parentNodeSkel["parentrepo"] or parentNodeSkel["key"]
 
-        if (len(kwargs) == 0  # no data supplied
+        if (
+            not kwargs  # no data supplied
             or not skel.fromClient(kwargs)  # failure on reading into the bones
             or not current.request.get().isPostRequest
-            or ("bounce" in kwargs and kwargs["bounce"] == "1")  # review before adding
+            or kwargs.get("bounce") == "1"  # review before adding
         ):
             return self.render.add(skel)
 
         self.onAdd(skelType, skel)
         skel.toDB()
         self.onAdded(skelType, skel)
+
         return self.render.addSuccess(skel)
 
     @exposed
     @force_ssl
     @skey(allow_empty=SKEY_ALLOW_EMPTY_FOR_KEY)
-    def edit(self, skelType: SkelType, key: str, *args, **kwargs) -> Any:
+    def edit(self, skelType: SkelType, key: db.Key | str | int, *args, **kwargs) -> Any:
         """
         Modify an existing entry, and render the entry, eventually with error notes on incorrect data.
         Data is taken by any other arguments in *kwargs*.
@@ -402,17 +404,22 @@ class Tree(SkelModule):
         skel = self.editSkel(skelType)
         if not skel.fromDB(key):
             raise errors.NotFound()
+
         if not self.canEdit(skelType, skel):
             raise errors.Unauthorized()
-        if (len(kwargs) == 0  # no data supplied
+
+        if (
+            not kwargs  # no data supplied
             or not skel.fromClient(kwargs)  # failure on reading into the bones
             or not current.request.get().isPostRequest
-            or ("bounce" in kwargs and kwargs["bounce"] == "1")  # review before adding
+            or kwargs.get("bounce") == "1"  # review before adding
         ):
             return self.render.edit(skel)
+
         self.onEdit(skelType, skel)
         skel.toDB()
         self.onEdited(skelType, skel)
+
         return self.render.editSuccess(skel)
 
     @exposed
@@ -438,16 +445,21 @@ class Tree(SkelModule):
         """
         if not (skelType := self._checkSkelType(skelType)):
             raise errors.NotAcceptable(f"Invalid skelType provided.")
+
         skel = self.editSkel(skelType)
         if not skel.fromDB(key):
             raise errors.NotFound()
+
         if not self.canDelete(skelType, skel):
             raise errors.Unauthorized()
+
         if skelType == "node":
             self.deleteRecursive(skel["key"])
+
         self.onDelete(skelType, skel)
         skel.delete()
         self.onDeleted(skelType, skel)
+
         return self.render.deleteSuccess(skel, skelType=skelType)
 
     @CallDeferred
@@ -477,7 +489,7 @@ class Tree(SkelModule):
     @force_ssl
     @force_post
     @skey
-    def move(self, skelType: SkelType, key: str, parentNode: str, *args, **kwargs) -> str:
+    def move(self, skelType: SkelType, key: db.Key | str | int, parentNode: str, *args, **kwargs) -> str:
         """
         Move a node (including its contents) or a leaf to another node.
 


### PR DESCRIPTION
This pull requests refactors the code for all prototype standard actions as follows:

- Consequent use of "key" in signature
- Clean-up kwargs check
- Clean-up "bounce" check
- Make code more readable
- Instanciate variables right before their use, and not on top