### PR TITLE
fix: Handle non-ASCII characters in username comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file documents any relevant changes done to ViUR-core since version 3.
 
+## [3.5.17]
+
+- fix: Handle non-ASCII characters in username comparison (#1112)
+
 ## [3.5.16]
 
 - chore: Dependency updates

--- a/src/viur/core/modules/user.py
+++ b/src/viur/core/modules/user.py
@@ -305,7 +305,7 @@ class UserPassword(UserAuthentication):
 
         # Check if the username matches
         stored_user_name = (user_entry.get("name") or {}).get("idx") or ""
-        is_okay = secrets.compare_digest(stored_user_name, name)
+        is_okay = secrets.compare_digest(stored_user_name.encode(), name.encode())
 
         # Check if the password matches
         stored_password_hash = password_data.get("pwhash", b"-invalid-")

--- a/src/viur/core/version.py
+++ b/src/viur/core/version.py
@@ -3,7 +3,7 @@
 # This will mark it as a pre-release as well on PyPI.
 # See CONTRIBUTING.md for further information.
 
-__version__ = "3.5.16"
+__version__ = "3.5.17"
 
 assert __version__.count(".") >= 2 and "".join(__version__.split(".", 3)[:3]).isdigit(), \
     "Semantic __version__ expected!"


### PR DESCRIPTION
Login causes error 500 when e.g. umlauts are being used.