### PR TITLE
feat: use `CustomJsonEncoder` class in `json.dumps` call

### DIFF
--- a/src/viur/core/render/json/default.py
+++ b/src/viur/core/render/json/default.py
@@ -224,4 +224,4 @@ class DefaultRender(object):
         for rn in rootNodes:
             rn["key"] = db.encodeKey(rn["key"])
 
-        return json.dumps(rootNodes)
+        return json.dumps(rootNodes, cls=CustomJsonEncoder)

--- a/src/viur/core/render/json/user.py
+++ b/src/viur/core/render/json/user.py
@@ -1,6 +1,7 @@
 import json
 from viur.core.modules.user import UserSecondFactorAuthentication
 from . import default as DefaultRender
+from .default import CustomJsonEncoder
 
 
 class UserRender(DefaultRender):  # Render user-data to json
@@ -11,7 +12,7 @@ class UserRender(DefaultRender):  # Render user-data to json
         return self.edit(skel, **kwargs)
 
     def loginChoices(self, authMethods, **kwargs):
-        return json.dumps(list(set([x[0] for x in authMethods])))
+        return json.dumps(list(set([x[0] for x in authMethods])), cls=CustomJsonEncoder)
 
     def loginSucceeded(self, msg="OKAY", **kwargs):
         return json.dumps(msg)
@@ -47,4 +48,4 @@ class UserRender(DefaultRender):  # Render user-data to json
     ):
         second_factors = [{"name": second_factor.NAME, "start_url": second_factor.start_url}
                           for second_factor in second_factors]
-        return json.dumps(second_factors)
+        return json.dumps(second_factors, cls=CustomJsonEncoder)

--- a/src/viur/core/render/vi/__init__.py
+++ b/src/viur/core/render/vi/__init__.py
@@ -158,7 +158,7 @@ def get_settings():
     fields["admin.user.google.clientID"] = conf.user.google_client_id
 
     current.request.get().response.headers["Content-Type"] = "application/json"
-    return json.dumps(fields)
+    return json.dumps(fields, cls=CustomJsonEncoder)
 
 
 def _postProcessAppObj(obj):


### PR DESCRIPTION
I want to translate our repo names, the `CustomJsonEncoder` can resolve the `translate` objects. Just in case I've added this class where it could make sense to have translated objects too.