### PR TITLE
fix: Broken use of tasks emulator in combination with the app_server

### DIFF
--- a/src/viur/core/tasks.py
+++ b/src/viur/core/tasks.py
@@ -214,9 +214,11 @@ class TaskHandler(Module):
         if 'X-AppEngine-TaskName' not in req.headers:
             logging.critical('Detected an attempted XSRF attack. The header "X-AppEngine-Taskname" was not set.')
             raise errors.Forbidden()
-        if req.environ.get("HTTP_X_APPENGINE_USER_IP") not in _appengineServiceIPs:
-            if not conf["viur.instance.is_dev_server"] or os.getenv("TASKS_EMULATOR") is None:
-                logging.critical('Detected an attempted XSRF attack. This request did not originate from Task Queue.')
+        if (
+            req.environ.get("HTTP_X_APPENGINE_USER_IP") not in _appengineServiceIPs
+            and (not conf["viur.instance.is_dev_server"] or os.getenv("TASKS_EMULATOR") is None)
+        ):
+            logging.critical('Detected an attempted XSRF attack. This request did not originate from Task Queue.')
             raise errors.Forbidden()
 
         # Check if the retry count exceeds our warning threshold


### PR DESCRIPTION
The logging statement was on the correct position, but not `raise errors.Forbidden`