### PR TITLE
feat: Extend `Method` to examine function signature and parse type annotations

### DIFF
--- a/src/viur/core/decorators.py
+++ b/src/viur/core/decorators.py
@@ -133,10 +133,3 @@ def skey(
         return decorator
 
     return decorator(func)
-
-
-def SKEY_ALLOW_EMPTY_FOR_KEY(args: tuple, kwargs: dict) -> bool:
-    """
-    Standard allow_empty-check for several prototype functions
-    """
-    return (len(args) == 1 and not kwargs) or (len(kwargs) == 1 and kwargs.get("key"))

--- a/src/viur/core/module.py
+++ b/src/viur/core/module.py
@@ -191,6 +191,11 @@ class Method:
             for name, value in kwargs.items():
                 if name not in self.signature.parameters:
                     parsed_kwargs[name] = value
+            varkwargs = bool(kwargs)
+        # always take "skey" when configured into kwargs, if varkwargs is unset
+        elif self.skey and self.skey["name"] in kwargs:
+            parsed_kwargs[self.skey["name"]] = kwargs[self.skey["name"]]
+            varkwargs = True
 
         args = tuple(parsed_args)
         kwargs = parsed_kwargs
@@ -213,7 +218,7 @@ class Method:
                     required = any(k for k in kwargs.keys() if k not in allow_empty)
                 # otherwise, kwargs may not be empty.
                 else:
-                    required = bool(kwargs)
+                    required = varargs or varkwargs
 
             if required:
                 security_key = kwargs.pop(self.skey["name"], "")

--- a/src/viur/core/prototypes/list.py
+++ b/src/viur/core/prototypes/list.py
@@ -114,7 +114,7 @@ class List(SkelModule):
         return self.render.view(skel)
 
     @exposed
-    def view(self, key: db.Key | str | int, *args, **kwargs) -> Any:
+    def view(self, key: db.Key | int | str, *args, **kwargs) -> Any:
         """
             Prepares and renders a single entry for viewing.
 
@@ -166,7 +166,7 @@ class List(SkelModule):
     @force_ssl
     @exposed
     @skey(allow_empty=SKEY_ALLOW_EMPTY_FOR_KEY)
-    def edit(self, key: db.Key | str | int, *args, **kwargs) -> Any:
+    def edit(self, key: db.Key | int | str, *args, **kwargs) -> Any:
         """
             Modify an existing entry, and render the entry, eventually with error notes on incorrect data.
             Data is taken by any other arguments in *kwargs*.
@@ -247,7 +247,7 @@ class List(SkelModule):
     @force_post
     @exposed
     @skey
-    def delete(self, key: db.Key | str | int, *args, **kwargs) -> Any:
+    def delete(self, key: db.Key | int | str, *args, **kwargs) -> Any:
         """
             Delete an entry.
 

--- a/src/viur/core/prototypes/list.py
+++ b/src/viur/core/prototypes/list.py
@@ -165,7 +165,7 @@ class List(SkelModule):
 
     @force_ssl
     @exposed
-    @skey(allow_empty=SKEY_ALLOW_EMPTY_FOR_KEY)
+    @skey(allow_empty=True)
     def edit(self, key: db.Key | int | str, *args, **kwargs) -> Any:
         """
             Modify an existing entry, and render the entry, eventually with error notes on incorrect data.
@@ -208,7 +208,7 @@ class List(SkelModule):
 
     @force_ssl
     @exposed
-    @skey(allow_empty=SKEY_ALLOW_EMPTY_FOR_KEY)
+    @skey(allow_empty=True)
     def add(self, *args, **kwargs) -> Any:
         """
             Add a new entry, and render the entry, eventually with error notes on incorrect data.

--- a/src/viur/core/prototypes/tree.py
+++ b/src/viur/core/prototypes/tree.py
@@ -328,7 +328,7 @@ class Tree(SkelModule):
 
     @exposed
     @force_ssl
-    @skey(allow_empty=SKEY_ALLOW_EMPTY_FOR_KEY)
+    @skey(allow_empty=True)
     def add(self, skelType: SkelType, node: db.Key | int | str, *args, **kwargs) -> Any:
         """
         Add a new entry with the given parent *node*, and render the entry, eventually with error notes
@@ -378,7 +378,7 @@ class Tree(SkelModule):
 
     @exposed
     @force_ssl
-    @skey(allow_empty=SKEY_ALLOW_EMPTY_FOR_KEY)
+    @skey(allow_empty=True)
     def edit(self, skelType: SkelType, key: db.Key | int | str, *args, **kwargs) -> Any:
         """
         Modify an existing entry, and render the entry, eventually with error notes on incorrect data.

--- a/src/viur/core/prototypes/tree.py
+++ b/src/viur/core/prototypes/tree.py
@@ -295,7 +295,7 @@ class Tree(SkelModule):
         return self.render.view(skel)
 
     @exposed
-    def view(self, skelType: SkelType, key: db.Key | str | int, *args, **kwargs) -> Any:
+    def view(self, skelType: SkelType, key: db.Key | int | str, *args, **kwargs) -> Any:
         """
         Prepares and renders a single entry for viewing.
 
@@ -329,7 +329,7 @@ class Tree(SkelModule):
     @exposed
     @force_ssl
     @skey(allow_empty=SKEY_ALLOW_EMPTY_FOR_KEY)
-    def add(self, skelType: SkelType, node: db.Key | str | int, *args, **kwargs) -> Any:
+    def add(self, skelType: SkelType, node: db.Key | int | str, *args, **kwargs) -> Any:
         """
         Add a new entry with the given parent *node*, and render the entry, eventually with error notes
         on incorrect data. Data is taken by any other arguments in *kwargs*.
@@ -379,7 +379,7 @@ class Tree(SkelModule):
     @exposed
     @force_ssl
     @skey(allow_empty=SKEY_ALLOW_EMPTY_FOR_KEY)
-    def edit(self, skelType: SkelType, key: db.Key | str | int, *args, **kwargs) -> Any:
+    def edit(self, skelType: SkelType, key: db.Key | int | str, *args, **kwargs) -> Any:
         """
         Modify an existing entry, and render the entry, eventually with error notes on incorrect data.
         Data is taken by any other arguments in *kwargs*.
@@ -489,7 +489,7 @@ class Tree(SkelModule):
     @force_ssl
     @force_post
     @skey
-    def move(self, skelType: SkelType, key: db.Key | str | int, parentNode: str, *args, **kwargs) -> str:
+    def move(self, skelType: SkelType, key: db.Key | int | str, parentNode: str, *args, **kwargs) -> str:
         """
         Move a node (including its contents) or a leaf to another node.
 


### PR DESCRIPTION
This pull requests does implement the following:

- Perform str to specific type parsing based on annotations for `@exposed` functions
- Report any required values which are unset, also with / and * Python-functions
- Removes any old stuff regarding parameter parsing and TypeError handling