### PR TITLE
fix: Don't obfuscate any route with character replacements

### DIFF
--- a/src/viur/core/request.py
+++ b/src/viur/core/request.py
@@ -493,11 +493,9 @@ class Router:
                 raise errors.Unauthorized()
 
             idx += 1
-            part = part.replace("-", "_")
+
             if part not in caller:
                 part = "index"
-
-            # print(part, caller.get(part))
 
             if caller := caller.get(part):
                 if isinstance(caller, Method):


### PR DESCRIPTION
Follow-up on #1157, fixes #1063