### PR TITLE
feat: Avoid multiple CSRF-security-key validation

### DIFF
--- a/src/viur/core/module.py
+++ b/src/viur/core/module.py
@@ -204,7 +204,7 @@ class Method:
             logging.debug(f"calling {self._func=} with cleaned {args=}, {kwargs=}")
 
         # evaluate skey guard setting?
-        if self.skey:
+        if self.skey and not current.request.get().skey_checked:
             if trace:
                 logging.debug(f"@skey {self.skey=}")
 
@@ -226,6 +226,7 @@ class Method:
 
                 from viur.core import securitykey
                 payload = securitykey.validate(security_key, **self.skey["extra_kwargs"])
+                current.request.get().skey_checked = True
 
                 if not payload or (self.skey["validate"] and not self.skey["validate"](payload)):
                     raise errors.PreconditionFailed(

--- a/src/viur/core/modules/file.py
+++ b/src/viur/core/modules/file.py
@@ -673,7 +673,7 @@ class File(Tree):
     @force_ssl
     @force_post
     @skey(allow_empty=True)
-    def add(self, skelType: SkelType, node=None, *args, **kwargs):
+    def add(self, skelType: SkelType, node: db.Key | int | str | None = None, *args, **kwargs):
         ## We can't add files directly (they need to be uploaded
         # if skelType != "node":
         #    raise errors.NotAcceptable()
@@ -714,7 +714,8 @@ class File(Tree):
             # Add updated download-URL as the auto-generated isn't valid yet
             skel["downloadUrl"] = utils.downloadUrlFor(skel["dlkey"], skel["name"], derived=False)
             return self.render.addSuccess(skel)
-        return super(File, self).add(skelType, node, *args, **kwargs)
+
+        return super().add(skelType, node, *args, **kwargs)
 
     def onEdit(self, skelType: SkelType, skel: SkeletonInstance):
         super().onEdit(skelType, skel)

--- a/src/viur/core/request.py
+++ b/src/viur/core/request.py
@@ -109,6 +109,7 @@ class BrowseHandler():  # webapp.RequestHandler
         self._traceID = request.headers.get('X-Cloud-Trace-Context', "").split("/")[0] or utils.generateRandomString()
         self.is_deferred = False
         self.path_list = ()
+        self.skey_checked = False  # indicates whether @skey-decorator-check has already performed within a request
         db.currentDbAccessLog.set(set())
 
     @property


### PR DESCRIPTION
The Method-interface and the new @skey decorator require that the security key is only validated on the first Method call, and not afterwards or below.