### PR TITLE
refactor: Rename `StringBone`'s `maxLength` into `max_length`

### DIFF
--- a/src/viur/core/bones/credential.py
+++ b/src/viur/core/bones/credential.py
@@ -17,10 +17,11 @@ class CredentialBone(StringBone):
     def __init__(
         self,
         *,
-        maxLength: int = None,  # Unlimited length
+        max_length: int = None,  # Unlimited length
         **kwargs
     ):
-        super().__init__(maxLength=maxLength, **kwargs)
+
+        super().__init__(max_length=max_length, **kwargs)
         if self.multiple or self.languages:
             raise ValueError("CredentialBone cannot be multiple or translated")
 
@@ -31,7 +32,7 @@ class CredentialBone(StringBone):
         """
         if value is None:
             return False
-        if self.maxLength is not None and len(value) > self.maxLength:
+        if self.max_length is not None and len(value) > self.max_length:
             return "Maximum length exceeded"
 
     def serialize(self, skel: 'SkeletonInstance', name: str, parentIndexed: bool) -> bool:

--- a/src/viur/core/bones/string.py
+++ b/src/viur/core/bones/string.py
@@ -36,7 +36,7 @@ class StringBone(BaseBone):
         """
         # fixme: Remove in viur-core >= 4
         if "maxLength" in kwargs:
-            warnings.warn("maxLength is deprecated, please use max_length")
+            warnings.warn("maxLength parameter is deprecated, please use max_length", DeprecationWarning)
             max_length = kwargs.pop("maxLength")
         super().__init__(**kwargs)
         if max_length is not None and max_length <= 0:
@@ -308,6 +308,6 @@ class StringBone(BaseBone):
 
     def structure(self) -> dict:
         ret = super().structure() | {
-            "max_length": self.max_length
+            "maxlength": self.max_length
         }
         return ret

--- a/src/viur/core/bones/string.py
+++ b/src/viur/core/bones/string.py
@@ -44,7 +44,6 @@ class StringBone(BaseBone):
         super().__init__(**kwargs)
         if max_length is not None and max_length <= 0:
             raise ValueError("max_length must be a positive integer or None")
-        
         if min_length is not None and min_length <= 0:
             raise ValueError("min_length must be a positive integer or None")
         if min_length is not None and max_length is not None:
@@ -320,7 +319,7 @@ class StringBone(BaseBone):
 
     def structure(self) -> dict:
         ret = super().structure() | {
-            "maxlength": self.max_length
+            "maxlength": self.max_length,
             "minlength": self.min_length
         }
         return ret

--- a/src/viur/core/bones/string.py
+++ b/src/viur/core/bones/string.py
@@ -26,7 +26,6 @@ class StringBone(BaseBone):
         Initializes a new StringBone.
 
         :param caseSensitive: When filtering for values in this bone, should it be case-sensitive?
-
         :param max_length: The maximum length allowed for values of this bone. Set to None for no limitation.
         :param min_length: The minimum length allowed for values of this bone. Set to None for no limitation.
         :param natural_sorting: Allows a more natural sorting

--- a/src/viur/core/bones/string.py
+++ b/src/viur/core/bones/string.py
@@ -1,3 +1,5 @@
+import warnings
+
 import logging
 from typing import Callable, Dict, List, Optional, Set
 
@@ -15,7 +17,7 @@ class StringBone(BaseBone):
         self,
         *,
         caseSensitive: bool = True,
-        maxLength: int | None = 254,
+        max_length: int | None = 254,
         natural_sorting: bool | Callable = False,
         **kwargs
     ):
@@ -23,7 +25,7 @@ class StringBone(BaseBone):
         Initializes a new StringBone.
 
         :param caseSensitive: When filtering for values in this bone, should it be case-sensitive?
-        :param maxLength: The maximum length allowed for values of this bone. Set to None for no limitation.
+        :param max_length: The maximum length allowed for values of this bone. Set to None for no limitation.
         :param natural_sorting: Allows a more natural sorting
             than the default sorting on the plain values.
             This uses the .sort_idx property.
@@ -32,11 +34,15 @@ class StringBone(BaseBone):
             that creates the value for the index property.
         :param kwargs: Inherited arguments from the BaseBone.
         """
+        # fixme: Remove in viur-core >= 4
+        if "maxLength" in kwargs:
+            warnings.warn("maxLength is deprecated, please use max_length")
+            max_length = kwargs.pop("maxLength")
         super().__init__(**kwargs)
-        if maxLength is not None and maxLength <= 0:
-            raise ValueError("maxLength must be a positive integer or None")
+        if max_length is not None and max_length <= 0:
+            raise ValueError("max_length must be a positive integer or None")
         self.caseSensitive = caseSensitive
-        self.maxLength = maxLength
+        self.max_length = max_length
         if callable(natural_sorting):
             self.natural_sorting = natural_sorting
         elif not isinstance(natural_sorting, bool):
@@ -104,12 +110,12 @@ class StringBone(BaseBone):
         Returns None if the value would be valid for
         this bone, an error-message otherwise.
         """
-        if self.maxLength is not None and len(value) > self.maxLength:
+        if self.max_length is not None and len(value) > self.max_length:
             return "Maximum length exceeded"
         return None
 
     def singleValueFromClient(self, value, skel, bone_name, client_data):
-        value = utils.escapeString(value, self.maxLength)
+        value = utils.escapeString(value, self.max_length)
 
         if not (err := self.isInvalid(value)):
             return value, None
@@ -302,6 +308,6 @@ class StringBone(BaseBone):
 
     def structure(self) -> dict:
         ret = super().structure() | {
-            "maxlength": self.maxLength
+            "max_length": self.max_length
         }
         return ret

--- a/src/viur/core/bones/text.py
+++ b/src/viur/core/bones/text.py
@@ -365,7 +365,7 @@ class TextBone(BaseBone):
         """
         # fixme: Remove in viur-core >= 4
         if "maxLength" in kwargs:
-            warnings.warn("maxLength is deprecated, please use max_length")
+            warnings.warn("maxLength parameter is deprecated, please use max_length", DeprecationWarning)
             max_length = kwargs.pop("maxLength")
         super().__init__(indexed=indexed, **kwargs)
 

--- a/src/viur/core/bones/text.py
+++ b/src/viur/core/bones/text.py
@@ -3,6 +3,7 @@ The `text` module contains the `Textbone` and a custom HTML-Parser
 to validate and extract client data for the `TextBone`.
 """
 import string
+import warnings
 from base64 import urlsafe_b64decode
 from datetime import datetime
 from html import entities as htmlentitydefs
@@ -332,7 +333,7 @@ class TextBone(BaseBone):
 
     :param Union[None, Dict] validHtml: A dictionary containing allowed HTML tags and their attributes. Defaults
         to _defaultTags. Must be a structured like :prop:_defaultTags
-    :param int maxLength: The maximum allowed length for the content. Defaults to 200000.
+    :param int max_length: The maximum allowed length for the content. Defaults to 200000.
     :param languages: If set, this bone can store a different content for each language
     :param Dict[str, List] srcSet: An optional dictionary containing width and height for srcset generation.
         Must be a dict of "width": [List of Ints], "height": [List of Ints], eg {"height": [720, 1080]}
@@ -349,7 +350,7 @@ class TextBone(BaseBone):
         self,
         *,
         validHtml: Union[None, Dict] = __undefinedC__,
-        maxLength: int = 200000,
+        max_length: int = 200000,
         srcSet: Optional[Dict[str, List]] = None,
         indexed: bool = False,
         **kwargs
@@ -357,11 +358,15 @@ class TextBone(BaseBone):
         """
             :param validHtml: If set, must be a structure like :prop:_defaultTags
             :param languages: If set, this bone can store a different content for each language
-            :param maxLength: Limit content to maxLength bytes
-            :param indexed: Must not be set True, unless you limit maxLength accordingly
+            :param max_length: Limit content to max_length bytes
+            :param indexed: Must not be set True, unless you limit max_length accordingly
             :param srcSet: If set, inject srcset tags to embedded images. Must be a dict of
                 "width": [List of Ints], "height": [List of Ints], eg {"height": [720, 1080]}
         """
+        # fixme: Remove in viur-core >= 4
+        if "maxLength" in kwargs:
+            warnings.warn("maxLength is deprecated, please use max_length")
+            max_length = kwargs.pop("maxLength")
         super().__init__(indexed=indexed, **kwargs)
 
         if validHtml == TextBone.__undefinedC__:
@@ -369,7 +374,7 @@ class TextBone(BaseBone):
             validHtml = _defaultTags
 
         self.validHtml = validHtml
-        self.maxLength = maxLength
+        self.max_length = max_length
         self.srcSet = srcSet
 
     def singleValueSerialize(self, value, skel: 'SkeletonInstance', name: str, parentIndexed: bool):
@@ -412,7 +417,7 @@ class TextBone(BaseBone):
 
         if value == None:
             return "No value entered"
-        if len(value) > self.maxLength:
+        if len(value) > self.max_length:
             return "Maximum length exceeded"
 
     def getReferencedBlobs(self, skel: 'viur.core.skeleton.SkeletonInstance', name: str) -> Set[str]:

--- a/src/viur/core/render/json/default.py
+++ b/src/viur/core/render/json/default.py
@@ -47,7 +47,7 @@ class DefaultRender(object):
                     "boundslng": "boundsLng",
                     "emptyvalue": "emptyValue",
                     "max": "maxAmount",
-                    "maxlength": "max_length",
+                    "maxlength": "maxLength",
                     "min": "minAmount",
                     "preventduplicates": "preventDuplicates",
                     "readonly": "readOnly",

--- a/src/viur/core/render/json/default.py
+++ b/src/viur/core/render/json/default.py
@@ -47,7 +47,7 @@ class DefaultRender(object):
                     "boundslng": "boundsLng",
                     "emptyvalue": "emptyValue",
                     "max": "maxAmount",
-                    "max_length": "max_length",
+                    "maxlength": "max_length",
                     "min": "minAmount",
                     "preventduplicates": "preventDuplicates",
                     "readonly": "readOnly",

--- a/src/viur/core/render/json/default.py
+++ b/src/viur/core/render/json/default.py
@@ -47,7 +47,7 @@ class DefaultRender(object):
                     "boundslng": "boundsLng",
                     "emptyvalue": "emptyValue",
                     "max": "maxAmount",
-                    "maxlength": "maxLength",
+                    "max_length": "max_length",
                     "min": "minAmount",
                     "preventduplicates": "preventDuplicates",
                     "readonly": "readOnly",

--- a/src/viur/core/utils.py
+++ b/src/viur/core/utils.py
@@ -79,7 +79,7 @@ def escapeString(val: str, max_length: int = 254, **kwargs) -> str:
     """
     # fixme: Remove in viur-core >= 4
     if "maxLength" in kwargs:
-        warnings.warn("maxLength is deprecated, please use max_length")
+        warnings.warn("maxLength parameter is deprecated, please use max_length", DeprecationWarning)
         max_length = kwargs.pop("maxLength")
 
     val = str(val).strip() \

--- a/src/viur/core/utils.py
+++ b/src/viur/core/utils.py
@@ -67,12 +67,12 @@ def markFileForDeletion(dlkey: str) -> None:
     db.Put(fileObj)
 
 
-def escapeString(val: str, maxLength: int = 254) -> str:
+def escapeString(val: str, max_length: int = 254) -> str:
     """
         Quotes several characters and removes "\\\\n" and "\\\\0" to prevent XSS injection.
 
         :param val: The value to be escaped.
-        :param maxLength: Cut-off after maxLength characters. A value of 0 means "unlimited".
+        :param max_length: Cut-off after max_length characters. A value of 0 means "unlimited".
         :returns: The quoted string.
     """
     val = str(val).strip() \
@@ -86,8 +86,8 @@ def escapeString(val: str, maxLength: int = 254) -> str:
         .replace("\n", "") \
         .replace("\0", "")
 
-    if maxLength:
-        return val[0:maxLength]
+    if max_length:
+        return val[0:max_length]
 
     return val
 

--- a/src/viur/core/utils.py
+++ b/src/viur/core/utils.py
@@ -94,7 +94,7 @@ def escapeString(val: str, max_length: int = 254, **kwargs) -> str:
         .replace("\0", "")
 
     if max_length:
-        return val[0:max_length]
+        return val[:max_length]
 
     return val
 

--- a/src/viur/core/utils.py
+++ b/src/viur/core/utils.py
@@ -1,5 +1,7 @@
 import hashlib
 import hmac
+import warnings
+
 import logging
 import secrets
 import string
@@ -67,7 +69,7 @@ def markFileForDeletion(dlkey: str) -> None:
     db.Put(fileObj)
 
 
-def escapeString(val: str, max_length: int = 254) -> str:
+def escapeString(val: str, max_length: int = 254, **kwargs) -> str:
     """
         Quotes several characters and removes "\\\\n" and "\\\\0" to prevent XSS injection.
 
@@ -75,6 +77,11 @@ def escapeString(val: str, max_length: int = 254) -> str:
         :param max_length: Cut-off after max_length characters. A value of 0 means "unlimited".
         :returns: The quoted string.
     """
+    # fixme: Remove in viur-core >= 4
+    if "maxLength" in kwargs:
+        warnings.warn("maxLength is deprecated, please use max_length")
+        max_length = kwargs.pop("maxLength")
+
     val = str(val).strip() \
         .replace("<", "&lt;") \
         .replace(">", "&gt;") \

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,5 +11,5 @@ class TestUtils(unittest.TestCase):
         from viur.core.utils import escapeString
 
         self.assertEqual("None", escapeString(None))
-        self.assertEqual("abcde", escapeString("abcdefghi", maxLength=5))
+        self.assertEqual("abcde", escapeString("abcdefghi", max_length=5))
         self.assertEqual("&lt;html&gt;&&lt;/html&gt;", escapeString("<html>\n&\0</html>"))


### PR DESCRIPTION
Replace all `maxLength` with `max_length` and a backwards compatible check with a warning.