### PR TITLE
fix: template name should not be static.

### DIFF
--- a/src/viur/core/modules/user.py
+++ b/src/viur/core/modules/user.py
@@ -1196,7 +1196,7 @@ class User(List):
             # We have only one second factor we don't need the choice template
             return second_factor_providers[0].start(userKey)
         # In case there is more than one second factor, let the user select a method.
-        return self.render.second_factor_choice(tpl="second_factor_choice", second_factors=second_factor_providers)
+        return self.render.second_factor_choice(second_factors=second_factor_providers)
 
     def secondFactorSucceeded(self, secondFactor, userKey):
         session = current.session.get()

--- a/src/viur/core/render/html/user.py
+++ b/src/viur/core/render/html/user.py
@@ -11,6 +11,7 @@ class Render(DefaultRender):  # Render user-data to xml
     passwdRecoverInfoTemplate = "user_passwdrecover_info"
     otp_add_template = "user_secondfactor_add"
     otp_add_success_template = "user_secondfactor_add_success"
+    second_factor_choice_template = "user_second_factor_choice"
 
     def _choose_template(self, tpl: None | str, fallback_attribute: str) -> str:
         if tpl:
@@ -75,6 +76,6 @@ class Render(DefaultRender):  # Render user-data to xml
         return template.render()
 
     def second_factor_choice(self, tpl: str | None = None, second_factors: list | tuple = ()):
-        tpl = self._choose_template(tpl, "second_factor_choice")
+        tpl = self._choose_template(tpl, "second_factor_choice_template")
         template = self.getEnv().get_template(self.getTemplateFileName(tpl))
         return template.render(second_factors=second_factors)


### PR DESCRIPTION
Look for the attribute `second_factor_choice_template` in the current renderer or the parent module (`user` module) and use it's value. By default this should be `"user_second_factor_choice"`.