### PR TITLE
fix: `vi.canAccess` based on fnmatch config setting

### DIFF
--- a/src/viur/core/config.py
+++ b/src/viur/core/config.py
@@ -397,26 +397,34 @@ class Security(ConfigType):
 
     password_recovery_key_length: int = 42
     """Length of the Password recovery key"""
+
     closed_system: bool = False
     """If `True` it activates a mode in which only authenticated users can access all routes."""
 
-    closed_system_allowed_paths: t.Iterable[str] = [
+    admin_allowed_paths: t.Iterable[str] = [
+        "vi",
+        "vi/skey",
+        "vi/settings",
+        "vi/user/auth_*",
+        "vi/user/f2_*",
+        "vi/user/getAuthMethods",  # FIXME: deprecated, use `login` for this
+        "vi/user/login",
+    ]
+    """Specifies admin tool paths which are being accessible without authenticated user."""
+
+    closed_system_allowed_paths: t.Iterable[str] = admin_allowed_paths + [
         "",  # index site
         "json/skey",
         "json/user/auth_*",
-        "json/user/getAuthMethods",
+        "json/user/f2_*",
+        "json/user/getAuthMethods",  # FIXME: deprecated, use `login` for this
         "json/user/login",
         "user/auth_*",
-        "user/getAuthMethods",
+        "user/f2_*",
+        "user/getAuthMethods",  # FIXME: deprecated, use `login` for this
         "user/login",
-        "vi",
-        "vi/settings",
-        "vi/skey",
-        "vi/user/auth_*",
-        "vi/user/getAuthMethods",
-        "vi/user/login",
     ]
-    """List of URLs that are accessible without authentication in a closed system"""
+    """Paths that are accessible without authentication in a closed system, see `closed_system` for details."""
 
     _mapping = {
         "contentSecurityPolicy": "content_security_policy",

--- a/src/viur/core/render/vi/__init__.py
+++ b/src/viur/core/render/vi/__init__.py
@@ -1,7 +1,7 @@
 import datetime
+import fnmatch
 import json
 import logging
-
 from viur.core import Module, conf, current, errors
 from viur.core.decorators import *
 from viur.core.render.json import skey as json_render_skey
@@ -142,27 +142,14 @@ def getVersion(*args, **kwargs):
 
 
 def canAccess(*args, **kwargs) -> bool:
-    if (user := current.user.get()) and ("root" in user["access"] or "admin" in user["access"]):
+    """
+    General access restrictions for the vi-render.
+    """
+
+    if (cuser := current.user.get()) and any(right in cuser["access"] for right in ("root", "admin")):
         return True
-    pathList = current.request.get().path_list
-    if len(pathList) >= 2 and pathList[1] in ["skey", "getVersion", "settings"]:
-        # Give the user the chance to login :)
-        return True
-    if (len(pathList) >= 3
-        and pathList[1] == "user"
-        and (pathList[2].startswith("auth_")
-             or pathList[2].startswith("f2_")
-             or pathList[2] == "getAuthMethods"
-             or pathList[2] == "logout")):
-        # Give the user the chance to login :)
-        return True
-    if (len(pathList) >= 4
-        and pathList[1] == "user"
-        and pathList[2] == "view"
-        and pathList[3] == "self"):
-        # Give the user the chance to view himself.
-        return True
-    return False
+
+    return any(fnmatch.fnmatch(current.request.get().path, pat) for pat in conf.security.admin_allowed_paths)
 
 
 @exposed

--- a/src/viur/core/request.py
+++ b/src/viur/core/request.py
@@ -6,13 +6,13 @@
     request processing (useful for global ratelimiting, DDoS prevention or access control).
 """
 import fnmatch
+import inspect
 import json
 import logging
 import os
 import time
 import traceback
 import typing as t
-import inspect
 import unicodedata
 import webob
 from abc import ABC, abstractmethod
@@ -111,6 +111,7 @@ class Router:
         self._traceID = \
             self.request.headers.get("X-Cloud-Trace-Context", "").split("/")[0] or utils.string.random()
         self.is_deferred = False
+        self.path = ""
         self.path_list = ()
 
         self.skey_checked = False  # indicates whether @skey-decorator-check has already performed within a request
@@ -438,6 +439,7 @@ class Router:
 
         # Parse the URL
         if path := parse.urlparse(path).path:
+            self.path = path
             self.path_list = tuple(unicodedata.normalize("NFC", parse.unquote(part))
                                    for part in path.strip("/").split("/"))
 


### PR DESCRIPTION
This is an extension to #1085 which both allows to use `vi/user/login` as the replacement for `vi/user/getAuthMethods` and generalizes the access verification based on the config.

Also adds `path`-member to Router/Request.