### PR TITLE
fix: Get rid of the catch all index behavior in vi renderer

### DIFF
--- a/src/viur/core/render/vi/__init__.py
+++ b/src/viur/core/render/vi/__init__.py
@@ -141,6 +141,8 @@ def canAccess(*args, **kwargs) -> bool:
 
 @exposed
 def index(*args, **kwargs):
+    if args or kwargs:
+        raise errors.NotFound
     if not conf.instance.project_base_path.joinpath("vi", "main.html").exists():
         raise errors.NotFound()
     if conf.instance.is_dev_server or current.request.get().isSSLConnection:

--- a/src/viur/core/render/vi/__init__.py
+++ b/src/viur/core/render/vi/__init__.py
@@ -142,7 +142,7 @@ def canAccess(*args, **kwargs) -> bool:
 @exposed
 def index(*args, **kwargs):
     if args or kwargs:
-        raise errors.NotFound
+        raise errors.NotFound()
     if not conf.instance.project_base_path.joinpath("vi", "main.html").exists():
         raise errors.NotFound()
     if conf.instance.is_dev_server or current.request.get().isSSLConnection:


### PR DESCRIPTION
Only `/vi/` should redirect, in case of `/vi/usre` (typo) it should raise an error (404) instead of redirection.

Resolves #787 
Alternative to #955 