### PR TITLE
feat: Add `run_in_transaction` decorator.

### DIFF
--- a/src/viur/core/decorators.py
+++ b/src/viur/core/decorators.py
@@ -133,3 +133,20 @@ def skey(
         return decorator
 
     return decorator(func)
+
+
+def run_in_transaction(func: Callable) -> Method:
+    """
+    Decorator, which enforces the Method to run in a transaction.
+    .. code-block:: python
+        from viur.core.decorators import run_in_transaction
+        def outer_method(key)
+            @run_in_transaction
+            def transaction_method(key):
+                db.Get(key)
+            return transaction_method(key)
+    """
+
+    func = Method.ensure(func)
+    func.run_in_transaction = True
+    return func

--- a/src/viur/core/module.py
+++ b/src/viur/core/module.py
@@ -35,6 +35,7 @@ class Method:
         self.ssl = False
         self.methods = ("GET", "POST", "HEAD")
         self.seo_language_map = None
+        self.run_in_transaction = False
 
         # Inspection
         self.signature = inspect.signature(self._func)
@@ -282,6 +283,8 @@ class Method:
                 raise errors.Forbidden(self.access["message"]) if self.access["message"] else errors.Forbidden()
 
         # call with instance when provided
+        if self.run_in_transaction:
+            return db.RunInTransaction(self._func, *args, **kwargs)
         if self._instance:
             return self._func(self._instance, *args, **kwargs)
 


### PR DESCRIPTION
This PR adds a  `run_in_transaction` decorator. Now you can call transaction like : 

```python
@exposed
	def test(self, key):
		@run_in_transaction
		def trans(key):
			e = db.Get(db.Key.from_legacy_urlsafe(key))
			assert e
			e["new"] = "123"
			return e

		return trans(key)
```
I think it looks cleaner.
This is only an Idea What do you think of it? 