### PR TITLE
fix: `list` should handle unsatisfiable queries

### DIFF
--- a/src/viur/core/prototypes/list.py
+++ b/src/viur/core/prototypes/list.py
@@ -199,7 +199,8 @@ class List(SkelModule):
             :raises: :exc:`viur.core.errors.Unauthorized`, if the current user does not have the required permissions.
         """
         # The general access control is made via self.listFilter()
-        if query := self.listFilter(self.viewSkel().all().mergeExternalFilter(kwargs)):
+        query = self.listFilter(self.viewSkel().all().mergeExternalFilter(kwargs))
+        if query and query.queries:
             # Apply default order when specified
             if self.default_order and not query.queries.orders and not current.request.get().kwargs.get("search"):
                 # TODO: refactor: Duplicate code in prototypes.Tree

--- a/src/viur/core/prototypes/tree.py
+++ b/src/viur/core/prototypes/tree.py
@@ -292,7 +292,8 @@ class Tree(SkelModule):
             raise errors.NotAcceptable("Invalid skelType provided.")
 
         # The general access control is made via self.listFilter()
-        if query := self.listFilter(self.viewSkel(skelType).all().mergeExternalFilter(kwargs)):
+        query = self.listFilter(self.viewSkel(skelType).all().mergeExternalFilter(kwargs))
+        if query and query.queries:
             # Apply default order when specified
             if self.default_order and not query.queries.orders and not current.request.get().kwargs.get("search"):
                 # TODO: refactor: Duplicate code in prototypes.List


### PR DESCRIPTION
When a list function is provided with invalid data, e.g. a non-base64-key, the `queries`-member of a `db.Query` is set to None, which causes failures with the default order feature.