### PR TITLE
feat: `clone`-action for `List` and `Tree`, recursive tree cloning

### DIFF
--- a/src/viur/core/prototypes/list.py
+++ b/src/viur/core/prototypes/list.py
@@ -327,6 +327,24 @@ class List(SkelModule):
     @force_ssl
     @skey(allow_empty=True)
     def clone(self, key: db.Key | str | int, **kwargs):
+        """
+        Clone an existing entry, and render the entry, eventually with error notes on incorrect data.
+        Data is taken by any other arguments in *kwargs*.
+
+        The function performs several access control checks on the requested entity before it is added.
+
+        .. seealso:: :func:`canEdit`, :func:`canAdd`, :func:`onClone`, :func:`onCloned`
+
+        :param key: URL-safe key of the item to be edited.
+
+        :returns: The cloned object of the entry, eventually with error hints.
+
+        :raises: :exc:`viur.core.errors.NotAcceptable`, when no valid *skelType* was provided.
+        :raises: :exc:`viur.core.errors.NotFound`, when no *entry* to clone from was found.
+        :raises: :exc:`viur.core.errors.Unauthorized`, if the current user does not have the required permissions.
+        :raises: :exc:`viur.core.errors.PreconditionFailed`, if the *skey* could not be verified.
+        """
+
         skel = self.cloneSkel()
         if not skel.fromDB(key):
             raise errors.NotFound()
@@ -619,9 +637,29 @@ class List(SkelModule):
             logging.info("User: %s (%s)" % (user["name"], user["key"]))
 
     def onClone(self, skel: SkeletonInstance, src_skel: SkeletonInstance):
-        ...
+        """
+            Hook function that is called before cloning an entry.
+
+            It can be overwritten to a module-specific behavior.
+
+            :param skel: The new Skeleton that is being created.
+            :param src_skel: The source Skeleton `skel` is cloned from.
+
+            .. seealso:: :func:`clone`, :func:`onCloned`
+        """
+        pass
 
     def onCloned(self, skel: SkeletonInstance, src_skel: SkeletonInstance):
+        """
+            Hook function that is called after cloning an entry.
+
+            It can be overwritten to a module-specific behavior.
+
+            :param skel: The new Skeleton that was created.
+            :param src_skel: The source Skeleton `skel` was cloned from.
+
+            .. seealso:: :func:`clone`, :func:`onClone`
+        """
         logging.info(f"Cloned: {skel['key']=} from {src_skel['key']=}")
         flushCache(kind=skel.kindName)
 

--- a/src/viur/core/prototypes/list.py
+++ b/src/viur/core/prototypes/list.py
@@ -75,18 +75,18 @@ class List(SkelModule):
 
     def cloneSkel(self, *args, **kwargs) -> SkeletonInstance:
         """
-            Retrieve a new instance of a :class:`viur.core.skeleton.Skeleton` that is used by the application
-            for cloning an existing entry from the list.
+        Retrieve a new instance of a :class:`viur.core.skeleton.Skeleton` that is used by the application
+        for cloning an existing entry from the list.
 
-            The default is a Skeleton instance returned by :func:`~baseSkel`.
+        The default is a SkeletonInstance returned by :func:`~baseSkel`.
 
-            Like in :func:`viewSkel`, the skeleton can be post-processed. Bones that are being removed aren't visible
-            and cannot be set, but it's also possible to just set a bone to readOnly (revealing it's value to the user,
-            but preventing any modification.
+        Like in :func:`viewSkel`, the skeleton can be post-processed. Bones that are being removed aren't visible
+        and cannot be set, but it's also possible to just set a bone to readOnly (revealing it's value to the user,
+        but preventing any modification.
 
-            .. seealso:: :func:`viewSkel`, :func:`editSkel`, :func:`~baseSkel`
+        .. seealso:: :func:`viewSkel`, :func:`editSkel`, :func:`~baseSkel`
 
-            :return: Returns a Skeleton instance for editing an entry.
+        :return: Returns a SkeletonInstance for editing an entry.
         """
         return self.baseSkel(*args, **kwargs)
 
@@ -342,7 +342,6 @@ class List(SkelModule):
         :raises: :exc:`viur.core.errors.NotAcceptable`, when no valid *skelType* was provided.
         :raises: :exc:`viur.core.errors.NotFound`, when no *entry* to clone from was found.
         :raises: :exc:`viur.core.errors.Unauthorized`, if the current user does not have the required permissions.
-        :raises: :exc:`viur.core.errors.PreconditionFailed`, if the *skey* could not be verified.
         """
 
         skel = self.cloneSkel()
@@ -638,27 +637,27 @@ class List(SkelModule):
 
     def onClone(self, skel: SkeletonInstance, src_skel: SkeletonInstance):
         """
-            Hook function that is called before cloning an entry.
+        Hook function that is called before cloning an entry.
 
-            It can be overwritten to a module-specific behavior.
+        It can be overwritten to a module-specific behavior.
 
-            :param skel: The new Skeleton that is being created.
-            :param src_skel: The source Skeleton `skel` is cloned from.
+        :param skel: The new SkeletonInstance that is being created.
+        :param src_skel: The source SkeletonInstance `skel` is cloned from.
 
-            .. seealso:: :func:`clone`, :func:`onCloned`
+        .. seealso:: :func:`clone`, :func:`onCloned`
         """
         pass
 
     def onCloned(self, skel: SkeletonInstance, src_skel: SkeletonInstance):
         """
-            Hook function that is called after cloning an entry.
+        Hook function that is called after cloning an entry.
 
-            It can be overwritten to a module-specific behavior.
+        It can be overwritten to a module-specific behavior.
 
-            :param skel: The new Skeleton that was created.
-            :param src_skel: The source Skeleton `skel` was cloned from.
+        :param skel: The new SkeletonInstance that was created.
+        :param src_skel: The source SkeletonInstance `skel` was cloned from.
 
-            .. seealso:: :func:`clone`, :func:`onClone`
+        .. seealso:: :func:`clone`, :func:`onClone`
         """
         logging.info(f"""Entry cloned: {skel["key"]!r}""")
         flushCache(kind=skel.kindName)

--- a/src/viur/core/prototypes/tree.py
+++ b/src/viur/core/prototypes/tree.py
@@ -125,14 +125,14 @@ class Tree(SkelModule):
 
     def cloneSkel(self, skelType: SkelType, *args, **kwargs) -> SkeletonInstance:
         """
-        Retrieve a new instance of a :class:`viur.core.skeleton.Skeleton` that is used by the application
+        Retrieve a new :class:`viur.core.skeleton.SkeletonInstance` that is used by the application
         for cloning an existing entry of the tree.
 
-        The default is a Skeleton instance returned by :func:`~baseSkel`.
+        The default is a SkeletonInstance returned by :func:`~baseSkel`.
 
         .. seealso:: :func:`viewSkel`, :func:`editSkel`, :func:`~baseSkel`
 
-        :return: Returns a Skeleton instance for cloning an entry.
+        :return: Returns a SkeletonInstance for cloning an entry.
         """
         return self.baseSkel(skelType, *args, **kwargs)
 
@@ -601,7 +601,6 @@ class Tree(SkelModule):
         :raises: :exc:`viur.core.errors.NotAcceptable`, when no valid *skelType* was provided.
         :raises: :exc:`viur.core.errors.NotFound`, when no *entry* to clone from was found.
         :raises: :exc:`viur.core.errors.Unauthorized`, if the current user does not have the required permissions.
-        :raises: :exc:`viur.core.errors.PreconditionFailed`, if the *skey* could not be verified.
         """
 
         if not (skelType := self._checkSkelType(skelType)):
@@ -915,15 +914,15 @@ class Tree(SkelModule):
 
     def onClone(self, skelType: SkelType, skel: SkeletonInstance, src_skel: SkeletonInstance):
         """
-            Hook function that is called before cloning an entry.
+        Hook function that is called before cloning an entry.
 
-            It can be overwritten to a module-specific behavior.
+        It can be overwritten to a module-specific behavior.
 
-            :param skelType: Defines the type of the node that is cloned.
-            :param skel: The new Skeleton that is being created.
-            :param src_skel: The source Skeleton `skel` is cloned from.
+        :param skelType: Defines the type of the node that is cloned.
+        :param skel: The new SkeletonInstance that is being created.
+        :param src_skel: The source SkeletonInstance `skel` is cloned from.
 
-            .. seealso:: :func:`clone`, :func:`onCloned`
+        .. seealso:: :func:`clone`, :func:`onCloned`
         """
         pass
 
@@ -968,20 +967,20 @@ class Tree(SkelModule):
 
     def onCloned(self, skelType: SkelType, skel: SkeletonInstance, src_skel: SkeletonInstance):
         """
-            Hook function that is called after cloning an entry.
+        Hook function that is called after cloning an entry.
 
-            It can be overwritten to a module-specific behavior.
+        It can be overwritten to a module-specific behavior.
 
-            By default, when cloning a "node", this function calls :func:`_clone_recursive`
-            which recursively clones the entire structure below this node in the background.
-            If this is not wanted, or wanted by a specific setting, overwrite this function
-            without a super-call.
+        By default, when cloning a "node", this function calls :func:`_clone_recursive`
+        which recursively clones the entire structure below this node in the background.
+        If this is not wanted, or wanted by a specific setting, overwrite this function
+        without a super-call.
 
-            :param skelType: Defines the type of the node that is cloned.
-            :param skel: The new Skeleton that was created.
-            :param src_skel: The source Skeleton `skel` was cloned from.
+        :param skelType: Defines the type of the node that is cloned.
+        :param skel: The new SkeletonInstance that was created.
+        :param src_skel: The source SkeletonInstance `skel` was cloned from.
 
-            .. seealso:: :func:`clone`, :func:`onClone`
+        .. seealso:: :func:`clone`, :func:`onClone`
         """
         logging.info(f"""Entry cloned: {skel["key"]!r} ({skelType!r})""")
         flushCache(kind=skel.kindName)


### PR DESCRIPTION
Since decades, it is not possible in the standard ViUR system to recursively copy trees or subtrees of a tree or hierarchy with a standardized method. This feature now implements a default recursive clone function, together with a clone-action.

The reason for a separate action is, that the clone-action can be customized (using the cloneSkel defined here), and introduces the new action-concept which will be hopefully prototyped soon in a backward compatbile manner.

This pull request is a replacement for parts of PR #829, implementing the following:

- Provides `clone`-actions for `List` and `Tree` prototypes
- Provides `cloneSkel`, `onClone` and `onCloned` hooks; Yes, this is in contrast to [the comment here](https://github.com/viur-framework/viur-core/pull/972#issuecomment-1845301188), which should not allow any more hooks in ViUR-core. However, this pull request should be seen as an intermediate step to make the feature and its possibilities available and usable in the new admin as well as in ViUR itself, without changing the overall concept of the system now. This will be done in a later step (Action-Skels)
- Added and fixed some docstrings.
- Tested agains a project, using the [Vi 3.0.37 in the `new-clone-attempt` branch](https://github.com/viur-framework/viur-vi/compare/v3.0.37...new-clone-attempt)

@akelch this pull request requires action in vi-admin development: The "clone"-action must be modified to call the "clone"-action on the server, and not make an edit with an add afterwards. The implementation entirely moves from the client to the server.