### PR TITLE
fix: Further refactoring and fixing of `File`-module for #1046

### DIFF
--- a/src/viur/core/bones/text.py
+++ b/src/viur/core/bones/text.py
@@ -10,8 +10,7 @@ from html import entities as htmlentitydefs
 from html.parser import HTMLParser
 import typing as t
 
-from viur.core import db, utils
-from viur.core.modules import file
+from viur.core import db, conf
 from viur.core.bones.base import BaseBone, ReadFromClientError, ReadFromClientErrorSeverity
 
 _defaultTags = {
@@ -50,36 +49,6 @@ A dictionary containing default configurations for handling HTML content in Text
 """
 
 
-def parseDownloadUrl(urlStr: str) -> tuple[t.Optional[str], t.Optional[bool], t.Optional[str]]:
-    """
-    Parses a file download URL in the format `/file/download/xxxx?sig=yyyy` into its components: blobKey, derived,
-    and filename. If the URL cannot be parsed, the function returns None for each component.
-
-    :param str urlStr: The file download URL to be parsed.
-    :return: A tuple containing the parsed components: (blobKey, derived, filename).
-            Each component will be None if the URL could not be parsed.
-    :rtype: Tuple[Optional[str], Optional[bool], Optional[str]]
-    """
-    if not urlStr.startswith("/file/download/") or "?" not in urlStr:
-        return None, None, None
-    dataStr, sig = urlStr[15:].split("?")  # Strip /file/download/ and split on ?
-    sig = sig[4:]  # Strip sig=
-    if not file.hmac_verify(dataStr, sig):
-        # Invalid signature, bail out
-        return None, None, None
-    # Split the blobKey into the individual fields it should contain
-    try:
-        dlPath, validUntil, _ = urlsafe_b64decode(dataStr).decode("UTF-8").split("\0")
-    except:  # It's the old format, without an downloadFileName
-        dlPath, validUntil = urlsafe_b64decode(dataStr).decode("UTF-8").split("\0")
-    if validUntil != "0" and datetime.strptime(validUntil, "%Y%m%d%H%M") < datetime.now():
-        # Signature expired, bail out
-        return None, None, None
-    blobkey, derived, fileName = dlPath.split("/")
-    derived = derived != "source"
-    return blobkey, derived, fileName
-
-
 class CollectBlobKeys(HTMLParser):
     """
     A custom HTML parser that extends the HTMLParser class to collect blob keys found in the "src" attribute
@@ -101,9 +70,9 @@ class CollectBlobKeys(HTMLParser):
         if tag in ["a", "img"]:
             for k, v in attrs:
                 if k == "src":
-                    blobKey, _, _ = parseDownloadUrl(v)
-                    if blobKey:
-                        self.blobs.add(blobKey)
+                    file = getattr(conf.main_app, "file", None)
+                    if file and (filepath := file.parse_download_url(v)):
+                        self.blobs.add(filepath.dlkey)
 
 
 class HtmlSerializer(HTMLParser):  # html.parser.HTMLParser
@@ -209,16 +178,21 @@ class HtmlSerializer(HTMLParser):  # html.parser.HTMLParser
                     checker = v.lower()
                     if not (checker.startswith("http://") or checker.startswith("https://") or checker.startswith("/")):
                         continue
-                    blobKey, derived, fileName = parseDownloadUrl(v)
-                    if blobKey:
-                        v = utils.downloadUrlFor(blobKey, fileName, derived, expires=None)
+
+                    file = getattr(conf.main_app, "file", None)
+                    if file and (filepath := file.parse_download_url(v)):
+                        v = file.create_download_url(
+                            filepath.dlkey,
+                            filepath.filename,
+                            filepath.is_derived,
+                            expires=None
+                        )
+
                         if self.srcSet:
                             # Build the src set with files already available. If a derived file is not yet build,
                             # getReferencedBlobs will catch it, build it, and we're going to be re-called afterwards.
-                            fileObj = db.Query("file").filter("dlkey =", blobKey) \
-                                .order(("creationdate", db.SortOrder.Ascending)).getEntry()
                             srcSet = file.create_src_set(
-                                fileObj,
+                                filepath.dlkey,
                                 None,
                                 self.srcSet.get("width"),
                                 self.srcSet.get("height")

--- a/src/viur/core/modules/file.py
+++ b/src/viur/core/modules/file.py
@@ -1,7 +1,6 @@
 import base64
 import datetime
 import google.auth
-import google.oauth2
 import hashlib
 import hmac
 import html
@@ -15,6 +14,7 @@ import typing as t
 from urllib.parse import quote as urlquote
 from urllib.request import urlopen
 from google.cloud import storage
+from google.oauth2.service_account import Credentials as ServiceAccountCredentials
 from viur.core import conf, current, db, errors, utils
 from viur.core.bones import BaseBone, BooleanBone, KeyBone, NumericBone, StringBone
 from viur.core.decorators import *

--- a/src/viur/core/render/html/env/viur.py
+++ b/src/viur/core/render/html/env/viur.py
@@ -683,7 +683,7 @@ def downloadUrlFor(
 ) -> str:
     """
     Constructs a signed download-url for the given file-bone. Mostly a wrapper around
-        :meth:`file.create_download_url`.
+        :meth:`file.File.create_download_url`.
 
         :param render: The jinja renderer instance
         :param fileObj: The file-bone (eg. skel["file"])

--- a/src/viur/core/render/html/env/viur.py
+++ b/src/viur/core/render/html/env/viur.py
@@ -713,17 +713,17 @@ def downloadUrlFor(
     if derived:
         return file.create_download_url(
             fileObj["dlkey"],
-            fileName=derived,
+            filename=derived,
             derived=True,
             expires=expires,
-            downloadFileName=downloadFileName,
+            download_filename=downloadFileName,
         )
 
     return file.create_download_url(
         fileObj["dlkey"],
-        fileName=fileObj["name"],
+        filename=fileObj["name"],
         expires=expires,
-        downloadFileName=downloadFileName
+        download_filename=downloadFileName
     )
 
 

--- a/src/viur/core/render/json/default.py
+++ b/src/viur/core/render/json/default.py
@@ -5,7 +5,6 @@ from viur.core import bones, utils, db, current
 from viur.core.skeleton import SkeletonInstance
 from viur.core.i18n import translate
 from viur.core.config import conf
-from viur.core.modules import file
 from datetime import datetime
 import typing as t
 
@@ -137,7 +136,12 @@ class DefaultRender(object):
         for key, bone in skel.items():
             res[key] = self.renderBoneValue(bone, skel, key)
 
-        if injectDownloadURL and "dlkey" in skel and "name" in skel:
+        if (
+            injectDownloadURL
+            and (file := getattr(conf.main_app, "file", None))
+            and "dlkey" in skel
+            and "name" in skel
+        ):
             res["downloadUrl"] = file.create_download_url(
                 skel["dlkey"],
                 skel["name"],

--- a/tests/main.py
+++ b/tests/main.py
@@ -32,6 +32,7 @@ def monkey_patch():
         "google.cloud.tasks_v2",
         "google.cloud",
         "google.oauth2",
+        "google.oauth2.service_account",
         "google.protobuf",
         "google",
     )


### PR DESCRIPTION
Accidently committed a wrong import, I was on this before. This fixes the use undefined ServiceAccountCredentials in download.

Additionally does further refactoring:

- All former `utils` functions are added to the `File` class as `@staticmethods`
- The `previous core.bones.text.parseDownloadUrl` is reborn as a heavily revised and now secure version as `File.parse_download_url()` (the previous version didn't take a few security-relevant cases into account).
- Also found a regression: call to `downloadUrlFor` that was being renamed and moved in #1046 already 