### PR TITLE
fix: `@property` in module causes problems during warmup

### DIFF
--- a/src/viur/core/module.py
+++ b/src/viur/core/module.py
@@ -525,7 +525,7 @@ class Module:
         for key in dir(self):
             if key[0] == "_":
                 continue
-            if not hasattr(self, key):
+            if isinstance(getattr(self.__class__, key, None), property):
                 continue
 
             prop = getattr(self, key)


### PR DESCRIPTION
This fixes #933 while the fix #952 doesn't work.
`hasattr(self, key)` is implemented as "do a `getattr` if this doesn't raise an `AttributeError`, the attribute must exist". So the property will be accessed anyway, which is a problem if it contains code which doesn't work during warmup (because there is not request), like accessing `current.session.get()["my_value"]` (it's `None`).