### PR TITLE
fix: Clean-up Skeletons `key` default bone

### DIFF
--- a/src/viur/core/skeleton.py
+++ b/src/viur/core/skeleton.py
@@ -642,7 +642,9 @@ class Skeleton(BaseSkeleton, metaclass=MetaSkel):
     # The "key" bone stores the current database key of this skeleton.
     # Warning: Assigning to this bones value now *will* set the key
     # it gets stored in. Must be kept readOnly to avoid security-issues with add/edit.
-    key = KeyBone(descr="key", readOnly=True, visible=False)
+    key = KeyBone(
+        descr="Key"
+    )
 
     # The date (including time) when this entry has been created
     creationdate = DateBone(


### PR DESCRIPTION
KeyBone is by default `readOnly=True` and `visible=False`. Also, generally enforce capitalization for nouns.