### PR TITLE
feat: Implement `@property` support in `Skeleton`s

### DIFF
--- a/src/viur/core/skeleton.py
+++ b/src/viur/core/skeleton.py
@@ -245,7 +245,7 @@ class SkeletonInstance:
                 except AttributeError as exc:
                     # The AttributeError cannot be re-raised any further at this point.
                     # Since this would then be evaluated as an access error
-                    # to the attribute of the property.
+                    # to the property attribute.
                     # Otherwise, it would be lost that it is an incorrect attribute access
                     # within this property (during the method call).
                     msg, *args = exc.args


### PR DESCRIPTION
Sometimes you want to perform skeleton related actions like `skel.view_url`. `@property`s  are a nice way for this.

Example:

```py
class ExampleSkel(Skeleton):
    # [...]

    @property
    def test_property(self):
        return f'test_property of {self.__class__.__name__} {self.key} {self["key"]}'
```