### PR TITLE
Add logging for raised `HTTPException`

### DIFF
--- a/src/viur/core/config.py
+++ b/src/viur/core/config.py
@@ -97,7 +97,7 @@ conf = Conf({
     # Database engine module
     "viur.db.engine": "viur.datastore",
 
-    # If enabled, trace any routing and decorations for debugging and insight
+    # If enabled, trace any routing, HTTPExceptions and decorations for debugging and insight
     "viur.debug.trace": False,
     # If enabled, user-generated exceptions from the viur.core.errors module won't be caught and handled
     "viur.debug.traceExceptions": False,

--- a/src/viur/core/request.py
+++ b/src/viur/core/request.py
@@ -310,6 +310,7 @@ class Router:
                 raise
             self.response.body = b""
             if isinstance(e, errors.HTTPException):
+                logging.info(f"[{e.status}] {e.name}: {e.descr}", exc_info=conf["viur.debug.trace"])
                 self.response.status = '%d %s' % (e.status, e.name)
                 # Set machine-readable x-viur-error response header in case there is an exception description.
                 if e.descr:


### PR DESCRIPTION
Normally only the `status`, `name` and `description` are logged. If you enable `conf["viur.debug.trace"] = True` you will also get a stack trace to see who raised it.