### PR TITLE
fix: Use `__getattribute__` instead of `__getattr__` for super call in utils

### DIFF
--- a/src/viur/core/utils/__init__.py
+++ b/src/viur/core/utils/__init__.py
@@ -151,4 +151,4 @@ def __getattr__(attr):
         logging.warning(msg, stacklevel=3)
         return replace[1]
 
-    return super(__import__(__name__).__class__).__getattr__(attr)
+    return super(__import__(__name__).__class__).__getattribute__(attr)


### PR DESCRIPTION
It caused
```py
'super' object has no attribute '__getattr__'
Traceback (most recent call last):
  File "/layers/google.python.pip/pip/lib/python3.11/site-packages/viur/core/request.py", line 298, in _process
    self._route(path)
  File "/layers/google.python.pip/pip/lib/python3.11/site-packages/viur/core/request.py", line 554, in _route
    res = caller(*self.args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/layers/google.python.pip/pip/lib/python3.11/site-packages/viur/core/module.py", line 299, in __call__
    return self._func(self._instance, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/modules/file.py", line 112, in static
    signed_url = utils.downloadUrlFor(
                 ^^^^^^^^^^^^^^^^^^^^
  File "/layers/google.python.pip/pip/lib/python3.11/site-packages/viur/core/utils/__init__.py", line 154, in __getattr__
    return super(__import__(__name__).__class__).__getattr__(attr)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'super' object has no attribute '__getattr__'
``` 

but should cause:
```py
AttributeError: 'super' object has no attribute 'downloadUrlFor'
```