### PR TITLE
fix: Improving several `User` auth method handling

### DIFF
--- a/src/viur/core/modules/user.py
+++ b/src/viur/core/modules/user.py
@@ -1016,7 +1016,6 @@ class AuthenticatorOTP(UserSecondFactorAuthentication):
         """
         return bool(skel.dbEntity.get("otp_app_secret", ""))
 
-
     @classmethod
     def patch_user_skel(cls, skel_cls):
         """


### PR DESCRIPTION
- Provides `GoogleLogin` only when `conf.user.google_client_id` is set
- Allows for `None`-providers, which are simply ignored
- Temporarily removes deprecation warning for `getAuthMethods`, which produces *not* the same result as `login()`, but should be replaced by `login()` soon.
- Docstrings