### PR TITLE
feat: Add stacklevels to `warning.warn` calls

### DIFF
--- a/src/viur/core/bones/__init__.py
+++ b/src/viur/core/bones/__init__.py
@@ -87,7 +87,7 @@ for __cls_name, __cls in locals().copy().items():
             def __init__(self, *args, **kwargs):
                 import logging, warnings
                 logging.warning(f"Use of class '{old_cls_name}' is deprecated, use '{cls_name}' instead.")
-                warnings.warn(f"Use of class '{old_cls_name}' is deprecated, use '{cls_name}' instead.")
+                warnings.warn(f"Use of class '{old_cls_name}' is deprecated, use '{cls_name}' instead.", stacklevel=2)
                 cls.__init__(self, *args, **kwargs)
 
             return __init__

--- a/src/viur/core/config.py
+++ b/src/viur/core/config.py
@@ -91,7 +91,8 @@ class ConfigType:
             old, key = key, self._mapping[key]
             warnings.warn(
                 f"Conf member {self._path}{old} is now {self._path}{key}!",
-                DeprecationWarning
+                DeprecationWarning,
+                stacklevel=3,
             )
         return key
 


### PR DESCRIPTION
The line which caused the deprecation should be printed, not the line where the the `warn` call is done.