### PR TITLE
fix: Raise an `AttributeError` in case of `KeyError` in `SkeletonInstance.boneMap`

### DIFF
--- a/src/viur/core/skeleton.py
+++ b/src/viur/core/skeleton.py
@@ -215,7 +215,10 @@ class SkeletonInstance:
                       "preProcessSerializedData", "preProcessBlobLocks", "postSavedHandler", "setBoneValue",
                       "delete", "postDeletedHandler", "refresh"}:
             return partial(getattr(self.skeletonCls, item), self)
-        return self.boneMap[item]
+        try:
+            return self.boneMap[item]
+        except KeyError:
+            raise AttributeError(f"{self.__class__.__name__!r} object has no attribute '{item}'")
 
     def __delattr__(self, item):
         del self.boneMap[item]


### PR DESCRIPTION

When trying to access an not existing attribute of a `SkeletonInstance` such as `skel.foo` an `KeyError` was raised. But an `AttributeError` should be raised instead.

This unpythonic behavior results in a bug when calling the periodic cron tasks: We've a module which that has a `db.Query` with `srcSkel` saved to it's instance, to use it for `Pagination`. On this `SkeletonInstance` the `in dir(...)` condition fails:
```py
Traceback (most recent call last):
  File "/layers/google.python.pip/pip/lib/python3.10/site-packages/viur/core/request.py", line 276, in processRequest
    self.findAndCall(path)
  File "/layers/google.python.pip/pip/lib/python3.10/site-packages/viur/core/request.py", line 636, in findAndCall
    res = caller(*newArgs, **newKwargs)
  File "/layers/google.python.pip/pip/lib/python3.10/site-packages/viur/core/tasks.py", line 309, in cron
    res = self.findBoundTask(task)
  File "/layers/google.python.pip/pip/lib/python3.10/site-packages/viur/core/tasks.py", line 185, in findBoundTask
    res = self.findBoundTask(task, v, depth + 1)
  File "/layers/google.python.pip/pip/lib/python3.10/site-packages/viur/core/tasks.py", line 185, in findBoundTask
    res = self.findBoundTask(task, v, depth + 1)
  File "/layers/google.python.pip/pip/lib/python3.10/site-packages/viur/core/tasks.py", line 185, in findBoundTask
    res = self.findBoundTask(task, v, depth + 1)
  File "/layers/google.python.pip/pip/lib/python3.10/site-packages/viur/core/tasks.py", line 175, in findBoundTask
    for attr in dir(obj):
  File "/layers/google.python.pip/pip/lib/python3.10/site-packages/viur/core/skeleton.py", line 217, in __getattr__
    return self.boneMap[item]
KeyError: '__dict__'
```

---


I just saw that there was already a ticket (#907). That should be exactly the case.