### PR TITLE
fix: Improvement `conf["viur.paramFilterFunction"]`

### DIFF
--- a/src/viur/core/config.py
+++ b/src/viur/core/config.py
@@ -196,7 +196,7 @@ conf = Conf({
     "viur.maxPostParamsCount": 250,
 
     # Function which decides if a request param should be used or filtered out
-    "viur.paramFilterFunction": lambda key, value: True,
+    "viur.paramFilterFunction": lambda key, value: key.startswith("_"),
 
     # Describing the internal ModuleConfig-module
     "viur.moduleconf.admin_info": {

--- a/src/viur/core/config.py
+++ b/src/viur/core/config.py
@@ -195,6 +195,9 @@ conf = Conf({
     # Upper limit of the amount of parameters we accept per request. Prevents Hash-Collision-Attacks
     "viur.maxPostParamsCount": 250,
 
+    # Function which decides if a request param should be used or filtered out
+    "viur.paramFilterFunction": lambda key, value: True,
+
     # Describing the internal ModuleConfig-module
     "viur.moduleconf.admin_info": {
         "icon": "icon-settings",

--- a/src/viur/core/request.py
+++ b/src/viur/core/request.py
@@ -437,7 +437,7 @@ class Router:
 
         param_filter = conf["viur.paramFilterFunction"]
         if param_filter and not callable(param_filter):
-           raise ValueError(f"""{param_filter=} is not callable""")
+            raise ValueError(f"""{param_filter=} is not callable""")
 
         for key, value in self.request.params.items():
             try:

--- a/src/viur/core/request.py
+++ b/src/viur/core/request.py
@@ -435,6 +435,7 @@ class Router:
                 f" of {conf['viur.maxPostParamsCount']} allowed arguments per request"
             )
 
+        param_filter = conf["viur.paramFilterFunction"]
         for key, value in self.request.params.items():
             try:
                 key = unicodedata.normalize("NFC", key)
@@ -444,7 +445,7 @@ class Router:
                 # someone tries to exploit unicode normalisation bugs)
                 raise errors.BadRequest()
 
-            if key.startswith("_"):  # Ignore keys starting with _ (like VI's _unused_time_stamp)
+            if not param_filter(key, value):
                 continue
 
             if key == TEMPLATE_STYLE_KEY:

--- a/src/viur/core/request.py
+++ b/src/viur/core/request.py
@@ -438,6 +438,7 @@ class Router:
         param_filter = conf["viur.paramFilterFunction"]
         if param_filter and not callable(param_filter):
            raise ValueError(f"""{param_filter=} is not callable""")
+
         for key, value in self.request.params.items():
             try:
                 key = unicodedata.normalize("NFC", key)

--- a/src/viur/core/request.py
+++ b/src/viur/core/request.py
@@ -436,6 +436,8 @@ class Router:
             )
 
         param_filter = conf["viur.paramFilterFunction"]
+        if param_filter and not callable(param_filter):
+           raise ValueError(f"""{param_filter=} is not callable""")
         for key, value in self.request.params.items():
             try:
                 key = unicodedata.normalize("NFC", key)
@@ -445,7 +447,7 @@ class Router:
                 # someone tries to exploit unicode normalisation bugs)
                 raise errors.BadRequest()
 
-            if not param_filter(key, value):
+            if param_filter and param_filter(key, value):
                 continue
 
             if key == TEMPLATE_STYLE_KEY:


### PR DESCRIPTION
Remove the static filter that removes any parameters passed, starting with "_", to a configurable filter function which provides more flexibility.