### PR TITLE
fix some mixed up and blurred methods and concepts.

### DIFF
--- a/src/viur/core/modules/user.py
+++ b/src/viur/core/modules/user.py
@@ -647,6 +647,7 @@ class UserSecondFactorAuthentication(UserAuthentication, abc.ABC):
     def __init__(self, moduleName, modulePath, _user_module):
         super().__init__(moduleName, modulePath, _user_module)
         self.action_url = f"{self.modulePath}/{self.ACTION_NAME}"
+        self.add_url = f"{self.modulePath}/add"
         self.start_url = f"{self.modulePath}/start"
 
     @abc.abstractmethod
@@ -907,6 +908,7 @@ class AuthenticatorOTP(UserSecondFactorAuthentication):
                 tpl=self.second_factor_add_template,
                 action_name=self.ACTION_NAME,
                 name=translate(self.NAME),
+                add_url=self.add_url,
                 otp_uri=AuthenticatorOTP.generate_otp_app_secret_uri(otp_app_secret))
         else:
             if not AuthenticatorOTP.verify_otp(otp, otp_app_secret):
@@ -914,6 +916,7 @@ class AuthenticatorOTP(UserSecondFactorAuthentication):
                     tpl=self.second_factor_add_template,
                     action_name=self.ACTION_NAME,
                     name=translate(self.NAME),
+                    add_url=self.add_url,
                     otp_uri=AuthenticatorOTP.generate_otp_app_secret_uri(otp_app_secret))  # to add errors
 
             # Now we can set the otp_app_secret to the current User and render der Success-template

--- a/src/viur/core/modules/user.py
+++ b/src/viur/core/modules/user.py
@@ -878,7 +878,7 @@ class AuthenticatorOTP(UserSecondFactorAuthentication):
     """
     This class handles the second factor for apps like authy and so on
     """
-    otp_add_template = "user_secondfactor_add"
+    second_factor_add_template = "user_secondfactor_add"
     """Template to configure (add) a new TOPT"""
     ACTION_NAME = "authenticator_otp"
     """Action name provided for *otp_template* on login"""
@@ -904,17 +904,24 @@ class AuthenticatorOTP(UserSecondFactorAuthentication):
 
         if otp is None:
             return self._user_module.render.second_factor_add(
-                tpl=self.otp_add_template,
+                tpl=self.second_factor_add_template,
+                action_name=self.ACTION_NAME,
+                name=translate(self.NAME),
                 otp_uri=AuthenticatorOTP.generate_otp_app_secret_uri(otp_app_secret))
         else:
             if not AuthenticatorOTP.verify_otp(otp, otp_app_secret):
                 return self._user_module.render.second_factor_add(
-                    tpl=self.otp_add_template,
+                    tpl=self.second_factor_add_template,
+                    action_name=self.ACTION_NAME,
+                    name=translate(self.NAME),
                     otp_uri=AuthenticatorOTP.generate_otp_app_secret_uri(otp_app_secret))  # to add errors
 
             # Now we can set the otp_app_secret to the current User and render der Success-template
             AuthenticatorOTP.set_otp_app_secret(otp_app_secret)
-            return self._user_module.render.second_factor_add_success()
+            return self._user_module.render.second_factor_add_success(
+                action_name=self.ACTION_NAME,
+                name=translate(self.NAME),
+            )
 
     def can_handle(self, possible_user: db.Entity) -> bool:
         """

--- a/src/viur/core/render/html/env/viur.py
+++ b/src/viur/core/render/html/env/viur.py
@@ -18,8 +18,6 @@ from viur.core.render.html.utils import jinjaGlobalFilter, jinjaGlobalFunction
 from viur.core.skeleton import RelSkel, SkeletonInstance
 from ..default import Render
 
-import qrcode
-import qrcode.image.svg
 
 
 @jinjaGlobalFunction

--- a/src/viur/core/render/html/env/viur.py
+++ b/src/viur/core/render/html/env/viur.py
@@ -18,6 +18,8 @@ from viur.core.render.html.utils import jinjaGlobalFilter, jinjaGlobalFunction
 from viur.core.skeleton import RelSkel, SkeletonInstance
 from ..default import Render
 
+import qrcode
+import qrcode.image.svg
 
 
 @jinjaGlobalFunction

--- a/src/viur/core/render/html/user.py
+++ b/src/viur/core/render/html/user.py
@@ -1,5 +1,7 @@
-from . import default as DefaultRender
+from typing import Iterable
 
+from . import default as DefaultRender
+from viur.core.modules.user import UserSecondFactorAuthentication
 
 class Render(DefaultRender):  # Render user-data to xml
     loginTemplate = "user_login"
@@ -9,8 +11,8 @@ class Render(DefaultRender):  # Render user-data to xml
     verifySuccessTemplate = "user_verify_success"
     verifyFailedTemplate = "user_verify_failed"
     passwdRecoverInfoTemplate = "user_passwdrecover_info"
-    otp_add_template = "user_secondfactor_add"
-    otp_add_success_template = "user_secondfactor_add_success"
+    second_factor_add_template = "user_secondfactor_add"
+    second_factor_add_success_template = "user_secondfactor_add_success"
 
     def _choose_template(self, tpl: None | str, fallback_attribute: str) -> str:
         if tpl:
@@ -64,17 +66,19 @@ class Render(DefaultRender):  # Render user-data to xml
     def passwdRecover(self, *args, **kwargs):
         return self.edit(*args, **kwargs)
 
-    def second_factor_add(self, tpl: str | None, otp_uri=None):
-        tpl = self._choose_template(tpl, "otp_add_template")
+    def second_factor_add(self, action_name: str, name: str, tpl: str | None, otp_uri=None):
+        tpl = self._choose_template(tpl, "second_factor_add_template")
         template = self.getEnv().get_template(self.getTemplateFileName(tpl))
-        return template.render(otp_uri=otp_uri)
+        return template.render(action_name=action_name, name=name, otp_uri=otp_uri)
 
-    def second_factor_add_success(self, tpl: str | None = None):
-        tpl = self._choose_template(tpl, "otp_add_success_template")
+    def second_factor_add_success(self, action_name: str, name: str, tpl: str | None = None):
+        tpl = self._choose_template(tpl, "second_factor_add_success_template")
         template = self.getEnv().get_template(self.getTemplateFileName(tpl))
-        return template.render()
+        return template.render(action_name=action_name, name=name)
 
-    def second_factor_choice(self, tpl: str | None = None, second_factors: list | tuple = ()):
+    def second_factor_choice(self,
+                             second_factors: Iterable[UserSecondFactorAuthentication],
+                             tpl: str | None = None):
         tpl = self._choose_template(tpl, "second_factor_choice")
         template = self.getEnv().get_template(self.getTemplateFileName(tpl))
         return template.render(second_factors=second_factors)

--- a/src/viur/core/render/html/user.py
+++ b/src/viur/core/render/html/user.py
@@ -66,10 +66,11 @@ class Render(DefaultRender):  # Render user-data to xml
     def passwdRecover(self, *args, **kwargs):
         return self.edit(*args, **kwargs)
 
-    def second_factor_add(self, action_name: str, name: str, tpl: str | None, otp_uri=None):
+    def second_factor_add(self, action_name: str, name: str, add_url: str,
+                          tpl: str | None, otp_uri=None):
         tpl = self._choose_template(tpl, "second_factor_add_template")
         template = self.getEnv().get_template(self.getTemplateFileName(tpl))
-        return template.render(action_name=action_name, name=name, otp_uri=otp_uri)
+        return template.render(action_name=action_name, name=name, add_url=add_url, otp_uri=otp_uri)
 
     def second_factor_add_success(self, action_name: str, name: str, tpl: str | None = None):
         tpl = self._choose_template(tpl, "second_factor_add_success_template")


### PR DESCRIPTION
- The methods `second_factor_add` and `second_factor_add_success` are generic. So their template name should also be generic and not include `"otp"`.
- Since the above methods are general, it must be known for which concrete 2nd factor they are currently rendered. So the `name` and `action_name` are missing.
- Rendering the method `second_factor_choice` without specifying `second_factors` makes no sense. So the parameter should not be keyword-only.
- Add `add_url` in `second_factor_add` where data should be POST to.