### PR TITLE
feat: Provide `default_order` for `List` and `Tree`

### DIFF
--- a/src/viur/core/modules/file.py
+++ b/src/viur/core/modules/file.py
@@ -396,6 +396,8 @@ class File(Tree):
         "admin": "*",
     }
 
+    default_order = "name"
+
     # Helper functions currently resist here
 
     @staticmethod

--- a/src/viur/core/modules/user.py
+++ b/src/viur/core/modules/user.py
@@ -1148,6 +1148,8 @@ class User(List):
 
     secondFactorTimeWindow = datetime.timedelta(minutes=10)
 
+    default_order = "name.idx"
+
     adminInfo = {
         "icon": "person-fill",
         "actions": [

--- a/src/viur/core/prototypes/tree.py
+++ b/src/viur/core/prototypes/tree.py
@@ -47,6 +47,14 @@ class Tree(SkelModule):
     nodeSkelCls = None
     leafSkelCls = None
 
+    default_order: str | tuple[str, db.SortOrder] | None = "sortindex"
+    """
+    Allows to specify a default order for this module, which is applied when no other order is specified.
+
+    Setting a default_order might result in the requirement of additional indexes, which are being raised
+    and must be specified.
+    """
+
     def __init__(self, moduleName, modulePath, *args, **kwargs):
         assert self.nodeSkelCls, f"Need to specify at least nodeSkelCls for {self.__class__.__name__!r}"
         super().__init__(moduleName, modulePath, *args, **kwargs)
@@ -281,13 +289,17 @@ class Tree(SkelModule):
         :raises: :exc:`viur.core.errors.Unauthorized`, if the current user does not have the required permissions.
         """
         if not (skelType := self._checkSkelType(skelType)):
-            raise errors.NotAcceptable(f"Invalid skelType provided.")
-        skel = self.viewSkel(skelType)
-        query = self.listFilter(skel.all().mergeExternalFilter(kwargs))  # Access control
-        if query is None:
-            raise errors.Unauthorized()
-        res = query.fetch()
-        return self.render.list(res)
+            raise errors.NotAcceptable("Invalid skelType provided.")
+
+        # The general access control is made via self.listFilter()
+        if query := self.listFilter(self.viewSkel(skelType).all().mergeExternalFilter(kwargs)):
+            # Apply default order when specified
+            if self.default_order and not query.queries.orders and not current.request.get().kwargs.get("search"):
+                query.order(self.default_order)
+
+            return self.render.list(query.fetch())
+
+        raise errors.Unauthorized()
 
     @exposed
     def structure(self, skelType: SkelType, *args, **kwargs) -> t.Any:


### PR DESCRIPTION
To avoid the creation of unsecure and error-prone `listFilter`s, this approach tries to fix #1011 and improves the ViUR system generally:

1. Trees default to sort by "sortindex"
2. The `File`-module defaults sorts by "name"
3. The `User`-module defaults to sort by "name" as well