### PR TITLE
fix: Readd is_dev_server check for secure cookies

### DIFF
--- a/src/viur/core/session.py
+++ b/src/viur/core/session.py
@@ -117,7 +117,7 @@ class Session:
             "Path=/",
             "HttpOnly",
             f"SameSite={self.same_site}" if self.same_site else None,
-            "Secure",
+            "Secure" if conf['viur.instance.is_dev_server'] else None,
             f"Max-Age={conf['viur.session.lifeTime']}" if not self.use_session_cookie else None,
         )
 


### PR DESCRIPTION
Revert https://github.com/viur-framework/viur-core/pull/931
If you set the cookie to `secure` but use [requests](https://github.com/psf/requests) to establish a connection via `http`, the python [http](https://github.com/python/cpython/tree/main/Lib/http) lib throws the cookie away.

Code:
https://github.com/python/cpython/blob/05a370abd6cdfe4b54be60b3b911f3a441026bb2/Lib/http/cookiejar.py#L1135-L1139