### PR TITLE
fix: `access` in method description must not be a generator object

### DIFF
--- a/src/viur/core/module.py
+++ b/src/viur/core/module.py
@@ -324,7 +324,7 @@ class Method:
             ret["skey"] = self.skey["name"]
 
         if self.access:
-            ret["access"] = (str(access) for access in self.access["access"])
+            ret["access"] = [str(access) for access in self.access["access"]]
 
         return ret
 

--- a/src/viur/core/module.py
+++ b/src/viur/core/module.py
@@ -324,7 +324,7 @@ class Method:
             ret["skey"] = self.skey["name"]
 
         if self.access:
-            ret["access"] = [str(access) for access in self.access["access"]]
+            ret["access"] = [str(access) for access in self.access["access"]]  # must be a list to be JSON-serializable
 
         return ret
 


### PR DESCRIPTION
A generator object is not JSON serializeable and `dumpConfig` fails