### PR TITLE
fix: Avoid `*AbstractSkel`s from being initialized

### DIFF
--- a/src/viur/core/skeleton.py
+++ b/src/viur/core/skeleton.py
@@ -20,6 +20,7 @@ from viur.core.bones.base import Compute, ComputeInterval, ComputeMethod, ReadFr
 from viur.core.tasks import CallDeferred, CallableTask, CallableTaskBase, QueryIter
 
 _undefined = object()
+ABSTRACT_SKEL_CLS_SUFFIX = "AbstractSkel"
 
 
 class MetaBaseSkel(type):
@@ -66,7 +67,7 @@ class MetaBaseSkel(type):
     def __init__(cls, name, bases, dct):
         cls.__boneMap__ = MetaBaseSkel.generate_bonemap(cls)
 
-        if not getSystemInitialized():
+        if not getSystemInitialized() and not cls.__name__.endswith(ABSTRACT_SKEL_CLS_SUFFIX):
             MetaBaseSkel._allSkelClasses.add(cls)
 
         super(MetaBaseSkel, cls).__init__(name, bases, dct)
@@ -542,7 +543,7 @@ class MetaSkel(MetaBaseSkel):
             .replace(str(conf.instance.core_base_path), "")
 
         # Check if we have an abstract skeleton
-        if cls.__name__.endswith("AbstractSkel"):
+        if cls.__name__.endswith(ABSTRACT_SKEL_CLS_SUFFIX):
             # Ensure that it doesn't have a kindName
             assert cls.kindName is _undefined or cls.kindName is None, "Abstract Skeletons can't have a kindName"
             # Prevent any further processing by this class; it has to be sub-classed before it can be used


### PR DESCRIPTION
This bug came up when I did this:

```py
class UserSkel(UserAbstractSkel):
    brand = None  # don't provide a brand bone
```

Importing the UserAbstractSkel caused that all bones of that Skeleton where initialized, althought it is set to None within the subclass. This causes bone-objects in memory which are never used by nothing.