### PR TITLE
fix: Add `google.cloud.logging_v2.handlers.transports.background_thread`  to the `EXCLUDED_LOGGER_DEFAULTS`

### DIFF
--- a/src/viur/core/logging.py
+++ b/src/viur/core/logging.py
@@ -156,6 +156,9 @@ for name, level in {
 for handler in logger.handlers[:]:
     logger.removeHandler(handler)
 
+EXCLUDED_LOGGER_DEFAULTS = list(EXCLUDED_LOGGER_DEFAULTS)
+EXCLUDED_LOGGER_DEFAULTS.append("google.cloud.logging_v2.handlers.transports.background_thread")
+
 # Disable internal logging
 # https://github.com/googleapis/python-logging/issues/13#issuecomment-539723753
 for logger_name in EXCLUDED_LOGGER_DEFAULTS:


### PR DESCRIPTION
This fix the Problem that the logging explorer is filled with trash logs.
Like 
![image](https://github.com/viur-framework/viur-core/assets/47318461/c44f8142-8917-4867-80a3-d0968a8eacbf)
