### PR TITLE
fix: Finetuning `ViurTagsSearchAdapter` defaults

### DIFF
--- a/src/viur/core/skeleton.py
+++ b/src/viur/core/skeleton.py
@@ -550,7 +550,7 @@ class ViurTagsSearchAdapter(CustomDatabaseAdapter):
     providesFulltextSearch = True
     fulltextSearchGuaranteesQueryConstrains = True
 
-    def __init__(self, min_length: int = 3, max_length: int = 99, substring_matching: bool = True):
+    def __init__(self, min_length: int = 2, max_length: int = 50, substring_matching: bool = False):
         super().__init__()
         self.min_length = min_length
         self.max_length = max_length


### PR DESCRIPTION
This pull request modifies `ViurTagsSearchAdapter` to the following defaults:

- `min_length` to 2, as some names and words are already made of 2 characters
- `max_length` to 50, as longest non-fictive words in the world are having at least 45 characters. This is "pneumonoultramicroscopicsilicovolcanoconiosis" in English (45 chars) and "Rechtsschutzversicherungsgesellschaften" (39 chars) in German. The german fictional word "Donaudampfschifffahrtselektrizitätenhauptbetriebswerkbauunterbeamtengesellschaft" has 80 chars, but we ignore this here.
- `substring_matching` should default to False, as all of our current software projects, substring_matching=True as its implemented here is not wanted or is wanted to be changed.