### PR TITLE
feat: Add and improve check on root node in `Tree` prototype

### DIFF
--- a/src/viur/core/prototypes/tree.py
+++ b/src/viur/core/prototypes/tree.py
@@ -546,7 +546,8 @@ class Tree(SkelModule):
 
         # Test if we try to move a rootNode
         tmp = skel.dbEntity
-        if tmp.get("rootNode") == 1 or tmp.get("is_root_node"):
+        # TODO: Remove "rootNode"-fallback with VIUR4
+        if skel.dbEntity.get("is_root_node") or skel.dbEntity.get("rootNode"):
             raise errors.NotAcceptable("Can't move a rootNode to somewhere else")
 
         currentParentRepo = skel["parentrepo"]

--- a/src/viur/core/prototypes/tree.py
+++ b/src/viur/core/prototypes/tree.py
@@ -545,7 +545,6 @@ class Tree(SkelModule):
             raise errors.NotAcceptable("Unable to find a root node in recursion?")
 
         # Test if we try to move a rootNode
-        tmp = skel.dbEntity
         # TODO: Remove "rootNode"-fallback with VIUR4
         if skel.dbEntity.get("is_root_node") or skel.dbEntity.get("rootNode"):
             raise errors.NotAcceptable("Can't move a rootNode to somewhere else")

--- a/src/viur/core/prototypes/tree.py
+++ b/src/viur/core/prototypes/tree.py
@@ -537,7 +537,7 @@ class Tree(SkelModule):
         for _ in range(0, 99):
             if currLevel.key == skel["key"]:
                 break
-            if currLevel.get("rootNode"):
+            if currLevel.get("rootNode") or currLevel.get("is_root_node"):
                 # We reached a rootNode, so this is okay
                 break
             currLevel = db.Get(currLevel["parententry"])
@@ -546,7 +546,7 @@ class Tree(SkelModule):
 
         # Test if we try to move a rootNode
         tmp = skel.dbEntity
-        if "rootNode" in tmp and tmp["rootNode"] == 1:
+        if tmp.get("rootNode") == 1 or tmp.get("is_root_node"):
             raise errors.NotAcceptable("Can't move a rootNode to somewhere else")
 
         currentParentRepo = skel["parentrepo"]


### PR DESCRIPTION
`rootNode` is neither snake_case or a boolen (`=1`).

In `viur-shop` I use the bone `is_root_node`: https://github.com/viur-framework/viur-shop/blob/eacfb4a9e5288d3f3b5bf4c0b6445657cb48ff3b/src/viur/shop/skeletons/cart.py#L79
* It's snake_case
* a BooleanBone
* and `is_` is describing a state. You could also think that the bone rootNode points to a rootnode as relation.