### PR TITLE
fix: Make `UserPassword.pwrecover` ready for action-skels

### DIFF
--- a/src/viur/core/modules/user.py
+++ b/src/viur/core/modules/user.py
@@ -261,7 +261,7 @@ class UserPassword(UserAuthentication):
                 "tooltip": i18n.translate(
                     key="viur.modules.user.userpassword.lostpasswordstep2.recoverykey",
                     defaultText="The key is expired. Please try again",
-                    hint="Shown when the user needs more than 10 minutes to paste the key"
+                    hint="Shown when the user needs more than 15 minutes to paste the key"
                 )
             }
         )
@@ -422,7 +422,7 @@ class UserPassword(UserAuthentication):
                 i18n.translate(
                     key="viur.modules.user.passwordrecovery.keyexpired",
                     defaultText="The key is expired. Please try again",
-                    hint="Shown when the user needs more than 10 minutes to paste the key"
+                    hint="Shown when the user needs more than 15 minutes to paste the key"
                 )
             )
 

--- a/src/viur/core/modules/user.py
+++ b/src/viur/core/modules/user.py
@@ -257,6 +257,13 @@ class UserPassword(UserAuthentication):
         recovery_key = StringBone(
             descr="Recovery Key",
             required=True,
+            params={
+                "tooltip": i18n.translate(
+                    key="viur.modules.user.userpassword.lostpasswordstep2.recoverykey",
+                    defaultText="The key is expired. Please try again",
+                    hint="Shown when the user needs more than 10 minutes to paste the key"
+                )
+            }
         )
 
     class LostPasswordStep3Skel(skeleton.RelSkel):
@@ -399,7 +406,7 @@ class UserPassword(UserAuthentication):
         skel = self.LostPasswordStep3Skel()
         skel["recovery_key"] = recovery_key
 
-        # check for any input; Render input-form when incomplete.
+        # check for any input; Render input-form again when incomplete.
         if not skel.fromClient(kwargs) or not current_request.isPostRequest:
             return self._user_module.render.edit(
                 skel=skel,

--- a/src/viur/core/modules/user.py
+++ b/src/viur/core/modules/user.py
@@ -401,9 +401,8 @@ class UserPassword(UserAuthentication):
                 params={
                     "message": i18n.translate(
                         key="viur.modules.user.userpassword.pwrecover.recoverykey",
-                        defaultText=
-                            "Please enter the security key you should have received via e-mail "
-                            "together with your new password.",
+                        defaultText="Please enter the recovery key you should have received to your "
+                            "e-mail address, along with your new password.",
                         hint="Provide a hint for the user to wait for recoverykey and enter new password"
                     ),
                 }

--- a/src/viur/core/modules/user.py
+++ b/src/viur/core/modules/user.py
@@ -403,7 +403,7 @@ class UserPassword(UserAuthentication):
                         key="viur.modules.user.userpassword.pwrecover.recoverykey",
                         defaultText="Please enter the recovery key you should have received to your "
                             "e-mail address, along with your new password.",
-                        hint="Provide a hint for the user to wait for recoverykey and enter new password"
+                        hint="Provide a hint for the user to wait for recovery key and enter new password"
                     ),
                 }
             )
@@ -457,7 +457,7 @@ class UserPassword(UserAuthentication):
             tpl=self.passwordRecoverySuccessTemplate,
             params={
                 "message": i18n.translate(
-                    key="viur.modules.user.userpassword.pwrecover.successfull",
+                    key="viur.modules.user.userpassword.pwrecover.successful",
                     defaultText="Your account has been recovered successfully, you can now login.",
                     hint="This is the message to be shown when the recovery was successfull."
                 ),


### PR DESCRIPTION
This pull request improves the `UserPassword.pwrecover` function to the following:

- Errors turned into HTTP-error-codes
- Step 2 becomes Step 3, and Step 2 is optional, as it can either be resolved by a link in the e-mail, or by a code that is prompted for. It depends on the project. This proposal is action-skel based, and backward-compatible to the previous implementation.
- Moved all texts into the action itself, and cleaned unused text away.