### PR TITLE
fix: `RelationalBone` locking bug

### DIFF
--- a/src/viur/core/bones/relational.py
+++ b/src/viur/core/bones/relational.py
@@ -506,7 +506,7 @@ class RelationalBone(BaseBone):
         for newLock in newRelationalLocks - oldRelationalLocks:
             # Lock new Entry
             if referencedObj := db.Get(newLock):
-                referencedOb.setdefault("viur_incomming_relational_locks", [])
+                referencedObj.setdefault("viur_incomming_relational_locks", [])
 
                 if skel["key"] not in referencedObj["viur_incomming_relational_locks"]:
                     referencedObj["viur_incomming_relational_locks"].append(skel["key"])
@@ -514,7 +514,7 @@ class RelationalBone(BaseBone):
 
         for oldLock in oldRelationalLocks - newRelationalLocks:
             # Remove Lock
-            if referencedObj := db.Get(newLock):
+            if referencedObj := db.Get(oldLock):
                 if skel["key"] in referencedObj["viur_incomming_relational_locks"]:
                     referencedObj["viur_incomming_relational_locks"].remove(skel["key"])
                     db.Put(referencedObj)

--- a/src/viur/core/bones/relational.py
+++ b/src/viur/core/bones/relational.py
@@ -486,35 +486,40 @@ class RelationalBone(BaseBone):
             else:
                 usingData = None
             res = {"rel": usingData, "dest": refData}
+
         skel.dbEntity[name] = res
+
         # Ensure our indexed flag is up2date
         if indexed and name in skel.dbEntity.exclude_from_indexes:
             skel.dbEntity.exclude_from_indexes.discard(name)
         elif not indexed and name not in skel.dbEntity.exclude_from_indexes:
             skel.dbEntity.exclude_from_indexes.add(name)
+
         # Ensure outgoing Locks are up2date
         if self.consistency != RelationalConsistency.PreventDeletion:
             # We don't need to lock anything, but may delete old locks held
             newRelationalLocks = set()
+
         # We should always run inside a transaction so we can safely get+put
-        skel.dbEntity["%s_outgoingRelationalLocks" % name] = list(newRelationalLocks)
+        skel.dbEntity[f"{name}_outgoingRelationalLocks"] = list(newRelationalLocks)
+
         for newLock in newRelationalLocks - oldRelationalLocks:
             # Lock new Entry
-            referencedObj = db.Get(newLock)
-            assert referencedObj, "Programming error detected?"
-            if not referencedObj.get("viur_incomming_relational_locks"):
-                referencedObj["viur_incomming_relational_locks"] = []
-            assert skel["key"] not in referencedObj["viur_incomming_relational_locks"]
-            referencedObj["viur_incomming_relational_locks"].append(skel["key"])
-            db.Put(referencedObj)
+            if referencedObj := db.Get(newLock):
+                if not referencedObj.get("viur_incomming_relational_locks"):
+                    referencedObj["viur_incomming_relational_locks"] = []
+
+                if skel["key"] not in referencedObj["viur_incomming_relational_locks"]:
+                    referencedObj["viur_incomming_relational_locks"].append(skel["key"])
+                    db.Put(referencedObj)
+
         for oldLock in oldRelationalLocks - newRelationalLocks:
             # Remove Lock
-            referencedObj = db.Get(oldLock)
-            assert referencedObj, "Programming error detected?"
-            assert isinstance(referencedObj.get("viur_incomming_relational_locks"), list), "Programming error detected?"
-            assert skel["key"] in referencedObj["viur_incomming_relational_locks"], "Programming error detected?"
-            referencedObj["viur_incomming_relational_locks"].remove(skel["key"])
-            db.Put(referencedObj)
+            if referencedObj := db.Get(newLock):
+                if skel["key"] in referencedObj["viur_incomming_relational_locks"]:
+                    referencedObj["viur_incomming_relational_locks"].remove(skel["key"])
+                    db.Put(referencedObj)
+
         return True
 
     def delete(self, skel: 'viur.core.skeleton.SkeletonInstance', name: str):
@@ -1296,7 +1301,6 @@ class RelationalBone(BaseBone):
         for idx, lang, value in self.iter_bone_value(skel, name):
             if value is None:
                 continue
-            logging.debug((idx, lang, value, name))
             for key, bone_ in value["dest"].items():
                 result.update(bone_.getReferencedBlobs(value["dest"], key))
             if value["rel"]:

--- a/src/viur/core/bones/relational.py
+++ b/src/viur/core/bones/relational.py
@@ -506,8 +506,7 @@ class RelationalBone(BaseBone):
         for newLock in newRelationalLocks - oldRelationalLocks:
             # Lock new Entry
             if referencedObj := db.Get(newLock):
-                if not referencedObj.get("viur_incomming_relational_locks"):
-                    referencedObj["viur_incomming_relational_locks"] = []
+                referencedOb.setdefault("viur_incomming_relational_locks", [])
 
                 if skel["key"] not in referencedObj["viur_incomming_relational_locks"]:
                     referencedObj["viur_incomming_relational_locks"].append(skel["key"])


### PR DESCRIPTION
This fixes the bug that comes up when there are two RelationalBones with `RelationalConsistency.PreventDeletion` being set to the same target kind. It raises an error 500 on a customer project, as the assertion and helpful "PROGRAMMING ERROR DETECTED" message are raised, which causes that this bug arose.