### PR TITLE
fix: Remove default `P.html = True` from prototypes

### DIFF
--- a/src/viur/core/prototypes/list.py
+++ b/src/viur/core/prototypes/list.py
@@ -571,5 +571,4 @@ class List(SkelModule):
 
 
 List.admin = True
-List.html = True
 List.vi = True

--- a/src/viur/core/prototypes/singleton.py
+++ b/src/viur/core/prototypes/singleton.py
@@ -293,5 +293,4 @@ class Singleton(SkelModule):
 
 
 Singleton.admin = True
-Singleton.html = True
 Singleton.vi = True


### PR DESCRIPTION
Ever wondered why every module you want to access by URL without specifying a renderer throws out an error message like this?

![image](https://github.com/viur-framework/viur-core/assets/16870072/e7b2d915-80c6-47f2-82eb-9fbea378fb86)

Well, this pull requests removes the inconsequent `Prototype.html = True` from the `List` and `Singleton` prototype. The `Tree` prototype was always not by default visible to the html-render.

This is how the same call is rendered now:
![image](https://github.com/viur-framework/viur-core/assets/16870072/67c9a67a-eafe-4b40-9b5f-6898ae12fa89)

Normally, all modules being visible to the standard html render have a `Module.html = True` on the bottom. Therefore, this little change wouldn't break too much. I'm also of the opinion, that it is a security issue.