### PR TITLE
fix: Prefix `project_id` to all admin emails

### DIFF
--- a/src/viur/core/email.py
+++ b/src/viur/core/email.py
@@ -274,6 +274,9 @@ def sendEMailToAdmins(subject: str, body: str, *args, **kwargs) -> bool:
             for user_skel in conf["viur.mainApp"].user.viewSkel().all().filter("access =", "root").fetch():
                 users.append(user_skel["name"])
 
+        # Prefix the instance's project_id to subject
+        subject = conf["viur.instance.project_id"] + ": " + subject
+
         if users:
             ret = sendEMail(dests=users, stringTemplate=os.linesep.join((subject, body)), *args, **kwargs)
             success = True
@@ -432,9 +435,9 @@ class EmailTransportSendInBlue(EmailTransport):
                 if entity["latest_warning_for"] == limit:
                     logging.info(f"Already send an email for {limit = }.")
                     break
+
                 sendEMailToAdmins(
-                    f"SendInBlue email budget for {conf['viur.instance.project_id']}: "
-                    f"{credits} ({idx}. warning)",
+                    f"SendInBlue email budget {credits} ({idx}. warning)",
                     f"The SendInBlue email budget reached {credits} credits "
                     f"for {data['email']}. Please increase soon.",
                 )

--- a/src/viur/core/modules/user.py
+++ b/src/viur/core/modules/user.py
@@ -1429,9 +1429,11 @@ def createNewUserIfNotExists():
                 logging.error("Something went wrong when trying to add admin user %s with Password %s", uname, pw)
                 logging.exception(e)
                 return
-            logging.warning("ViUR created a new admin-user for you! Username: %s, Password: %s", uname, pw)
-            email.sendEMailToAdmins("Your new ViUR password",
-                                    "ViUR created a new admin-user for you! Username: %s, Password: %s" % (uname, pw))
+
+            msg = f"ViUR created a new admin-user for you!\nUsername: {uname}\nPassword: {pw}"
+
+            logging.warning(msg)
+            email.sendEMailToAdmins("New ViUR password", msg)
 
 
 # DEPRECATED ATTRIBUTES HANDLING


### PR DESCRIPTION
This prefixes the project's ID to every mail sent via `email.sendEMailToAdmins`, which helps to identify the project where the error occurs, especially when the same sib-credentials are used by multiple projects.