### PR TITLE
fix: User roles: Automatic "view" right when "edit" or "delete" is provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file documents any relevant changes done to ViUR-core since version 3.
 
+## [3.5.16]
+
+- fix: User roles: Automatic "view" right when "edit" or "delete" is provided (#1102)
+
 ## [3.5.15]
 
 - fix: Several improvements on `ModuleConf` (#1073)

--- a/src/viur/core/modules/user.py
+++ b/src/viur/core/modules/user.py
@@ -210,6 +210,10 @@ class UserSkel(skeleton.Skeleton):
                             if right in module.accessRights:
                                 access.add(f"{name}-{right}")
 
+                                # special case: "edit" and "delete" actions require "view" as well!
+                                if right in ("edit", "delete") and "view" in module.accessRights:
+                                    access.add(f"{name}-view")
+
             skel["access"] = list(access)
 
         return super().toDB(skel, *args, **kwargs)

--- a/src/viur/core/version.py
+++ b/src/viur/core/version.py
@@ -3,7 +3,7 @@
 # This will mark it as a pre-release as well on PyPI.
 # See CONTRIBUTING.md for further information.
 
-__version__ = "3.5.15"
+__version__ = "3.5.16"
 
 assert __version__.count(".") >= 2 and "".join(__version__.split(".", 3)[:3]).isdigit(), \
     "Semantic __version__ expected!"


### PR DESCRIPTION
The `File`-module has default setting "add", "edit" for editor-role, which didn't work. One correction would be to simply add "view" there, but this method automatically adds "view" when "edit" or "delete" is given.