### PR TITLE
fix: Provide "moduleGroups" in `/vi/config`

### DIFF
--- a/src/viur/core/config.py
+++ b/src/viur/core/config.py
@@ -263,10 +263,10 @@ class Admin(ConfigType):
     """URL for the Logo over the VI Login screen"""
 
     color_primary: str = "#d00f1c"
-    """primary color for the VI"""
+    """primary color for viur-admin"""
 
     color_secondary: str = "#333333"
-    """secondary color for the VI"""
+    """secondary color for viur-admin"""
 
     module_groups: dict[str, dict[Literal["name", "icon", "sortindex"], str | int]] = {}
     """Module Groups for the VI
@@ -278,12 +278,12 @@ class Admin(ConfigType):
             "content": {
                 "name": "Content",
                 "icon": "text-file",
-                "sortIndex": 10,
+                "sortindex": 10,
             },
             "shop": {
                 "name": "Shop",
                 "icon": "cart",
-                "sortIndex": 20,
+                "sortindex": 20,
             },
         }
 

--- a/src/viur/core/config.py
+++ b/src/viur/core/config.py
@@ -263,10 +263,34 @@ class Admin(ConfigType):
     """URL for the Logo over the VI Login screen"""
 
     color_primary: str = "#d00f1c"
-    """primary color for the  VI"""
+    """primary color for the VI"""
 
     color_secondary: str = "#333333"
-    """secondary color for the  VI"""
+    """secondary color for the VI"""
+
+    module_groups: dict[str, dict[Literal["name", "icon", "sortindex"], str | int]] = {}
+    """Module Groups for the VI
+
+    Group modules in the sidebar in categories (groups).
+
+    Example:
+        conf.admin.module_groups = {
+            "content": {
+                "name": "Content",
+                "icon": "text-file",
+                "sortIndex": 10,
+            },
+            "shop": {
+                "name": "Shop",
+                "icon": "cart",
+                "sortIndex": 20,
+            },
+        }
+
+    To add a module to one of these groups (e.g. content), add `moduleGroup` to
+    the admin_info of the module:
+        "moduleGroup": "content",
+    """
 
     _mapping: dict[str, str] = {
         "login.background": "login_background",

--- a/src/viur/core/render/vi/__init__.py
+++ b/src/viur/core/render/vi/__init__.py
@@ -90,9 +90,6 @@ def dumpConfig():
             k.replace("_", "."): v for k, v in conf.admin.items(True)
         }
     }
-    # The vi-admin expects moduleGroups in camelCase without "admin." prefix
-    res["configuration"]["moduleGroups"] = conf.admin.module_groups
-
     current.request.get().response.headers["Content-Type"] = "application/json"
     return json.dumps(res, cls=CustomJsonEncoder)
 

--- a/src/viur/core/render/vi/__init__.py
+++ b/src/viur/core/render/vi/__init__.py
@@ -90,6 +90,9 @@ def dumpConfig():
             k.replace("_", "."): v for k, v in conf.admin.items(True)
         }
     }
+    # The vi-admin expects moduleGroups in CamelCase without "admin." prefix
+    res["configuration"]["moduleGroups"] = conf.admin.module_groups
+
     current.request.get().response.headers["Content-Type"] = "application/json"
     return json.dumps(res, cls=CustomJsonEncoder)
 

--- a/src/viur/core/render/vi/__init__.py
+++ b/src/viur/core/render/vi/__init__.py
@@ -90,7 +90,7 @@ def dumpConfig():
             k.replace("_", "."): v for k, v in conf.admin.items(True)
         }
     }
-    # The vi-admin expects moduleGroups in CamelCase without "admin." prefix
+    # The vi-admin expects moduleGroups in camelCase without "admin." prefix
     res["configuration"]["moduleGroups"] = conf.admin.module_groups
 
     current.request.get().response.headers["Content-Type"] = "application/json"


### PR DESCRIPTION
The vi-admin expects "moduleGroups" in `/vi/config`: https://github.com/viur-framework/vi-vue-components/blob/b7d21dacb93003bbf85f89ee51f3e0ec2f9433c6/components/screens/TheMainScreen.vue#L113

This patch add the related conf variable and ensures the value will be available under the old name (and the new, as in the conf itself: `admin.module_groups`).

Regression of #979 