### PR TITLE
    feat: Implement `translation_key_prefix` for `SelectBone` values

### DIFF
--- a/src/viur/core/bones/__init__.py
+++ b/src/viur/core/bones/__init__.py
@@ -25,7 +25,11 @@ from .raw import RawBone
 from .record import RecordBone
 from .relational import RelationalBone, RelationalConsistency, RelationalUpdateLevel
 from .selectcountry import SelectCountryBone
-from .select import SelectBone
+from .select import (
+    SelectBone,
+    translation_key_prefix_skeleton_bonename,
+    translation_key_prefix_bonename,
+)
 from .sortindex import SortIndexBone
 from .spatial import SpatialBone
 from .string import StringBone
@@ -71,6 +75,8 @@ __all = [
     "UniqueLockMethod",
     "UniqueValue",
     "UserBone",
+    "translation_key_prefix_bonename",
+    "translation_key_prefix_skeleton_bonename",
 ]
 
 for __cls_name, __cls in locals().copy().items():

--- a/src/viur/core/bones/base.py
+++ b/src/viur/core/bones/base.py
@@ -187,6 +187,12 @@ class BaseBone(object):
     type = "hidden"
     isClonedInstance = False
 
+    _owner = None
+    """Skeleton class to which this bone instance belongs"""
+
+    _name = None
+    """Name of this bone (attribute name in the skeletons containing this bone)"""
+
     def __init__(
         self,
         *,
@@ -293,6 +299,10 @@ class BaseBone(object):
             self._prevent_compute = False
 
         self.compute = compute
+
+    def __set_name__(self, owner: t.Any, name: str) -> None:
+        self._owner = owner
+        self._name = name
 
     def setSystemInitialized(self):
         """

--- a/src/viur/core/bones/base.py
+++ b/src/viur/core/bones/base.py
@@ -16,6 +16,9 @@ import typing as t
 from viur.core import db, utils
 from viur.core.config import conf
 
+if t.TYPE_CHECKING:
+    from ..skeleton import Skeleton
+
 __system_initialized = False
 """
 Initializes the global variable __system_initialized
@@ -187,10 +190,10 @@ class BaseBone(object):
     type = "hidden"
     isClonedInstance = False
 
-    _owner = None
+    skel_cls = None
     """Skeleton class to which this bone instance belongs"""
 
-    _name = None
+    name = None
     """Name of this bone (attribute name in the skeletons containing this bone)"""
 
     def __init__(
@@ -300,9 +303,9 @@ class BaseBone(object):
 
         self.compute = compute
 
-    def __set_name__(self, owner: Skeleton, name: str) -> None:
-        self._owner = owner
-        self._name = name
+    def __set_name__(self, owner: "Skeleton", name: str) -> None:
+        self.skel_cls = owner
+        self.name = name
 
     def setSystemInitialized(self):
         """

--- a/src/viur/core/bones/base.py
+++ b/src/viur/core/bones/base.py
@@ -300,7 +300,7 @@ class BaseBone(object):
 
         self.compute = compute
 
-    def __set_name__(self, owner: t.Any, name: str) -> None:
+    def __set_name__(self, owner: Skeleton, name: str) -> None:
         self._owner = owner
         self._name = name
 

--- a/src/viur/core/bones/select.py
+++ b/src/viur/core/bones/select.py
@@ -1,7 +1,7 @@
 import enum
+import typing as t
 from collections import OrderedDict
 from numbers import Number
-import typing as t
 
 from viur.core.bones.base import BaseBone, ReadFromClientError, ReadFromClientErrorSeverity
 from viur.core.i18n import translate
@@ -20,21 +20,18 @@ Type alias of possible values in a SelectBone. SelectBoneValue can be either a s
 """
 
 SelectBoneMultiple = list[SelectBoneValue]
-""" SelectBoneMultiple is a list of SelectBoneValue elements."""
+"""Type alias for values of a multiple SelectBone."""
 
 
 def translation_key_prefix_skeleton_bonename(bones_instance: BaseBone) -> str:
     """Generate a translation key prefix based on the skeleton name"""
-    # print(f"{bones_instance = }")
-    # print(f"{vars(bones_instance) = }")
     return f'skeleton.{bones_instance._owner.__name__.lower().removesuffix("skel")}.{bones_instance._name}.'
 
 
 def translation_key_prefix_bonename(bones_instance: BaseBone) -> str:
     """Generate a translation key prefix based on the skeleton and bone name"""
-    # print(f"{bones_instance = }")
-    # print(f"{vars(bones_instance) = }")
     return f'skeleton.{bones_instance._owner.__name__.lower().removesuffix("skel")}.{bones_instance._name}.'
+
 
 class SelectBone(BaseBone):
     """
@@ -104,7 +101,6 @@ class SelectBone(BaseBone):
                 )
                 for key, label in values.items()
             }
-            print(f"{values = }")
 
             return values
 

--- a/src/viur/core/bones/select.py
+++ b/src/viur/core/bones/select.py
@@ -35,12 +35,8 @@ def translation_key_prefix_bonename(bones_instance: BaseBone) -> str:
 
 class SelectBone(BaseBone):
     """
-    A SelectBone is a bone which can take a value from a certain list of values..
+    A SelectBone is a bone which can take a value from a certain list of values.
     Inherits from the BaseBone class. The `type` attribute is set to "select".
-
-    :param defaultValue: key(s) of the values which will be checked by default.
-    :param values: dict of key->value pairs from which the user can choose from.
-    :param kwargs: Additional keyword arguments that will be passed to the superclass' __init__ method.
     """
     type = "select"
 
@@ -57,6 +53,17 @@ class SelectBone(BaseBone):
         translation_key_prefix: str | t.Callable[[Self], str] = "",
         **kwargs
     ):
+        """
+        Initializes a new SelectBone.
+
+        :param defaultValue: key(s) of the values which will be checked by default.
+        :param values: dict of key->value pairs from which the user can choose from
+            -- or a callable that returns a dict.
+        :param translation_key_prefix: A prefix for the key of the translation object.
+            It is empty by default, so that only the label (dict value) from the values is used.
+            A static string or dynamic method can be used (like `translation_key_prefix_bonename`).
+        :param kwargs: Additional keyword arguments that will be passed to the superclass' __init__ method.
+        """
         super().__init__(defaultValue=defaultValue, **kwargs)
         self.translation_key_prefix = translation_key_prefix
 

--- a/src/viur/core/bones/select.py
+++ b/src/viur/core/bones/select.py
@@ -25,12 +25,12 @@ SelectBoneMultiple = list[SelectBoneValue]
 
 def translation_key_prefix_skeleton_bonename(bones_instance: BaseBone) -> str:
     """Generate a translation key prefix based on the skeleton name"""
-    return f'skeleton.{bones_instance._owner.__name__.lower().removesuffix("skel")}.{bones_instance._name}.'
+    return f'skeleton.{bones_instance.skel_cls.__name__.lower().removesuffix("skel")}.{bones_instance.name}.'
 
 
 def translation_key_prefix_bonename(bones_instance: BaseBone) -> str:
     """Generate a translation key prefix based on the skeleton and bone name"""
-    return f'skeleton.{bones_instance._owner.__name__.lower().removesuffix("skel")}.{bones_instance._name}.'
+    return f'skeleton.{bones_instance.skel_cls.__name__.lower().removesuffix("skel")}.{bones_instance.name}.'
 
 
 class SelectBone(BaseBone):
@@ -104,7 +104,7 @@ class SelectBone(BaseBone):
             values = {
                 key: label if isinstance(label, translate) else translate(
                     f"{prefix}{label}", str(label),
-                    f"value {key} for {self._name}<{type(self).__name__}> in {self._owner.__name__} in {self._owner}"
+                    f"value {key} for {self.name}<{type(self).__name__}> in {self.skel_cls.__name__} in {self.skel_cls}"
                 )
                 for key, label in values.items()
             }

--- a/src/viur/core/skeleton.py
+++ b/src/viur/core/skeleton.py
@@ -99,9 +99,9 @@ class MetaBaseSkel(type):
         return map
 
     def __setattr__(self, key, value):
-        # print(f"MetaSkeleton.__setattr__({key}) {self=} {value=}")
         super().__setattr__(key, value)
         if isinstance(value, BaseBone):
+            # Call BaseBone.__set_name__ manually for bones that are assigned at runtime
             value.__set_name__(self, key)
 
 
@@ -289,7 +289,6 @@ class SkeletonInstance:
     def __setattr__(self, key, value):
         if key in self.boneMap or isinstance(value, BaseBone):
             self.boneMap[key] = value
-            # value.__set_name__(self, key)
         elif key == "renderPreparation":
             super().__setattr__(key, value)
             self.renderAccessedValues.clear()
@@ -1298,10 +1297,6 @@ class Skeleton(BaseSkeleton, metaclass=MetaSkel):
         # Inform the custom DB Adapter
         if skel.customDatabaseAdapter:
             skel.customDatabaseAdapter.deleteEntry(dbObj, skel)
-    #
-    # def __setattr__(self, key, value):
-    #     print(f"Skeleton.__setattr__({key})")
-    #     super().__setattr__(key, value)
 
 
 class RelSkel(BaseSkeleton):


### PR DESCRIPTION

Currently only the label is used as `translation` key, but also not in
every case. This PR changes allows to set a custom prefix or use a
included method to generator a prefix from the skeleton and bone name.

Furthermore context is added via translation hint.


This is especially interesting for enums, where you cannot set a custom label.