### PR TITLE
fix: Undocumented and uninitialized `conf["viur.user.google.gsuiteDomains"]`

### DIFF
--- a/src/viur/core/config.py
+++ b/src/viur/core/config.py
@@ -320,6 +320,9 @@ conf = Conf({
         "admin": "Administrator",
     },
 
+    # Allow-list for domains accepting Google users when registration is generally disabled.
+    "viur.user.google.gsuiteDomains": (),
+
     # Which application-ids we're supposed to run on
     "viur.validApplicationIDs": [],
 

--- a/src/viur/core/modules/user.py
+++ b/src/viur/core/modules/user.py
@@ -597,10 +597,10 @@ class GoogleAccount(UserAuthentication):
             if not (userSkel := addSkel().all().filter("name.idx =", email.lower()).getSkel()):
                 # Still no luck - it's a completely new user
                 if not self.registrationEnabled:
-                    if userInfo.get("hd") and userInfo["hd"] in conf["viur.user.google.gsuiteDomains"]:
-                        print("User is from domain - adding account")
+                    if (domain := userInfo.get("hd")) and domain in conf["viur.user.google.gsuiteDomains"]:
+                        logging.debug(f"Google user is from allowed {domain} - adding account")
                     else:
-                        logging.warning("Denying registration of %s", email)
+                        logging.debug(f"Google user is from {domain} - denying registration")
                         raise errors.Forbidden("Registration for new users is disabled")
 
                 userSkel = addSkel()  # We'll add a new user


### PR DESCRIPTION
Refactoring and hotfix for this traceback, when `conf["viur.user.google.gsuiteDomains"]` was not explicitly set before.
```
Traceback (most recent call last):
  File "/layers/google.python.pip/pip/lib/python3.11/site-packages/viur/core/request.py", line 298, in _process
    self._route(path)
  File "/layers/google.python.pip/pip/lib/python3.11/site-packages/viur/core/request.py", line 548, in _route
    res = caller(*self.args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/layers/google.python.pip/pip/lib/python3.11/site-packages/viur/core/module.py", line 299, in __call__
    return self._func(self._instance, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/layers/google.python.pip/pip/lib/python3.11/site-packages/viur/core/modules/user.py", line 600, in login
    if userInfo.get("hd") and userInfo["hd"] in conf["viur.user.google.gsuiteDomains"]:
                                                ~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/layers/google.python.pip/pip/lib/python3.11/site-packages/viur/core/config.py", line 26, in __getitem__
    return super().__getitem__(key)
           ^^^^^^^^^^^^^^^^^^^^^^^^
KeyError: 'viur.user.google.gsuiteDomains'
```