### PR TITLE
feat: Collect modules recursivly in `vi/config`

### DIFF
--- a/src/viur/core/render/vi/__init__.py
+++ b/src/viur/core/render/vi/__init__.py
@@ -98,7 +98,7 @@ def dumpConfig():
 
             if admin_info := module.describe():
                 # map path --> config
-                res[module.modulePath.lstrip("/vi")] = admin_info
+                res[module.modulePath.removeprefix("/vi/")] = admin_info
             # Collect children
             collect_modules(module, depth=depth + 1)
 

--- a/src/viur/core/render/vi/__init__.py
+++ b/src/viur/core/render/vi/__init__.py
@@ -7,7 +7,7 @@ from viur.core.decorators import *
 from viur.core.render.json import skey as json_render_skey
 from viur.core.render.json.default import CustomJsonEncoder, DefaultRender
 # noinspection PyUnresolvedReferences
-from viur.core.render.vi.user import UserRender as user, UserRender as user  # this import must exist!
+from viur.core.render.vi.user import UserRender as user  # this import must exist!
 from viur.core.skeleton import SkeletonInstance
 
 

--- a/src/viur/core/render/vi/__init__.py
+++ b/src/viur/core/render/vi/__init__.py
@@ -98,7 +98,7 @@ def dumpConfig():
 
             if admin_info := module.describe():
                 # map path --> config
-                res[module.modulePath.removeprefix("/vi/")] = admin_info
+                res[module.modulePath.removeprefix("/vi/").replace("/", ".")] = admin_info
             # Collect children
             collect_modules(module, depth=depth + 1)
 


### PR DESCRIPTION
The viur-shop has it's modules as submodules under a main `shop`. As you can see [here](https://github.com/viur-framework/viur-shop/blob/191b6a56e764a709170bcd1e3f1e27f1e3fa4c1b/src/viur/shop/shop.py#L45-L53).

So for example we have this path `/shop/address/list`.
It's perfectly routeable, but the vi doesn't know it because submodules are not collected. This PR adds a recursive walk through all the modules and collects them in `/vi/config`.
