### PR TITLE
feat: Provide `Module`-specific `Logger`

### DIFF
--- a/src/viur/core/logging.py
+++ b/src/viur/core/logging.py
@@ -110,6 +110,10 @@ class ViURLocalFormatter(logging.Formatter):
 
         record.pathname = pathname
 
+        # Show logger-name before message when not "root" logger
+        if record.name != "root":
+            record.msg = record.name + ": " + record.msg
+
         # Select colorization mode
         match (os.getenv(f"VIUR_LOGGING_COLORIZATION") or "FULL").upper():
             case "DECENT":

--- a/src/viur/core/module.py
+++ b/src/viur/core/module.py
@@ -496,6 +496,7 @@ class Module:
     """
 
     def __init__(self, moduleName: str, modulePath: str, *args, **kwargs):
+        self.log = logging.getLogger(self.__class__.__name__)
         self.render = None  # will be set to the appropriate render instance at runtime
         self._cached_description = None  # caching used by describe()
         self.moduleName = moduleName  # Name of this module (usually it's class name, e.g. "file")

--- a/src/viur/core/module.py
+++ b/src/viur/core/module.py
@@ -496,7 +496,7 @@ class Module:
     """
 
     def __init__(self, moduleName: str, modulePath: str, *args, **kwargs):
-        self.log = logging.getLogger(self.__class__.__name__)
+        self.log = logging.getLogger(self.__class__.__name__.lower())
         self.render = None  # will be set to the appropriate render instance at runtime
         self._cached_description = None  # caching used by describe()
         self.moduleName = moduleName  # Name of this module (usually it's class name, e.g. "file")

--- a/src/viur/core/modules/moduleconf.py
+++ b/src/viur/core/modules/moduleconf.py
@@ -1,4 +1,3 @@
-import logging
 from viur.core.bones import StringBone, TextBone
 from viur.core.bones.text import _defaultTags
 from viur.core.tasks import StartupTask
@@ -59,7 +58,7 @@ class ModuleConf(List):
         db_key = db.Key("viur-module-conf", module_name)
         skel = conf["viur.mainApp"]._moduleconf.viewSkel()
         if not skel.fromDB(db_key):
-            logging.error(f"module({module_name}) not found in viur-module-conf")
+            self.log.error(f"module({module_name}) not found in viur-module-conf")
             return None
 
         return skel

--- a/src/viur/core/prototypes/list.py
+++ b/src/viur/core/prototypes/list.py
@@ -1,4 +1,3 @@
-import logging
 from typing import Any, Optional
 from viur.core import current, db, errors, utils
 from viur.core.decorators import *
@@ -74,7 +73,7 @@ class List(SkelModule):
         """
         return self.baseSkel(*args, **kwargs)
 
-    ## External exposed functions
+    # External exposed functions
 
     @exposed
     @force_post
@@ -307,7 +306,7 @@ class List(SkelModule):
     def getDefaultListParams(self):
         return {}
 
-    ## Default access control functions
+    # Default access control functions
 
     def listFilter(self, query: db.Query) -> Optional[db.Query]:
         """
@@ -471,7 +470,7 @@ class List(SkelModule):
 
         return False
 
-    ## Override-able event-hooks
+    # Override-able event-hooks
 
     def onAdd(self, skel: SkeletonInstance):
         """
@@ -496,10 +495,10 @@ class List(SkelModule):
 
             .. seealso:: :func:`add`, , :func:`onAdd`
         """
-        logging.info("Entry added: %s" % skel["key"])
+        self.log.info(f"Entry {skel['key']} added")
         flushCache(kind=skel.kindName)
         if user := current.user.get():
-            logging.info("User: %s (%s)" % (user["name"], user["key"]))
+            self.log.info(f"By user {user['name']!r} ({user['key']})")
 
     def onEdit(self, skel: SkeletonInstance):
         """
@@ -524,10 +523,10 @@ class List(SkelModule):
 
             .. seealso:: :func:`edit`, :func:`onEdit`
         """
-        logging.info("Entry changed: %s" % skel["key"])
+        self.log.info(f"Entry {skel['key']} edited")
         flushCache(key=skel["key"])
         if user := current.user.get():
-            logging.info("User: %s (%s)" % (user["name"], user["key"]))
+            self.log.info(f"By user {user['name']!r} ({user['key']})")
 
     def onView(self, skel: SkeletonInstance):
         """
@@ -565,10 +564,10 @@ class List(SkelModule):
 
             .. seealso:: :func:`delete`, :func:`onDelete`
         """
-        logging.info("Entry deleted: %s" % skel["key"])
+        self.log.info(f"Entry {skel['key']} deleted")
         flushCache(key=skel["key"])
         if user := current.user.get():
-            logging.info("User: %s (%s)" % (user["name"], user["key"]))
+            self.log.info(f"By user {user['name']!r} ({user['key']})")
 
 
 List.admin = True

--- a/src/viur/core/prototypes/singleton.py
+++ b/src/viur/core/prototypes/singleton.py
@@ -1,4 +1,3 @@
-import logging
 from typing import Any
 from viur.core import db, current, errors
 from viur.core.decorators import *
@@ -274,10 +273,10 @@ class Singleton(SkelModule):
 
         .. seealso:: :func:`edit`, :func:`onEdit`
         """
-        logging.info("Entry changed: %s" % skel["key"])
+        self.log.info(f"Entry {skel['key']} edited")
         flushCache(key=skel["key"])
         if user := current.user.get():
-            logging.info("User: %s (%s)" % (user["name"], user["key"]))
+            self.log.info(f"By user {user['name']!r} ({user['key']})")
 
     def onView(self, skel: SkeletonInstance):
         """

--- a/src/viur/core/prototypes/tree.py
+++ b/src/viur/core/prototypes/tree.py
@@ -1,4 +1,3 @@
-import logging
 from typing import Any, Dict, List, Literal, Optional, Type
 from viur.core import utils, errors, db, current
 from viur.core.decorators import *
@@ -188,9 +187,9 @@ class Tree(SkelModule):
         :param depth: Safety level depth preventing infinitive loops.
         """
         if depth > 99:
-            logging.critical("Maximum recursion depth reached in %s/updateParentRepo", self.updateParentRepo.__module__)
-            logging.critical("Your data is corrupt!")
-            logging.critical("Params: parentNode: %s, newRepoKey: %s" % (parentNode, newRepoKey))
+            self.log.critical("Maximum recursion depth reached in %s/updateParentRepo", self.updateParentRepo.__module__)
+            self.log.critical("Your data is corrupt!")
+            self.log.critical("Params: parentNode: %s, newRepoKey: %s" % (parentNode, newRepoKey))
             return
 
         def fixTxn(nodeKey, newRepoKey):
@@ -747,10 +746,10 @@ class Tree(SkelModule):
 
         .. seealso:: :func:`add`, :func:`onAdd`
         """
-        logging.info("Entry of kind %r added: %s", skelType, skel["key"])
+        self.log.info(f"Entry {skelType} {skel['key']} added")
         flushCache(kind=skel.kindName)
         if user := current.user.get():
-            logging.info("User: %s (%s)" % (user["name"], user["key"]))
+            self.log.info(f"By user {user['name']!r} ({user['key']})")
 
     def onEdit(self, skelType: SkelType, skel: SkeletonInstance):
         """
@@ -777,10 +776,10 @@ class Tree(SkelModule):
 
         .. seealso:: :func:`edit`, :func:`onEdit`
         """
-        logging.info("Entry of kind %r changed: %s", skelType, skel["key"])
+        self.log.info(f"Entry {skelType} {skel['key']} edited")
         flushCache(key=skel["key"])
         if user := current.user.get():
-            logging.info("User: %s (%s)" % (user["name"], user["key"]))
+            self.log.info(f"By user {user['name']!r} ({user['key']})")
 
     def onView(self, skelType: SkelType, skel: SkeletonInstance):
         """
@@ -824,10 +823,10 @@ class Tree(SkelModule):
 
         .. seealso:: :func:`delete`, :func:`onDelete`
         """
-        logging.info("Entry deleted: %s (%s)" % (skel["key"], type(skel)))
+        self.log.info(f"Entry {skelType} {skel['key']} deleted")
         flushCache(key=skel["key"])
         if user := current.user.get():
-            logging.info("User: %s (%s)" % (user["name"], user["key"]))
+            self.log.info(f"By user {user['name']!r} ({user['key']})")
 
 
 Tree.vi = True

--- a/src/viur/core/prototypes/tree.py
+++ b/src/viur/core/prototypes/tree.py
@@ -187,9 +187,9 @@ class Tree(SkelModule):
         :param depth: Safety level depth preventing infinitive loops.
         """
         if depth > 99:
-            self.log.critical("Maximum recursion depth reached in %s/updateParentRepo", self.updateParentRepo.__module__)
-            self.log.critical("Your data is corrupt!")
-            self.log.critical("Params: parentNode: %s, newRepoKey: %s" % (parentNode, newRepoKey))
+            self.log.critical(
+                f"Maximum recursion {depth=} reached, {parentNode=}, {newRepoKey=}, maybe a data corruption"
+            )
             return
 
         def fixTxn(nodeKey, newRepoKey):


### PR DESCRIPTION
Introduces `log`-member to Modules, so logs can be filtered by module and are also printed so to the local formatter, using 'Module: message'. No need to import logging to all your ViUR modules anymore, just use `self.log`.