### PR TITLE
feat: View script by path

### DIFF
--- a/src/viur/core/modules/script.py
+++ b/src/viur/core/modules/script.py
@@ -1,6 +1,7 @@
 import re
+import typing as t
 from viur.core.bones import *
-from viur.core.prototypes.tree import Tree, TreeSkel
+from viur.core.prototypes.tree import Tree, TreeSkel, SkelType
 from viur.core import db, conf, current, skeleton, tasks, errors
 from viur.core.decorators import exposed
 from viur.core.i18n import translate
@@ -98,7 +99,7 @@ class Script(Tree):
         return [{"name": "Scripts", "key": self.ensureOwnModuleRootNode().key}]
 
     @exposed
-    def view(self, skelType, key, *args, **kwargs):
+    def view(self, skelType: SkelType, key: db.Key | int | str, *args, **kwargs) -> t.Any:
         try:
             return super().view(skelType, key, *args, **kwargs)
         except errors.NotFound:

--- a/src/viur/core/modules/script.py
+++ b/src/viur/core/modules/script.py
@@ -1,10 +1,9 @@
+import re
 from viur.core.bones import *
 from viur.core.prototypes.tree import Tree, TreeSkel
-from viur.core import db, conf, current, skeleton, tasks
-from viur.core.prototypes.tree import Tree
+from viur.core import db, conf, current, skeleton, tasks, errors
+from viur.core.decorators import exposed
 from viur.core.i18n import translate
-import re
-
 
 # pre-compile patterns for vfuncs
 DIRECTORY_PATTERN = re.compile(r'^[a-zA-Z0-9äöüÄÖÜ_-]*$')
@@ -97,6 +96,17 @@ class Script(Tree):
             return []
 
         return [{"name": "Scripts", "key": self.ensureOwnModuleRootNode().key}]
+
+    @exposed
+    def view(self, skelType, key, *args, **kwargs):
+        try:
+            return super().view(skelType, key, *args, **kwargs)
+        except errors.NotFound:
+            # When key is not found, try to interpret key as path
+            if skel := self.viewSkel(skelType).all().mergeExternalFilter({"path": key}).getSkel():
+                return super().view(skelType, skel["key"], *args, **kwargs)
+
+            raise
 
     def onEdit(self, skelType, skel):
         self.update_path(skel)


### PR DESCRIPTION
When providing permalinks to Scriptor scripts across multiple projects, it's better to either use the path of the script rather then the key. This is also useful for the script runner and for scriptor actions integrated somewhere.

Additionally allows to view a script by its path, e.g. `http://localhost:8080/json/script/view/leaf/export.py` or `http://localhost:8080/json/script/view/leaf?key=folder/sub/result.py`