### PR TITLE
fix: Support `/deploy/admin` folder as well

### DIFF
--- a/src/viur/core/render/vi/__init__.py
+++ b/src/viur/core/render/vi/__init__.py
@@ -156,7 +156,10 @@ def canAccess(*args, **kwargs) -> bool:
 def index(*args, **kwargs):
     if args or kwargs:
         raise errors.NotFound()
-    if not conf.instance.project_base_path.joinpath("vi", "main.html").exists():
+    if (
+        not conf.instance.project_base_path.joinpath("vi", "main.html").exists()
+        and not conf.instance.project_base_path.joinpath("admin", "main.html").exists()
+    ):
         raise errors.NotFound()
     if conf.instance.is_dev_server or current.request.get().isSSLConnection:
         raise errors.Redirect("/vi/s/main.html")


### PR DESCRIPTION
With viur-cli v2 the vi-admin moved from `/deploy/vi/` to `/deploy/admin/`. Therefore the redirect from `HOST/vi` to `HOST/vi/s/main.html` does no longer work. Now we have to check both path.
(We could make this configurable in 3.7 ...)