### PR TITLE
bug: Add import of `PIL.ImageCms`

### DIFF
--- a/src/viur/core/modules/file.py
+++ b/src/viur/core/modules/file.py
@@ -8,6 +8,7 @@ import io
 import json
 import logging
 import PIL
+import PIL.ImageCms
 import re
 import requests
 import string


### PR DESCRIPTION
Otherwise I get locally and in the cloud this error:

```py
[2024-04-12 20:21:50,559] /.../viur/core/tasks.py:248 [ERROR] module 'PIL' has no attribute 'ImageCms'
Traceback (most recent call last):
  File "..lib/python3.11/site-packages/viur/core/tasks.py", line 244, in deferred
    _deferred_tasks[funcPath](*args, **kwargs)
  File ".../site-packages/viur/core/bones/file.py", line 58, in ensureDerived
    callRes = callee(skel, skel["derived"]["files"], params)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../site-packages/viur/core/modules/file.py", line 114, in thumbnailer
    src_profile = PIL.ImageCms.ImageCmsProfile(f)
                  ^^^^^^^^^^^^
AttributeError: module 'PIL' has no attribute 'ImageCms'
```