### PR TITLE
fix: Adding linter settings for flake8 as well

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,3 +6,8 @@ show-source = False
 ignore = E121, E123, E126, E133, E226, E241, E242, E704, W503, W504, W505
 max-line-length = 120
 statistics = False
+
+[flake8]
+ignore = E121, E123, E126, E133, E226, E241, E242, E704, W503, W504, W505
+max-line-length = 120
+statistics = False


### PR DESCRIPTION
VSCode updated its Python plugin to not cover pycodestyle as linter. Therefore, moving to e.g. flake8 is required, but flake8 does not recognize pycodestyle settings.

Did several tests to get it work with just one setting, but no way currently.