### PR TITLE
feat: Add `expand`-flag to `RelationalBone`

### DIFF
--- a/src/viur/core/render/html/default.py
+++ b/src/viur/core/render/html/default.py
@@ -189,6 +189,8 @@ class Render(object):
             return KeyValueWrapper(boneValue, get_label(boneValue))
 
         elif bone.type == "relational" or bone.type.startswith("relational."):
+            # FIXME: Here, the RelationalBone.expand feature could be implemented,
+            # FIXME: in case this ugly, outdated piece of renderer is entirely refactored before.
             if isinstance(boneValue, list):
                 tmpList = []
                 for k in boneValue:


### PR DESCRIPTION
Allows for specific renders to expand the values of a RelationalBone to its full dest-skeleton, and not only the specified refKeys.

This is useful to directly fetch entire data structures with just one request, and is useful for modern single-page-apps.

Example usage:
```python
class UserPortal(Skeleton):
    portal = RelationalBone(
        descr="Portal",
        kind="portal",
        expand=True,
        readOnly=True,
        format="$(dest.identifier)",
        refKeys=["key", "identifier", "name"],
        consistency=RelationalConsistency.CascadeDeletion,
    )
```

This expands portal to its full skeleton, including all descriptions, logos, marketing-huiuiui-wheeee-images and texts without spamming the datastore, by extending all bones to refKeys. The userportal entity still only stores the values in refKeys.