### PR TITLE
fix: Python identifier mapping in request `Router`

### DIFF
--- a/src/viur/core/request.py
+++ b/src/viur/core/request.py
@@ -493,11 +493,11 @@ class Router:
                 raise errors.Unauthorized()
 
             idx += 1
-            part = part.replace("-", "_")
+
+            # Turn part into a Python identifier, to allow mapping e.g. "sitemap.xml" to a `sitemap_xml` method.
+            part = part.replace("-", "_").replace(".", "_")
             if part not in caller:
                 part = "index"
-
-            # print(part, caller.get(part))
 
             if caller := caller.get(part):
                 if isinstance(caller, Method):


### PR DESCRIPTION
The `sitemap.xml` routing in several ViUR projects is broken. This re-enables support of parts containing dots within module/method routing.