### PR TITLE
fix: Clean-up user/view and user/edit with "self"

### DIFF
--- a/src/viur/core/module.py
+++ b/src/viur/core/module.py
@@ -204,7 +204,7 @@ class Method:
             logging.debug(f"calling {self._func=} with cleaned {args=}, {kwargs=}")
 
         # evaluate skey guard setting?
-        if self.skey and not current.request.get().skey_checked:
+        if self.skey and not current.request.get().skey_checked:  # skey guardiance is only required once per request
             if trace:
                 logging.debug(f"@skey {self.skey=}")
 
@@ -216,13 +216,16 @@ class Method:
                 # or allow_empty itself can be a sequence of allowed keys
                 elif isinstance(allow_empty, (list, tuple)):
                     required = any(k for k in kwargs.keys() if k not in allow_empty)
-                # otherwise, kwargs may not be empty.
+                # otherwise, varargs and varkwargs may not be empty.
                 else:
                     required = varargs or varkwargs
+                    if trace:
+                        logging.debug(f"@skey {required=} because either {varargs=} or {varkwargs=}")
 
             if required:
                 security_key = kwargs.pop(self.skey["name"], "")
-                logging.debug(f"@skey wanted, validating {security_key!r}")
+                if trace:
+                    logging.debug(f"@skey wanted, validating {security_key!r}")
 
                 from viur.core import securitykey
                 payload = securitykey.validate(security_key, **self.skey["extra_kwargs"])

--- a/src/viur/core/modules/user.py
+++ b/src/viur/core/modules/user.py
@@ -1289,26 +1289,23 @@ class User(List):
         logging.info(f"""User {skel["name"]} logged out""")
 
     @exposed
-    def edit(self, *args, **kwargs):
-        user = current.user.get()
-
-        # fixme: This assumes that the user can edit itself when no parameters are provided...
-        if len(args) == 0 and "key" not in kwargs and user:
-            # it is not a security issue as super().edit() checks the access rights.
-            kwargs["key"] = user["key"]
-
-        return super().edit(*args, **kwargs)
-
-    @exposed
-    def view(self, key, *args, **kwargs):
+    def view(self, key: db.Key | int | str = "self", *args, **kwargs):
         """
-            Allow a special key "self" to reference always the current user
+            Allow a special key "self" to reference the current user.
+
+            By default, any authenticated user can view its own user entry,
+            to obtain access rights and any specific user information.
+            This behavior is defined in the customized `canView` function,
+            which is overwritten by the User-module.
+
+            The rendered skeleton can be modified or restriced by specifying
+            a customized view-skeleton.
         """
         if key == "self":
-            if not (user := current.user.get()):
-                raise errors.Unauthorized()
-
-            return super().view(str(user["key"].id_or_name), *args, **kwargs)
+            if user := current.user.get():
+                key = user["key"]
+            else:
+                raise errors.Unauthorized("Cannot view 'self' with unknown user")
 
         return super().view(key, *args, **kwargs)
 
@@ -1321,6 +1318,27 @@ class User(List):
                 return True
 
         return False
+
+    @exposed
+    @skey(allow_empty=True)
+    def edit(self, key: db.Key | int | str = "self", *args, **kwargs):
+        """
+            Allow a special key "self" to reference the current user.
+
+            This modification will only allow to use "self" as a key;
+            The specific access right to let the user edit itself must
+            still be customized.
+
+            The rendered and editable skeleton can be modified or restriced
+            by specifying a customized edit-skeleton.
+        """
+        if key == "self":
+            if user := current.user.get():
+                key = user["key"]
+            else:
+                raise errors.Unauthorized("Cannot edit 'self' with unknown user")
+
+        return super().edit(key, *args, **kwargs)
 
     @exposed
     def getAuthMethods(self, *args, **kwargs):


### PR DESCRIPTION
This is only a suggestion. Please comment for any ambiguity or improvement. We can also remove /user/edit/self completely, or make "self" a mandatory parameter, so that "/user/view" or "/user/edit" are not allowed without parameters.