### PR TITLE
fix: Add `is None`-check for bone values with languages

### DIFF
--- a/src/viur/core/render/json/default.py
+++ b/src/viur/core/render/json/default.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from enum import Enum
 
 from viur.core import bones, utils, db, current
@@ -110,7 +111,7 @@ class DefaultRender(object):
         elif bone.languages:
             res = {}
             for language in bone.languages:
-                if boneVal and language in boneVal and boneVal[language]:
+                if boneVal and language in boneVal and boneVal[language] is not None:
                     res[language] = self.renderSingleBoneValue(boneVal[language], bone, skel, key)
                 else:
                     res[language] = None

--- a/src/viur/core/render/json/default.py
+++ b/src/viur/core/render/json/default.py
@@ -1,5 +1,4 @@
 import json
-import logging
 from enum import Enum
 
 from viur.core import bones, utils, db, current

--- a/src/viur/core/render/xml/default.py
+++ b/src/viur/core/render/xml/default.py
@@ -79,7 +79,7 @@ class DefaultRender(object):
         elif bone.languages:
             res = {}
             for language in bone.languages:
-                if boneVal and language in boneVal and boneVal[language]:
+                if boneVal and language in boneVal and boneVal[language] is not None:
                     res[language] = self.renderSingleBoneValue(boneVal[language], bone, skel, key)
                 else:
                     res[language] = None


### PR DESCRIPTION
>There's still no difference between False and None.
(https://github.com/viur-framework/viur-core/issues/1096#issuecomment-1999974027)

With this PR it's fixed.