### PR TITLE
fix: `ViURJsonEncoder` doesn't handle `db.Entity`

### DIFF
--- a/src/viur/core/utils/json.py
+++ b/src/viur/core/utils/json.py
@@ -25,14 +25,18 @@ class ViURJsonEncoder(json.JSONEncoder):
         # cannot be tested in tests...
         elif isinstance(obj, db.Key):
             return {".__key__": db.encodeKey(obj)}
-        elif isinstance(obj, db.Entity):
+
+        return super().default(obj)
+
+    def encode(self, obj: t.Any) -> t.Any:
+        if isinstance(obj, db.Entity):
             # TODO: Handle SkeletonInstance as well?
-            return {
+            obj = {
                 ".__entity__": dict(obj),
                 ".__key__": db.encodeKey(obj.key) if obj.key else None
             }
 
-        return super().default(obj)
+        return super().encode(obj)
 
 
 def dumps(obj: t.Any, *, cls=ViURJsonEncoder, **kwargs) -> str:

--- a/tests/main.py
+++ b/tests/main.py
@@ -58,6 +58,9 @@ def monkey_patch():
     tmp.EXCLUDED_LOGGER_DEFAULTS = []
 
     db_attr = (
+        "!Entity",
+        "!Key",
+        "!KeyClass",
         "acquireTransactionSuccessMarker",
         "AllocateIDs",
         "cache",
@@ -66,14 +69,11 @@ def monkey_patch():
         "DATASTORE_BASE_TYPES",
         "Delete",
         "endDataAccessLog",
-        "Entity",
         "fixUnindexableProperties",
         "Get",
         "GetOrInsert",
         "IsInTransaction",
         "KEY_SPECIAL_PROPERTY",
-        # "Key",
-        # "KeyClass",
         "keyHelper",
         "Put",
         "Query",
@@ -86,12 +86,13 @@ def monkey_patch():
     viur_datastore = mock.Mock()
 
     for attr in db_attr:
-        setattr(viur_datastore, attr, mock.MagicMock())
+        # classes must not be instances of MagicMock, otherwise isinstance checks does not work
+        if attr.startswith("!"):
+            setattr(viur_datastore, attr[1:], mock.MagicMock)
+        else:
+            setattr(viur_datastore, attr, mock.MagicMock())
 
     viur_datastore.config = {}
-    # classes must not be instances of MagicMock, otherwise isinstance checks does not work
-    viur_datastore.Key = mock.MagicMock
-    viur_datastore.KeyClass = mock.MagicMock
     sys.modules["viur.datastore"] = viur_datastore
 
     os.environ["GAE_VERSION"] = "v42"


### PR DESCRIPTION
`db.Entity` was handled like a dict, and therefore the key was gone.