### PR TITLE
feat: Provide `LoginSkel` on `UserPassword.login`

### DIFF
--- a/src/viur/core/bones/password.py
+++ b/src/viur/core/bones/password.py
@@ -3,10 +3,9 @@ The PasswordBone class is a specialized version of the StringBone class designed
 data. It hashes the password data before saving it to the database and prevents it from being read
 directly. The class also includes various tests to determine the strength of the entered password.
 """
-
 import hashlib
 import re
-
+import typing as t
 from viur.core import conf, utils
 from viur.core.bones.string import StringBone
 from viur.core.i18n import translate
@@ -46,7 +45,7 @@ class PasswordBone(StringBone):
     """A string representing the bone type, which is "password" in this case."""
     saltLength = 13
 
-    tests: tuple[tuple[str, str, bool]] = (
+    tests: t.Iterable[t.Iterable[str, str, bool]] = (
         (r"^.*[A-Z].*$", translate("core.bones.password.no_capital_letters",
                                    defaultText="The password entered has no capital letters."), False),
         (r"^.*[a-z].*$", translate("core.bones.password.no_lowercase_letters",
@@ -65,15 +64,14 @@ class PasswordBone(StringBone):
         *,
         descr: str = "Password",
         test_threshold: int = 4,
-        tests: list[tuple] = tests,
+        tests: t.Iterable[t.Iterable[str, str, bool]] = tests,
         **kwargs
     ):
         """
             Initializes a new PasswordBone.
 
             :param test_threshold: The minimum number of tests the password must pass.
-            :param password_tests: A list of tuples. The tuple contains the test and a reason for the user if the test
-                    fails.
+            :param password_tests: Defines separate tests specified as tuples of regex, hint and required-flag.
         """
         super().__init__(descr=descr, **kwargs)
         self.test_threshold = test_threshold
@@ -193,6 +191,6 @@ class PasswordBone(StringBone):
 
     def structure(self) -> dict:
         return super().structure() | {
-            "tests": self.tests,
+            "tests": self.tests if self.test_threshold else (),
             "test_threshold": self.test_threshold,
         }

--- a/src/viur/core/bones/password.py
+++ b/src/viur/core/bones/password.py
@@ -57,7 +57,7 @@ class PasswordBone(StringBone):
         (r"^.{8,}$", translate("core.bones.password.too_short",
                                defaultText="The password is too short. It requires for at least 8 characters."), True),
     )
-    """Provides tests based on regular expressions to test the password stength.
+    """Provides tests based on regular expressions to test the password strength.
 
     Note: The provided regular expressions have to produce exactly the same results in Python and JavaScript.
           This requires that some feature either cannot be used, or must be rewritten to match on both engines.

--- a/src/viur/core/bones/password.py
+++ b/src/viur/core/bones/password.py
@@ -45,7 +45,7 @@ class PasswordBone(StringBone):
     """A string representing the bone type, which is "password" in this case."""
     saltLength = 13
 
-    tests: t.Iterable[type((str, str, bool))] = (
+    tests: t.Iterable[t.Iterable[t.Tuple[str, str, bool]]] = (
         (r"^.*[A-Z].*$", translate("core.bones.password.no_capital_letters",
                                    defaultText="The password entered has no capital letters."), False),
         (r"^.*[a-z].*$", translate("core.bones.password.no_lowercase_letters",
@@ -64,7 +64,7 @@ class PasswordBone(StringBone):
         *,
         descr: str = "Password",
         test_threshold: int = 4,
-        tests: t.Iterable[type((str, str, bool))] = tests,
+        tests: t.Iterable[t.Iterable[t.Tuple[str, str, bool]]] = tests,
         **kwargs
     ):
         """

--- a/src/viur/core/bones/password.py
+++ b/src/viur/core/bones/password.py
@@ -45,7 +45,7 @@ class PasswordBone(StringBone):
     """A string representing the bone type, which is "password" in this case."""
     saltLength = 13
 
-    tests: t.Iterable[[str, str, bool]] = (
+    tests: t.Iterable[type((str, str, bool))] = (
         (r"^.*[A-Z].*$", translate("core.bones.password.no_capital_letters",
                                    defaultText="The password entered has no capital letters."), False),
         (r"^.*[a-z].*$", translate("core.bones.password.no_lowercase_letters",
@@ -64,7 +64,7 @@ class PasswordBone(StringBone):
         *,
         descr: str = "Password",
         test_threshold: int = 4,
-        tests: t.Iterable[[str, str, bool]] = tests,
+        tests: t.Iterable[type((str, str, bool))] = tests,
         **kwargs
     ):
         """

--- a/src/viur/core/bones/password.py
+++ b/src/viur/core/bones/password.py
@@ -57,7 +57,11 @@ class PasswordBone(StringBone):
         (r"^.{8,}$", translate("core.bones.password.too_short",
                                defaultText="The password is too short. It requires for at least 8 characters."), True),
     )
-    """Provides tests based on regular expressions to test the password stength."""
+    """Provides tests based on regular expressions to test the password stength.
+
+    Note: The provided regular expressions have to produce exactly the same results in Python and JavaScript.
+          This requires that some feature either cannot be used, or must be rewritten to match on both engines.
+    """
 
     def __init__(
         self,

--- a/src/viur/core/bones/password.py
+++ b/src/viur/core/bones/password.py
@@ -45,7 +45,7 @@ class PasswordBone(StringBone):
     """A string representing the bone type, which is "password" in this case."""
     saltLength = 13
 
-    tests: t.Iterable[t.Iterable[str, str, bool]] = (
+    tests: t.Iterable[[str, str, bool]] = (
         (r"^.*[A-Z].*$", translate("core.bones.password.no_capital_letters",
                                    defaultText="The password entered has no capital letters."), False),
         (r"^.*[a-z].*$", translate("core.bones.password.no_lowercase_letters",
@@ -64,7 +64,7 @@ class PasswordBone(StringBone):
         *,
         descr: str = "Password",
         test_threshold: int = 4,
-        tests: t.Iterable[t.Iterable[str, str, bool]] = tests,
+        tests: t.Iterable[[str, str, bool]] = tests,
         **kwargs
     ):
         """

--- a/src/viur/core/modules/user.py
+++ b/src/viur/core/modules/user.py
@@ -266,6 +266,7 @@ class UserPassword(UserPrimaryAuthentication):
         )
         password = PasswordBone(
             required=True,
+            test_threshold=0,
         )
 
     class LostPasswordStep1Skel(skeleton.RelSkel):
@@ -314,7 +315,7 @@ class UserPassword(UserPrimaryAuthentication):
             return self._user_module.render.loginSucceeded()
 
         if not name or not password:
-            return self._user_module.render.login(self.LoginSkel())
+            return self._user_module.render.login(self.LoginSkel(), action="login")
 
         self.loginRateLimit.assertQuotaIsAvailable()
 
@@ -342,6 +343,7 @@ class UserPassword(UserPrimaryAuthentication):
             skel = self.LoginSkel()
             return self._user_module.render.login(
                 skel,
+                action="login",
                 loginFailed=True,  # FIXME: Is this still being used?
                 accountStatus=user_skel["status"]  # FIXME: Is this still being used?
             )


### PR DESCRIPTION
- Implements action skel `LoginSkel` correctly with the right action
- Modifies PasswordBone to not render tests when test_threshold is set to 0, which is a security improvement, as it is not rendered to non-authenticated users