### PR TITLE
feat: add hooks on_item_added_and_edited and `on_item_added_and_edited_and_deleted`

### DIFF
--- a/src/viur/core/prototypes/list.py
+++ b/src/viur/core/prototypes/list.py
@@ -500,6 +500,8 @@ class List(SkelModule):
         flushCache(kind=skel.kindName)
         if user := current.user.get():
             logging.info("User: %s (%s)" % (user["name"], user["key"]))
+        self.on_item_added_and_edited(skel)
+        self.on_item_added_and_edited_and_deleted(skel)
 
     def onEdit(self, skel: SkeletonInstance):
         """
@@ -528,6 +530,8 @@ class List(SkelModule):
         flushCache(key=skel["key"])
         if user := current.user.get():
             logging.info("User: %s (%s)" % (user["name"], user["key"]))
+        self.on_item_added_and_edited(skel)
+        self.on_item_added_and_edited_and_deleted(skel)
 
     def onView(self, skel: SkeletonInstance):
         """
@@ -569,6 +573,21 @@ class List(SkelModule):
         flushCache(key=skel["key"])
         if user := current.user.get():
             logging.info("User: %s (%s)" % (user["name"], user["key"]))
+        self.on_item_added_and_edited_and_deleted(skel)
+
+    def on_item_added_and_edited(self, skel: SkeletonInstance) -> None:
+        """Hook method which will be called if a skeleton changed.
+
+        Useful to do the same action onAdded, onEdited.
+        """
+        pass
+
+    def on_item_added_and_edited_and_deleted(self, skel: SkeletonInstance) -> None:
+        """Hook method which will be called if a skeleton changed.
+
+        Useful to do the same action onAdded, onEdited and onDeleted.
+        """
+        pass
 
 
 List.admin = True

--- a/src/viur/core/prototypes/tree.py
+++ b/src/viur/core/prototypes/tree.py
@@ -752,6 +752,8 @@ class Tree(SkelModule):
         flushCache(kind=skel.kindName)
         if user := current.user.get():
             logging.info("User: %s (%s)" % (user["name"], user["key"]))
+        self.on_item_added_and_edited(skel)
+        self.on_item_added_and_edited_and_deleted(skel)
 
     def onEdit(self, skelType: SkelType, skel: SkeletonInstance):
         """
@@ -782,6 +784,8 @@ class Tree(SkelModule):
         flushCache(key=skel["key"])
         if user := current.user.get():
             logging.info("User: %s (%s)" % (user["name"], user["key"]))
+        self.on_item_added_and_edited(skel)
+        self.on_item_added_and_edited_and_deleted(skel)
 
     def onView(self, skelType: SkelType, skel: SkeletonInstance):
         """
@@ -829,7 +833,21 @@ class Tree(SkelModule):
         flushCache(key=skel["key"])
         if user := current.user.get():
             logging.info("User: %s (%s)" % (user["name"], user["key"]))
+        self.on_item_added_and_edited_and_deleted(skel)
 
+    def on_item_added_and_edited(self, skel: SkeletonInstance) -> None:
+        """Hook method which will be called if a skeleton changed.
+
+        Useful to do the same action onAdded, onEdited.
+        """
+        pass
+
+    def on_item_added_and_edited_and_deleted(self, skel: SkeletonInstance) -> None:
+        """Hook method which will be called if a skeleton changed.
+
+        Useful to do the same action onAdded, onEdited and onDeleted.
+        """
+        pass
 
 Tree.vi = True
 Tree.admin = True


### PR DESCRIPTION
I've often methods / actions that should be called after and skeleton has changes and exist (`on_item_added_and_edited`) or a skeleton has changes in any way (`on_item_added_and_edited_and_deleted`). 
With these methods it's very easy to call these actions.


--- 

I know the name is long, but expressive. And to be honest, I don't have a better one. `on_changed` would be okay for all three cases, but how should the other one be called?
