### PR TITLE
refactor: Refactor `Router` + collect context-variables to `Router.context`

### DIFF
--- a/src/viur/core/__init__.py
+++ b/src/viur/core/__init__.py
@@ -259,7 +259,7 @@ def setup(modules: Union[object, ModuleType], render: Union[ModuleType, Dict] = 
 
 
 def app(environ: dict, start_response: Callable):
-    return request.Request(environ).response(environ, start_response)
+    return request.Router(environ).response(environ, start_response)
 
 
 # DEPRECATED ATTRIBUTES HANDLING

--- a/src/viur/core/__init__.py
+++ b/src/viur/core/__init__.py
@@ -25,20 +25,18 @@
 """
 
 import os
-import webob
 import yaml
 import warnings
 import inspect
 from types import ModuleType
 from typing import Callable, Dict, Union, List
-from viur.core import session, errors, i18n, request, utils, current
+from viur.core import errors, i18n, request, utils, current
 from viur.core.config import conf
 from viur.core.tasks import TaskHandler, runStartupTasks
 from viur.core.module import Module, Method
 # noinspection PyUnresolvedReferences
 from viur.core import logging as viurLogging  # unused import, must exist, initializes request logging
 from viur.core.decorators import force_post, force_ssl, internal_exposed, exposed as _exposed  # backward-compatibility
-
 import logging  # this import has to stay here, see #571
 
 
@@ -261,26 +259,7 @@ def setup(modules: Union[object, ModuleType], render: Union[ModuleType, Dict] = 
 
 
 def app(environ: dict, start_response: Callable):
-    req = webob.Request(environ)
-    resp = webob.Response()
-    handler = request.BrowseHandler(req, resp)
-
-    # Set context variables
-    current.language.set(conf["viur.defaultLanguage"])
-    current.request.set(handler)
-    current.session.set(session.Session())
-    current.request_data.set({})
-    # Handle request
-    handler.processRequest()
-
-    # Unset context variables
-    current.language.set(None)
-    current.request_data.set(None)
-    current.session.set(None)
-    current.request.set(None)
-    current.user.set(None)
-
-    return resp(environ, start_response)
+    return request.Request(environ).response(environ, start_response)
 
 
 # DEPRECATED ATTRIBUTES HANDLING

--- a/src/viur/core/request.py
+++ b/src/viur/core/request.py
@@ -521,8 +521,15 @@ class Request:
                 logging.debug("Caching disabled by X-Viur-Disable-Cache header")
                 self.disableCache = True
 
+        # Copy contexts into self.contexts if available
+        if contexts := {k: v for k, v in self.kwargs.items() if k.startswith("@")}:
+            kwargs = {k: v for k, v in self.kwargs.items() if k not in contexts}
+            self.contexts |= contexts
+        else:
+            kwargs = self.kwargs
+
         # Now call the routed method!
-        res = caller(*self.args, **self.kwargs)
+        res = caller(*self.args, **kwargs)
 
         if not isinstance(res, bytes):  # Convert the result to bytes if it is not already!
             res = str(res).encode("UTF-8")

--- a/src/viur/core/request.py
+++ b/src/viur/core/request.py
@@ -74,7 +74,7 @@ class FetchMetaDataValidator(RequestValidator):
         return 403, "Forbidden", "Request rejected due to fetch metadata"
 
 
-class Request:
+class Router:
     """
         This class accepts the requests, collect its parameters and routes the request
         to its destination function.

--- a/src/viur/core/session.py
+++ b/src/viur/core/session.py
@@ -2,7 +2,6 @@ import hmac
 import logging
 import time
 from viur.core.tasks import DeleteEntitiesIter
-from viur.core.request import BrowseHandler
 from viur.core.config import conf  # this import has to stay alone due partial import
 from viur.core import db, utils, tasks
 from typing import Any, Optional, Union
@@ -58,7 +57,7 @@ class Session:
         self.static_security_key = None
         self.session = db.Entity()
 
-    def load(self, req: BrowseHandler):
+    def load(self, req):
         """
             Initializes the Session.
 
@@ -83,7 +82,7 @@ class Session:
         else:
             self.reset()
 
-    def save(self, req: BrowseHandler):
+    def save(self, req):
         """
             Writes the session into the database.
 


### PR DESCRIPTION
Initial commit, refactor of BrowseHandler to Request. This is a first attempt to refactor this module without doing too big changes.

Contexts are already used in several ViUR projects to turn requests into a specific data environment. Context-parameters are preceded by an "@". This can be changed to a dynamic or customizable version in a next release.

This behavior is wanted:
- Request.kwargs contains all kwargs (because of backward compatibility)
- caller(kwargs) is a filtered kwargs without contexts
- Request.contexts contains only contexts
