### PR TITLE
fix: `current.user` unset in deferred task calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file documents any relevant changes done to ViUR-core since version 3.
 
+## [3.5.14]
+
+- fix: `current.user` unset in deferred task calls (#1067)
+
 ## [3.5.13]
 
 - fix: `RelationalBone` locking bug (#1052)

--- a/src/viur/core/modules/user.py
+++ b/src/viur/core/modules/user.py
@@ -1217,11 +1217,9 @@ class User(List):
         return getattr(self, "f2_%s" % cls.__name__.lower())
 
     def getCurrentUser(self):
-        # May be a deferred task
-        if not (session := current.session.get()):
-            return None
+        session = current.session.get()
 
-        if user := session.get("user"):
+        if session and (user := session.get("user")):
             skel = self.baseSkel()
             skel.setEntity(user)
             return skel

--- a/src/viur/core/tasks.py
+++ b/src/viur/core/tasks.py
@@ -222,6 +222,10 @@ class TaskHandler(Module):
         if env:
             if "user" in env and env["user"]:
                 current.session.get()["user"] = env["user"]
+
+                # Load current user into context variable if user module is there.
+                if user_mod := getattr(conf["viur.mainApp"], "user", None):
+                    current.user.set(user_mod.getCurrentUser())
             if "lang" in env and env["lang"]:
                 current.language.set(env["lang"])
             if "transactionMarker" in env:

--- a/src/viur/core/version.py
+++ b/src/viur/core/version.py
@@ -3,7 +3,7 @@
 # This will mark it as a pre-release as well on PyPI.
 # See CONTRIBUTING.md for further information.
 
-__version__ = "3.5.13"
+__version__ = "3.5.14"
 
 assert __version__.count(".") >= 2 and "".join(__version__.split(".", 3)[:3]).isdigit(), \
     "Semantic __version__ expected!"


### PR DESCRIPTION
Already released as v3.5.14 and tested in a live environment.