### PR TITLE
fix: `html.Render.getTemplateFileName()` should be deterministic

### DIFF
--- a/src/viur/core/render/html/default.py
+++ b/src/viur/core/render/html/default.py
@@ -104,18 +104,17 @@ class Render(object):
             template = (template,)
 
         for tpl in template:
-            filenames = [
-                tpl,
-                tpl + style_postfix,
-            ]
+            filenames = [tpl]
+            if style_postfix:
+                filenames.append(tpl + style_postfix)
 
             if lang:
                 filenames += [
-                    os.path.join(lang, tpl + style_postfix),
-                    os.path.join(lang, tpl),
+                    os.path.join(lang, tpl)
+                    for _tpl in filenames
                 ]
 
-            for filename in set(reversed(filenames)):
+            for filename in reversed(filenames):
                 filename += ".html"
 
                 if "_" in filename:


### PR DESCRIPTION
This bug was introduced in https://github.com/viur-framework/viur-core/pull/658 We can't use a `set` here because it's unordered. So it's random which template is chosen in case of a `style` or `lang` argument.

Just make sure we don't add duplicates.