### PR TITLE
fix: Reactivate old-style `trace*CallRouting` for backward compatibility

### DIFF
--- a/src/viur/core/__init__.py
+++ b/src/viur/core/__init__.py
@@ -172,7 +172,9 @@ def buildApp(modules: Union[ModuleType, object], renderers: Union[ModuleType, Di
 
     conf["viur.mainResolver"] = resolver
 
-    if conf["viur.debug.trace"]:
+    if (conf["viur.debug.trace"]
+            or conf["viur.debug.traceExternalCallRouting"]
+            or conf["viur.debug.traceInternalCallRouting"]):
         from viur.core import email
         try:
             email.sendEMailToAdmins(

--- a/src/viur/core/__init__.py
+++ b/src/viur/core/__init__.py
@@ -172,7 +172,7 @@ def buildApp(modules: Union[ModuleType, object], renderers: Union[ModuleType, Di
 
     conf["viur.mainResolver"] = resolver
 
-    if conf["viur.debug.traceExternalCallRouting"] or conf["viur.debug.traceInternalCallRouting"]:
+    if conf["viur.debug.trace"]:
         from viur.core import email
         try:
             email.sendEMailToAdmins(

--- a/src/viur/core/config.py
+++ b/src/viur/core/config.py
@@ -101,6 +101,10 @@ conf = Conf({
     "viur.debug.trace": False,
     # If enabled, user-generated exceptions from the viur.core.errors module won't be caught and handled
     "viur.debug.traceExceptions": False,
+    # If enabled, ViUR will log which (exposed) function are called from outside with what arguments
+    "viur.debug.traceExternalCallRouting": False,
+    # If enabled, ViUR will log which (internal-exposed) function are called from templates with what arguments
+    "viur.debug.traceInternalCallRouting": False,
     # If enabled, log errors raises from skeleton.fromClient()
     "viur.debug.skeleton.fromClient": False,
 

--- a/src/viur/core/config.py
+++ b/src/viur/core/config.py
@@ -101,10 +101,6 @@ conf = Conf({
     "viur.debug.trace": False,
     # If enabled, user-generated exceptions from the viur.core.errors module won't be caught and handled
     "viur.debug.traceExceptions": False,
-    # If enabled, ViUR will log which (exposed) function are called from outside with what arguments
-    "viur.debug.traceExternalCallRouting": False,
-    # If enabled, ViUR will log which (internal-exposed) function are called from templates with what arguments
-    "viur.debug.traceInternalCallRouting": False,
     # If enabled, log errors raises from skeleton.fromClient()
     "viur.debug.skeleton.fromClient": False,
 

--- a/src/viur/core/request.py
+++ b/src/viur/core/request.py
@@ -530,7 +530,9 @@ class Router:
 
         if ((self.internalRequest and conf["viur.debug.traceInternalCallRouting"])
                 or conf["viur.debug.traceExternalCallRouting"]):
-            logging.debug(f"Calling {caller._func!r} with args={self.args!r}, {kwargs=} within context={self.context!r}")
+            logging.debug(
+                f"Calling {caller._func!r} with args={self.args!r}, {kwargs=} within context={self.context!r}"
+            )
 
         # Now call the routed method!
         res = caller(*self.args, **kwargs)

--- a/src/viur/core/request.py
+++ b/src/viur/core/request.py
@@ -117,7 +117,7 @@ class Router:
         self.pendingTasks = []
         self.args = ()
         self.kwargs = {}
-        self.contexts = {}
+        self.context = {}
 
         # Check if it's a HTTP-Method we support
         self.method = self.request.method.lower()
@@ -521,12 +521,16 @@ class Router:
                 logging.debug("Caching disabled by X-Viur-Disable-Cache header")
                 self.disableCache = True
 
-        # Copy contexts into self.contexts if available
-        if contexts := {k: v for k, v in self.kwargs.items() if k.startswith("@")}:
-            kwargs = {k: v for k, v in self.kwargs.items() if k not in contexts}
-            self.contexts |= contexts
+        # Copy context into self.context if available
+        if context := {k: v for k, v in self.kwargs.items() if k.startswith("@")}:
+            kwargs = {k: v for k, v in self.kwargs.items() if k not in context}
+            self.context |= context
         else:
             kwargs = self.kwargs
+
+        if ((self.internalRequest and conf["viur.debug.traceInternalCallRouting"])
+                or conf["viur.debug.traceExternalCallRouting"]):
+            logging.debug(f"Calling {caller._func!r} with args={self.args!r}, {kwargs=} within context={self.context!r}")
 
         # Now call the routed method!
         res = caller(*self.args, **kwargs)


### PR DESCRIPTION
Removes the defaults for `conf["viur.debug.traceExternalCallRouting"]` and `conf["viur.debug.traceInternalCallRouting"]`, which where removed by previous refactors.