### PR TITLE
feat: `default_order` should support multiple orders as well

### DIFF
--- a/src/viur/core/prototypes/list.py
+++ b/src/viur/core/prototypes/list.py
@@ -187,6 +187,7 @@ class List(SkelModule):
         if query := self.listFilter(self.viewSkel().all().mergeExternalFilter(kwargs)):
             # Apply default order when specified
             if self.default_order and not query.queries.orders and not current.request.get().kwargs.get("search"):
+                # TODO: refactor: Duplicate code in prototypes.Tree
                 if callable(default_order := self.default_order):
                     default_order = default_order(query)
 

--- a/src/viur/core/prototypes/list.py
+++ b/src/viur/core/prototypes/list.py
@@ -190,7 +190,7 @@ class List(SkelModule):
                 if callable(default_order := self.default_order):
                     default_order = default_order(query)
 
-                if isinstance(default_order, tuple) and all(isinstance(pair, tuple) for pair in default_order):
+                if isinstance(default_order, tuple | list) and all(isinstance(pair, tuple) and len(pair) == 2 for pair in default_order):
                     query.order(*default_order)
                 elif default_order:
                     query.order(default_order)

--- a/src/viur/core/prototypes/list.py
+++ b/src/viur/core/prototypes/list.py
@@ -190,11 +190,20 @@ class List(SkelModule):
                 if callable(default_order := self.default_order):
                     default_order = default_order(query)
 
-                if isinstance(default_order, tuple | list) and all(isinstance(pair, tuple) and len(pair) == 2
-                                                                   for pair in default_order):
-                    query.order(*default_order)
-                elif default_order:
-                    query.order(default_order)
+                if default_order:
+                    # FIXME: This ugly test can be removed when there is type that abstracts SortOrders
+                    if (
+                        isinstance(default_order, str)
+                        or (
+                            isinstance(default_order, tuple)
+                            and len(default_order) == 2
+                            and isinstance(default_order[0], str)
+                            and isinstance(default_order[1], db.SortOrder)
+                        )
+                    ):
+                        query.order(default_order)
+                    else:
+                        query.order(*default_order)
 
             return self.render.list(query.fetch())
 

--- a/src/viur/core/prototypes/list.py
+++ b/src/viur/core/prototypes/list.py
@@ -190,7 +190,8 @@ class List(SkelModule):
                 if callable(default_order := self.default_order):
                     default_order = default_order(query)
 
-                if isinstance(default_order, tuple | list) and all(isinstance(pair, tuple) and len(pair) == 2 for pair in default_order):
+                if isinstance(default_order, tuple | list) and all(isinstance(pair, tuple) and len(pair) == 2
+                                                                   for pair in default_order):
                     query.order(*default_order)
                 elif default_order:
                     query.order(default_order)

--- a/src/viur/core/prototypes/list.py
+++ b/src/viur/core/prototypes/list.py
@@ -190,7 +190,9 @@ class List(SkelModule):
                 if callable(default_order := self.default_order):
                     default_order = default_order(query)
 
-                if default_order:
+                if isinstance(default_order, tuple) and all(isinstance(pair, tuple) for pair in default_order):
+                    query.order(*default_order)
+                elif default_order:
                     query.order(default_order)
 
             return self.render.list(query.fetch())

--- a/src/viur/core/prototypes/skelmodule.py
+++ b/src/viur/core/prototypes/skelmodule.py
@@ -3,9 +3,14 @@ from viur.core.skeleton import skeletonByKind, Skeleton, SkeletonInstance
 import typing as t
 
 
-ORDER_TYPE = str | tuple[str, db.SortOrder] | None
+SINGLE_ORDER_TYPE = str | tuple[str, db.SortOrder]
 """
-Type for sort order definitions.
+Type for exactly one sort order definitions.
+"""
+
+ORDER_TYPE = SINGLE_ORDER_TYPE | tuple[SINGLE_ORDER_TYPE] | list[SINGLE_ORDER_TYPE] | None
+"""
+Type for sort order definitions (any amount of single order definitions).
 """
 
 DEFAULT_ORDER_TYPE = ORDER_TYPE | t.Callable[[db.Query], ORDER_TYPE]

--- a/src/viur/core/prototypes/tree.py
+++ b/src/viur/core/prototypes/tree.py
@@ -295,11 +295,24 @@ class Tree(SkelModule):
         if query := self.listFilter(self.viewSkel(skelType).all().mergeExternalFilter(kwargs)):
             # Apply default order when specified
             if self.default_order and not query.queries.orders and not current.request.get().kwargs.get("search"):
+                # TODO: refactor: Duplicate code in prototypes.List
                 if callable(default_order := self.default_order):
                     default_order = default_order(query)
 
                 if default_order:
-                    query.order(default_order)
+                    # FIXME: This ugly test can be removed when there is type that abstracts SortOrders
+                    if (
+                        isinstance(default_order, str)
+                        or (
+                            isinstance(default_order, tuple)
+                            and len(default_order) == 2
+                            and isinstance(default_order[0], str)
+                            and isinstance(default_order[1], db.SortOrder)
+                        )
+                    ):
+                        query.order(default_order)
+                    else:
+                        query.order(*default_order)
 
             return self.render.list(query.fetch())
 


### PR DESCRIPTION
e.g.:
```py
    default_order: DEFAULT_ORDER_TYPE = (
        ("firstname", db.SortOrder.Ascending),
        ("lastname", db.SortOrder.Ascending),
    )
```