### PR TITLE
feat: Provide script configuration in `ModuleConf`

### DIFF
--- a/src/viur/core/languages/de.py
+++ b/src/viur/core/languages/de.py
@@ -350,7 +350,7 @@ de = {
     "module helptext": "Modul Hilfetext",
     "add helptext": "Hinzufügen Hilfetext",
     "edit helptext": "Editieren Hilfetext",
-    "scriptor scripts":"Scriptor Scripte",
+    "scriptor scripts": "Scriptor Scripte",
 
     # Bones
     "core.bones.password.no_capital_letters": "Das eingegebene Passwort enthält keine Großbuchstaben.",

--- a/src/viur/core/languages/de.py
+++ b/src/viur/core/languages/de.py
@@ -350,6 +350,7 @@ de = {
     "module helptext": "Modul Hilfetext",
     "add helptext": "Hinzufügen Hilfetext",
     "edit helptext": "Editieren Hilfetext",
+    "scriptor scripts":"Scriptor Scripte",
 
     # Bones
     "core.bones.password.no_capital_letters": "Das eingegebene Passwort enthält keine Großbuchstaben.",

--- a/src/viur/core/languages/de.py
+++ b/src/viur/core/languages/de.py
@@ -350,7 +350,7 @@ de = {
     "module helptext": "Modul Hilfetext",
     "add helptext": "Hinzufügen Hilfetext",
     "edit helptext": "Editieren Hilfetext",
-    "scriptor scripts": "Scriptor Scripte",
+    "scriptor scripts": "Scripte",
 
     # Bones
     "core.bones.password.no_capital_letters": "Das eingegebene Passwort enthält keine Großbuchstaben.",

--- a/src/viur/core/modules/moduleconf.py
+++ b/src/viur/core/modules/moduleconf.py
@@ -1,12 +1,38 @@
 import logging
-from viur.core.bones import StringBone, TextBone
+from viur.core.bones import StringBone, TextBone, SelectBone, TreeLeafBone
 from viur.core.bones.text import _defaultTags
 from viur.core.tasks import StartupTask
 from viur.core import Module, conf, db
 from viur.core.i18n import translate
-from viur.core.skeleton import Skeleton, SkeletonInstance
+from viur.core.skeleton import Skeleton, SkeletonInstance, RelSkel
 from viur.core.prototypes import List
 
+class ScriptRelSkel(RelSkel):
+    name = StringBone(
+        descr="Displayname"
+    )
+
+    icon = StringBone(
+        descr = "Icon"
+    )
+
+    capable = SelectBone(
+        descr="Capable to handle",
+        values={
+            "none": "Run action without further parameters.",
+            "single": "Script may use one entity key in parameters",
+            "multiple": "Script may use several entity keys in parameters"
+        }
+    )
+
+    access = SelectBone(
+        descr="Required access rights to run this Script",
+        values=lambda: {
+            right: translate("server.modules.user.accessright.%s" % right, defaultText=right)
+            for right in sorted(conf["viur.accessRights"])
+        },
+        multiple=True,
+    )
 
 class ModuleConfSkel(Skeleton):
     kindName = "viur-module-conf"
@@ -35,6 +61,14 @@ class ModuleConfSkel(Skeleton):
         descr=translate("edit helptext"),
         validHtml=_valid_html,
     )
+
+    scripts = TreeLeafBone(
+        descr=translate("scriptor scripts"),
+        module="script",
+        kind="viur-script-leaf",
+        using=ScriptRelSkel,
+        refKeys=['key','name','access'],
+        multiple=True)
 
 
 class ModuleConf(List):

--- a/src/viur/core/modules/moduleconf.py
+++ b/src/viur/core/modules/moduleconf.py
@@ -28,7 +28,7 @@ class ScriptRelSkel(RelSkel):
     access = SelectBone(
         descr="Required access rights to run this Script",
         values=lambda: {
-            right:translate("server.modules.user.accessright.%s" % right, defaultText=right)
+            right: translate("server.modules.user.accessright.%s" % right, defaultText=right)
             for right in sorted(conf["viur.accessRights"])
         },
         multiple=True,

--- a/src/viur/core/modules/moduleconf.py
+++ b/src/viur/core/modules/moduleconf.py
@@ -11,12 +11,18 @@ from viur.core.prototypes import List
 class ScriptRelSkel(RelSkel):
 
     name = StringBone(
-        descr="Name",
+        descr="Label",
         required=True,
+        params={
+            "tooltip": "Label for the action button displayed."
+        },
     )
 
     icon = StringBone(
         descr="Icon",
+        params={
+            "tooltip": "Shoelace-conforming icon identifier."
+        },
     )
 
     capable = SelectBone(
@@ -24,10 +30,15 @@ class ScriptRelSkel(RelSkel):
         required=True,
         defaultValue="none",
         values={
-            "none": "No arguments, always executable",
-            "single": "Run script with single entry key as argument",
-            "multiple": "Run script with list of entity keys as argument",
-        }
+            "none": "none: No arguments, always executable",
+            "single": "single: Run script with single entry key as argument",
+            "multiple": "multiple: Run script with list of entity keys as argument",
+        },
+        params={
+            "tooltip":
+                "Describes the behavior in the admin, "
+                "if and how selected entries from the module are being processed."
+        },
     )
 
     access = SelectBone(
@@ -37,6 +48,11 @@ class ScriptRelSkel(RelSkel):
             for right in sorted(conf["viur.accessRights"])
         },
         multiple=True,
+        params={
+            "tooltip":
+                "To whom the button should be displayed in the admin. "
+                "In addition, the admin checks whether all rights of the script are also fulfilled.",
+        },
     )
 
 

--- a/src/viur/core/modules/moduleconf.py
+++ b/src/viur/core/modules/moduleconf.py
@@ -7,28 +7,33 @@ from viur.core.i18n import translate
 from viur.core.skeleton import Skeleton, SkeletonInstance, RelSkel
 from viur.core.prototypes import List
 
+
 class ScriptRelSkel(RelSkel):
+
     name = StringBone(
-        descr="Displayed name"
+        descr="Name",
+        required=True,
     )
 
     icon = StringBone(
-        descr = "Icon"
+        descr="Icon",
     )
 
     capable = SelectBone(
-        descr="Capable to handle",
+        descr="Arguments",
+        required=True,
+        defaultValue="none",
         values={
-            "none": "Run action without further parameters.",
-            "single": "Script may use one entity key in parameters",
-            "multiple": "Script may use several entity keys in parameters"
+            "none": "No arguments, always executable",
+            "single": "Run script with single entry key as argument",
+            "multiple": "Run script with list of entity keys as argument",
         }
     )
 
     access = SelectBone(
-        descr="Required access rights to run this Script",
+        descr="Required access rights",
         values=lambda: {
-            right: translate("server.modules.user.accessright.%s" % right, defaultText=right)
+            right: translate(f"server.modules.user.accessright.{right}", defaultText=right)
             for right in sorted(conf["viur.accessRights"])
         },
         multiple=True,
@@ -71,7 +76,7 @@ class ModuleConfSkel(Skeleton):
         refKeys=[
             "key",
             "name",
-            "access"
+            "access",
         ],
         multiple=True,
     )

--- a/src/viur/core/modules/moduleconf.py
+++ b/src/viur/core/modules/moduleconf.py
@@ -9,7 +9,7 @@ from viur.core.prototypes import List
 
 class ScriptRelSkel(RelSkel):
     name = StringBone(
-        descr="Displayname"
+        descr="Displayed name"
     )
 
     icon = StringBone(
@@ -68,8 +68,12 @@ class ModuleConfSkel(Skeleton):
         module="script",
         kind="viur-script-leaf",
         using=ScriptRelSkel,
-        refKeys=['key','name','access'],
-        multiple=True
+        refKeys=[
+            "key",
+            "name",
+            "access"
+        ],
+        multiple=True,
     )
 
 

--- a/src/viur/core/modules/moduleconf.py
+++ b/src/viur/core/modules/moduleconf.py
@@ -28,11 +28,12 @@ class ScriptRelSkel(RelSkel):
     access = SelectBone(
         descr="Required access rights to run this Script",
         values=lambda: {
-            right: translate("server.modules.user.accessright.%s" % right, defaultText=right)
+            right:translate("server.modules.user.accessright.%s" % right, defaultText=right)
             for right in sorted(conf["viur.accessRights"])
         },
         multiple=True,
     )
+
 
 class ModuleConfSkel(Skeleton):
     kindName = "viur-module-conf"
@@ -68,7 +69,8 @@ class ModuleConfSkel(Skeleton):
         kind="viur-script-leaf",
         using=ScriptRelSkel,
         refKeys=['key','name','access'],
-        multiple=True)
+        multiple=True
+    )
 
 
 class ModuleConf(List):

--- a/src/viur/core/modules/script.py
+++ b/src/viur/core/modules/script.py
@@ -2,6 +2,7 @@ from viur.core.bones import *
 from viur.core.prototypes.tree import Tree, TreeSkel
 from viur.core import db, conf, current, skeleton, tasks
 from viur.core.prototypes.tree import Tree
+from viur.core.i18n import translate
 import re
 
 
@@ -68,6 +69,15 @@ class ScriptLeafSkel(BaseScriptAbstractSkel):
     script = RawBone(
         descr="Code",
         indexed=False
+    )
+
+    access = SelectBone(
+        descr="Required access rights to run this Script",
+        values=lambda: {
+            right: translate("server.modules.user.accessright.%s" % right, defaultText=right)
+            for right in sorted(conf["viur.accessRights"])
+        },
+        multiple=True,
     )
 
 


### PR DESCRIPTION
Adds Scriptor Scripts to the moduleconf:
The relation set in the moduleConf is responsible for the display and behavior of the scriptor action.

- name and icon:  are responsible for the appearance of the button in the admin.
- capable: describes the behavior in the admin
- access: to whom the button should be displayed in the admin. In addition, the admin checks whether all rights of the script are also fulfilled

