### PR TITLE
fix: import qrcode's element with an alias

### DIFF
--- a/src/viur/core/render/html/env/viur.py
+++ b/src/viur/core/render/html/env/viur.py
@@ -1,25 +1,22 @@
-from collections import OrderedDict
-
 import logging
 import os
 import string
 import urllib
 import urllib.parse
+from collections import OrderedDict
 from datetime import timedelta
 from hashlib import sha512
 from typing import Any, Dict, List, NoReturn, Optional, Union
 
-import viur.core.render.html.default
-from viur.core import Method
-from viur.core import db, current, errors, prototypes, securitykey, utils
+from qrcode import make as qrcode_make
+from qrcode.image import svg as qrcode_svg
+
+from viur.core import Method, current, db, errors, prototypes, securitykey, utils
 from viur.core.config import conf
 from viur.core.i18n import translate as translationClass
 from viur.core.render.html.utils import jinjaGlobalFilter, jinjaGlobalFunction
 from viur.core.skeleton import RelSkel, SkeletonInstance
 from ..default import Render
-
-import qrcode
-import qrcode.image.svg
 
 
 @jinjaGlobalFunction
@@ -739,4 +736,4 @@ def qrcode(render: Render, data: str) -> str:
 
     :return: The SVG string representation.
     """
-    return qrcode.make(data, image_factory=qrcode.image.svg.SvgPathImage, box_size=30).to_string().decode("utf-8")
+    return qrcode_make(data, image_factory=qrcode_svg.SvgPathImage, box_size=30).to_string().decode("utf-8")


### PR DESCRIPTION
There was a name conflict between the imported `qrcode` package and the jinja function `qrcode`.

```py
[2023-09-08 21:37:26,287] main.py:119 [ERROR] 'function' object has no attribute 'make'
Traceback (most recent call last):
  [...]
    {{ qrcode(otp_uri) }}
  File "/project/deploy/viur/core/render/html/env/viur.py", line 742, in qrcode
    return qrcode.make(data, image_factory=qrcode.image.svg.SvgPathImage, box_size=30).to_string().decode("utf-8")
AttributeError: 'function' object has no attribute 'make'
```