### PR TITLE
refactor: static skey marker

### DIFF
--- a/src/viur/core/modules/user.py
+++ b/src/viur/core/modules/user.py
@@ -1285,7 +1285,7 @@ class User(List):
         # Update session, user and request
         session["user"] = skel.dbEntity
 
-        current.request.get().response.headers[securitykey.SECURITYKEY_STATIC] = session.static_security_key
+        current.request.get().response.headers[securitykey.SECURITYKEY_STATIC_HEADER] = session.static_security_key
         current.user.set(self.getCurrentUser())
 
         self.onLogin(skel)

--- a/src/viur/core/securitykey.py
+++ b/src/viur/core/securitykey.py
@@ -12,7 +12,7 @@
         This key is only revealed once during login, as the protected header "Sec-X-ViUR-StaticSessionKey".
 
         This can be used instead of the one-time sessions security key by sending it back as the same protected HTTP
-        header and setting the skey value to "Sec-X-ViUR-StaticSessionKey". This is only intended for non-web-browser,
+        header and setting the skey value to "STATIC_SESSION_KEY". This is only intended for non-web-browser,
         programmatic access (admin tools, import tools etc.) where CSRF attacks are not applicable.
 
         Therefor that header is prefixed with "Sec-" - so it cannot be read or set using JavaScript.
@@ -24,7 +24,12 @@ from viur.core import conf, utils, current, db, tasks
 
 SECURITYKEY_KINDNAME = "viur-securitykey"
 SECURITYKEY_DURATION = 24 * 60 * 60  # one day
-SECURITYKEY_STATIC = "Sec-X-ViUR-StaticSessionKey"
+SECURITYKEY_STATIC_HEADER: typing.Final[str] = "Sec-X-ViUR-StaticSessionKey"
+"""The name of the header in which the static session key is provided at login
+and must be specified in requests that require a skey."""
+SECURITYKEY_STATIC_SKEY: typing.Final[str] = "STATIC_SESSION_KEY"
+"""Value that must be used as a marker in the payload (key: skey) to indicate
+that the session key from the headers should be used."""
 
 
 def create(
@@ -77,8 +82,8 @@ def validate(key: str, session_bound: bool = True) -> typing.Union[bool, db.Enti
         :returns: False if the key was not valid for whatever reasons, the data (given during :meth:`create`) as
             dictionary or True if the dict is empty (or session was True).
     """
-    if session_bound and key == SECURITYKEY_STATIC:
-        if skey_header_value := current.request.get().request.headers.get(SECURITYKEY_STATIC):
+    if session_bound and key == SECURITYKEY_STATIC_SKEY:
+        if skey_header_value := current.request.get().request.headers.get(SECURITYKEY_STATIC_HEADER):
             return hmac.compare_digest(current.session.get().static_security_key, skey_header_value)
 
         return False


### PR DESCRIPTION
Resolve #796 as follow-up of #764

Before #764 the marker was `staticSessionKey`, but that wasn't PEP8. And since that has already been changed, I am using a new name, which IMO is better understood as a constant marker.