### PR TITLE
fix: Remove replace of `.` to `_`

### DIFF
--- a/src/viur/core/request.py
+++ b/src/viur/core/request.py
@@ -466,7 +466,7 @@ class Router:
                 raise errors.Unauthorized()
 
             idx += 1
-            part = part.replace("-", "_").replace(".", "_")
+            part = part.replace("-", "_")
             if part not in caller:
                 part = "index"
 


### PR DESCRIPTION
This is not consistent with the `buildApp`. In the `viur.mainResolver` modules like `sub1.sub2.foo2` are added but cannot be routed.


See https://github.com/viur-framework/viur-base/pull/112#pullrequestreview-1629315674