### PR TITLE
fix: disable cookie's `SameSite` and `Secure` for local server

### DIFF
--- a/src/viur/core/session.py
+++ b/src/viur/core/session.py
@@ -116,8 +116,8 @@ class Session:
         flags = (
             "Path=/",
             "HttpOnly",
-            f"SameSite={self.same_site}" if self.same_site else None,
-            "Secure",
+            f"SameSite={self.same_site}" if self.same_site and not conf["viur.instance.is_dev_server"] else None,
+            "Secure" if not conf["viur.instance.is_dev_server"] else None,
             f"Max-Age={conf['viur.session.lifeTime']}" if not self.use_session_cookie else None,
         )
 


### PR DESCRIPTION
`SameSite=None` requires `Secure` and modern browsers can ignore `Secure` (see #931) but `requests` doesn't ignore `Secure` of a cookie (see #949).

Therefore the consequence is to disable `SameSite` on localhost (which means the default `lax` is used) and obmitting the Secure attribute.


---

To reproduce the problem after #931 you can use this script:
```py
import requests

with requests.Session() as sess:
    for i in range(3):
        r = sess.get("http://localhost:8080")
        print(r.cookies)
        print(sess.cookies)
```

Before (current main, v3.5.7):
```py
<RequestsCookieJar[<Cookie viur_cookie_my-project=a0I9Y9smrNnk5qKDIuuC4vaANDRxH60LtOqjm8LYXL for localhost.local/>]>
<RequestsCookieJar[<Cookie viur_cookie_my-project=a0I9Y9smrNnk5qKDIuuC4vaANDRxH60LtOqjm8LYXL for localhost.local/>]>
<RequestsCookieJar[<Cookie viur_cookie_my-project=8N7Pnm6g18XUsGqa9qzaALspQo6oGsYpjhduNu1bKr for localhost.local/>]>
<RequestsCookieJar[<Cookie viur_cookie_my-project=8N7Pnm6g18XUsGqa9qzaALspQo6oGsYpjhduNu1bKr for localhost.local/>]>
<RequestsCookieJar[<Cookie viur_cookie_my-project=seoB2Up2J1gut3DC4UbH5n8tj64oZ8jsxpvu7lXJEE for localhost.local/>]>
<RequestsCookieJar[<Cookie viur_cookie_my-project=seoB2Up2J1gut3DC4UbH5n8tj64oZ8jsxpvu7lXJEE for localhost.local/>]>
```



Now (with this PR patch):
```py
<RequestsCookieJar[<Cookie viur_cookie_my-project=hb3YFGtNWRtSjxXFqVIJalKcsUOJHvs5rH7cZP317I for localhost.local/>]>
<RequestsCookieJar[<Cookie viur_cookie_my-project=hb3YFGtNWRtSjxXFqVIJalKcsUOJHvs5rH7cZP317I for localhost.local/>]>
<RequestsCookieJar[]>
<RequestsCookieJar[<Cookie viur_cookie_my-project=hb3YFGtNWRtSjxXFqVIJalKcsUOJHvs5rH7cZP317I for localhost.local/>]>
<RequestsCookieJar[]>
<RequestsCookieJar[<Cookie viur_cookie_my-project=hb3YFGtNWRtSjxXFqVIJalKcsUOJHvs5rH7cZP317I for localhost.local/>]>
```


As you can see the cookie is now constant during the same session used.