### PR TITLE
fix: Invalid `maxLength` check in `StringBone`

### DIFF
--- a/src/viur/core/bones/string.py
+++ b/src/viur/core/bones/string.py
@@ -114,7 +114,7 @@ class StringBone(BaseBone):
         this bone, otherwise the empty value and an error-message.
         """
         if not (err := self.isInvalid(value)):
-            return utils.escapeString(value, self.maxLength), None
+            return utils.escapeString(value, None), None
         return self.getEmptyValue(), [ReadFromClientError(ReadFromClientErrorSeverity.Invalid, err)]
 
     def buildDBFilter(

--- a/src/viur/core/bones/string.py
+++ b/src/viur/core/bones/string.py
@@ -104,7 +104,7 @@ class StringBone(BaseBone):
         Returns None if the value would be valid for
         this bone, an error-message otherwise.
         """
-        if self.maxLength is not None and len(value) > self.maxLength:
+        if self.maxLength is not None and len(str(value)) > self.maxLength:
             return "Maximum length exceeded"
         return None
 

--- a/src/viur/core/bones/string.py
+++ b/src/viur/core/bones/string.py
@@ -109,10 +109,12 @@ class StringBone(BaseBone):
         return None
 
     def singleValueFromClient(self, value, skel, bone_name, client_data):
-        value = utils.escapeString(value, self.maxLength)
-
+        """
+        Returns None and the escaped value if the value would be valid for
+        this bone, otherwise the empty value and an error-message.
+        """
         if not (err := self.isInvalid(value)):
-            return value, None
+            return utils.escapeString(value, self.maxLength), None
         return self.getEmptyValue(), [ReadFromClientError(ReadFromClientErrorSeverity.Invalid, err)]
 
     def buildDBFilter(


### PR DESCRIPTION
This PR fixes the problem that the value was always shortened to the maximum length before it was checked for the maximum length and so you simply lose data without getting an error message