### PR TITLE
feat: Add missing type hints for `current` module

### DIFF
--- a/src/viur/core/current.py
+++ b/src/viur/core/current.py
@@ -1,7 +1,14 @@
+import typing
 from contextvars import ContextVar
+from typing import Optional
 
-request = ContextVar("Request", default=None)
-request_data = ContextVar("Request-Data", default=None)
-session = ContextVar("Session", default=None)
-language = ContextVar("Language", default=None)
-user = ContextVar("User", default=None)
+if typing.TYPE_CHECKING:
+    from .request import Router
+    from .session import Session
+    from .skeleton import SkeletonInstance
+
+request: ContextVar[Optional["Router"]] = ContextVar("Request", default=None)
+request_data: ContextVar[Optional[dict]] = ContextVar("Request-Data", default=None)
+session: ContextVar[Optional["Session"]] = ContextVar("Session", default=None)
+language: ContextVar[Optional[str]] = ContextVar("Language", default=None)
+user: ContextVar[Optional["SkeletonInstance"]] = ContextVar("User", default=None)


### PR DESCRIPTION
Using forward references and `typing.TYPE_CHECKING` to avoid circular imports.