### PR TITLE
fix: Always set `Secure` mode for session cookie

### DIFF
--- a/src/viur/core/session.py
+++ b/src/viur/core/session.py
@@ -117,7 +117,7 @@ class Session:
             "Path=/",
             "HttpOnly",
             f"SameSite={self.same_site}" if self.same_site else None,
-            "Secure" if not conf["viur.instance.is_dev_server"] else None,
+            "Secure",
             f"Max-Age={conf['viur.session.lifeTime']}" if not self.use_session_cookie else None,
         )
 


### PR DESCRIPTION
According to https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#secure, and in combination with SameSite=none, Secure must be set, and is ignored on localhost since Chrome 89 and Firefox 75.

The disabling of `Secure` on local development server is therefore source for blocked cookies in combination with `SameSite`, and shall be removed.