### PR TITLE
fix: Add `try`/`except` around task emulation call

### DIFF
--- a/src/viur/core/request.py
+++ b/src/viur/core/request.py
@@ -418,7 +418,10 @@ class Router:
             while self.pendingTasks:
                 task = self.pendingTasks.pop()
                 logging.debug(f"Deferred task emulation, executing {task=}")
-                task()
+                try:
+                    task()
+                except Exception:  # noqa
+                    logging.exception(f"Deferred Task emulation {task} failed")
 
     def _route(self, path: str) -> None:
         """


### PR DESCRIPTION
If a deferred task fails, the entire request will fails. To run most tasks as possible this patch adds an `try`/`except` block around each call.