### PR TITLE
fix:  `_validate_request` in `tasks`

### DIFF
--- a/src/viur/core/tasks.py
+++ b/src/viur/core/tasks.py
@@ -341,7 +341,7 @@ class TaskHandler(Module):
         ):
             logging.critical("Detected an attempted XSRF attack. This request did not originate from Task Queue.")
             raise errors.Forbidden()
-        if require_cron and "X-Appengine-Cron" not in req.request.headers:
+        if require_cron and "X-Appengine-Cron" not in req.headers:
             logging.critical('Detected an attempted XSRF attack. The header "X-AppEngine-Cron" was not set.')
             raise errors.Forbidden()
         if require_taskname and "X-AppEngine-TaskName" not in req.headers:


### PR DESCRIPTION
Fix error caused by #1004.

Error: 
```shell
File "/home/foo/Schreibtisch/work/foo-dev/viur/src/viur/core/tasks.py", line 342, in _validate_request
    if require_cron and "X-Appengine-Cron" not in req.request.headers:
                                                  ^^^^^^^^^^^
  File "/home/foo/.local/share/virtualenvs/foo-lcuCThDg/lib/python3.11/site-packages/webob/request.py", line 1410, in __getattr__
    raise AttributeError(attr)
AttributeError: request
```