### PR TITLE
feat: Provide `UserPassword.on_login()` hook

### DIFF
--- a/src/viur/core/modules/user.py
+++ b/src/viur/core/modules/user.py
@@ -341,6 +341,13 @@ class UserPassword(UserAuthentication):
             skel["password"] = password  # will be hashed on serialize
             skel.toDB(update_relations=False)
 
+        return self.on_login(user_entry)
+
+    def on_login(self, user_entry: db.Entity):
+        """
+        Hook that is called whenever the password authentication was successful.
+        It allows to perform further steps in custom UserPassword authentications.
+        """
         return self._user_module.continueAuthenticationFlow(self, user_entry.key)
 
     @exposed


### PR DESCRIPTION
Implements a hook that is called whenever the password authentication was successful. It allows to perform further steps in custom UserPassword authentications.

The login process should be interruptible, so that custom modules can provide additional steps before  `continueAuthenticationFlow` is being called.

In my custom implementation, `on_login` is overwritten as follows:
```py
    def on_login(self, user_entry):
        if user_entry["password_enforce_change"]:
            logging.info("Require password change")
            return self.new_password()

        return super().on_login(self, user_entry)
```

Without this hook, I need to copy the entire `login`-function and inject my custom code before the `continueAuthenticationFlow` call. Please respect this implementation, it works fine.