### PR TITLE
fix: Keep HTML-entities in `HtmlSerializer`

### DIFF
--- a/src/viur/core/bones/text.py
+++ b/src/viur/core/bones/text.py
@@ -91,7 +91,6 @@ class HtmlSerializer(HTMLParser):  # html.parser.HTMLParser
          "\n": "",
          "\0": ""})
 
-
     def __init__(self, validHtml=None, srcSet=None, convert_charrefs: bool = True):
         super().__init__(convert_charrefs=convert_charrefs)
         self.result = ""  # The final result that will be returned

--- a/src/viur/core/bones/text.py
+++ b/src/viur/core/bones/text.py
@@ -91,9 +91,9 @@ class HtmlSerializer(HTMLParser):  # html.parser.HTMLParser
          "\n": "",
          "\0": ""})
 
-    def __init__(self, validHtml=None, srcSet=None):
-        global _defaultTags
-        super(HtmlSerializer, self).__init__()
+
+    def __init__(self, validHtml=None, srcSet=None, convert_charrefs: bool = True):
+        super().__init__(convert_charrefs=convert_charrefs)
         self.result = ""  # The final result that will be returned
         self.openTagsList = []  # List of tags that still need to be closed
         self.tagCache = []  # Tuple of tags that have been processed but not written yet
@@ -369,7 +369,7 @@ class TextBone(BaseBone):
 
     def singleValueFromClient(self, value, skel, bone_name, client_data):
         if not (err := self.isInvalid(value)):  # Returns None on success, error-str otherwise
-            return HtmlSerializer(self.validHtml, self.srcSet).sanitize(value), None
+            return HtmlSerializer(self.validHtml, self.srcSet, False).sanitize(value), None
         else:
             return self.getEmptyValue(), [ReadFromClientError(ReadFromClientErrorSeverity.Invalid, err)]
 

--- a/tests/bones/test_text_bone.py
+++ b/tests/bones/test_text_bone.py
@@ -101,7 +101,10 @@ Next line</p>
 """
         res = bone.singleValueFromClient(client_value, skel, self.bone_name, None)
         escaped_value = (
-            """<h1>Headline</h1><p>This is a&nbsp;paragraph<br>Next line</p> alert(&#39;I am evil!&#39;)"""
+            """<h1>Headline</h1>"""
+            """<p>This is a&nbsp;paragraph<br>"""
+            """Next line</p>"""
+            """ alert(&#39;I am evil!&#39;)"""
             """<img src="/logo.png"><div>A div</div>"""
             """<div>    Another div    <span>Opened span, but never closed</span></div>"""
         )

--- a/tests/bones/test_text_bone.py
+++ b/tests/bones/test_text_bone.py
@@ -87,15 +87,15 @@ class TestTextBone_fromClient(unittest.TestCase):
         bone = TextBone()
         skel = {}
 
-        client_value = \
-            """<h1>Headline</h1>
-            <p>This is a&nbsp;paragraph<br>
-            Next line</p>
-            <script>alert('I am evil!')</script>
-            <img onload="alert('I am evil!')" src="/logo.png">
-            <div>A div</div>
-            <span>Opened, but never closed
-            """
+        client_value = """
+<h1>Headline</h1>
+<p>This is a&nbsp;paragraph<br>
+Next line</p>
+<script>alert('I am evil!')</script>
+<img onload="alert('I am evil!')" src="/logo.png">
+<div>A div</div>
+<span>Opened, but never closed
+"""
         res = bone.singleValueFromClient(client_value, skel, self.bone_name, None)
         escaped_value = (
             """<h1>Headline</h1><p>This is a&nbsp;paragraph<br>Next line</p> alert(&#39;I am evil!&#39;)"""

--- a/tests/bones/test_text_bone.py
+++ b/tests/bones/test_text_bone.py
@@ -94,11 +94,15 @@ Next line</p>
 <script>alert('I am evil!')</script>
 <img onload="alert('I am evil!')" src="/logo.png">
 <div>A div</div>
-<span>Opened, but never closed
+<div>
+    Another div
+    <span>Opened span, but never closed
+</div>
 """
         res = bone.singleValueFromClient(client_value, skel, self.bone_name, None)
         escaped_value = (
             """<h1>Headline</h1><p>This is a&nbsp;paragraph<br>Next line</p> alert(&#39;I am evil!&#39;)"""
-            """<img src="/logo.png"><div>A div</div><span>Opened, but never closed</span>"""
+            """<img src="/logo.png"><div>A div</div>"""
+            """<div>    Another div    <span>Opened span, but never closed</span></div>"""
         )
         self.assertEqual((escaped_value, None), res)

--- a/tests/bones/test_text_bone.py
+++ b/tests/bones/test_text_bone.py
@@ -1,0 +1,104 @@
+import unittest
+
+import mock
+
+
+class TestTextBone_fromClient(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        from main import monkey_patch
+        monkey_patch()
+        from viur.core import conf
+        conf.main_app = mock.MagicMock()
+        conf.main_app.vi = None
+        cls.bone_name = "myTextBone"
+
+    def test_fromClient_single(self):
+        from viur.core.bones import TextBone
+        from viur.core.bones.base import ReadFromClientError
+        bone = TextBone()
+        skel = {}
+        data = {self.bone_name: "foo"}
+        self.assertIsNone(bone.fromClient(skel, self.bone_name, data))
+        self.assertIn(self.bone_name, skel)
+        self.assertEqual(data[self.bone_name], skel[self.bone_name])
+        # invalid data
+        data = {self.bone_name: None}
+        self.assertIsInstance(res := bone.fromClient(skel, self.bone_name, data), list)
+        self.assertTrue(res)  # list not empty
+        self.assertIsInstance(res[0], ReadFromClientError)
+
+    def test_fromClient_multi(self):
+        from viur.core.bones import TextBone
+        bone = TextBone(multiple=True)
+        skel = {}
+        data = {self.bone_name: ["foo", "bar"]}
+        self.assertIsNone(bone.fromClient(skel, self.bone_name, data))
+        self.assertIn(self.bone_name, skel)
+        self.assertListEqual(data[self.bone_name], skel[self.bone_name])
+
+    def test_fromClient_lang(self):
+        from viur.core.bones import TextBone
+        bone = TextBone(languages=["en", "de"])
+        skel = {}
+        lang = "de"
+        data = {f"{self.bone_name}.{lang}": "foo"}
+        self.assertIsNone(bone.fromClient(skel, self.bone_name, data))
+        self.assertIn(self.bone_name, skel)
+        self.assertIn(lang, skel[self.bone_name])
+        self.assertIn("en", skel[self.bone_name])
+        self.assertIsNone(skel[self.bone_name]["en"])
+        self.assertNotIn("fr", skel[self.bone_name])
+        self.assertEqual("foo", skel[self.bone_name][lang])
+
+    def test_fromClient_multi_lang(self):
+        from viur.core.bones import TextBone
+        bone = TextBone(multiple=True, languages=["en", "de"])
+        skel = {}
+        lang = "de"
+        data = {f"{self.bone_name}.{lang}": ["foo", "bar"]}
+        self.assertIsNone(bone.fromClient(skel, self.bone_name, data))
+        self.assertIn(self.bone_name, skel)
+        self.assertIn(lang, skel[self.bone_name])
+        self.assertEqual(["foo", "bar"], skel[self.bone_name][lang])
+        self.assertIn("en", skel[self.bone_name])
+        self.assertListEqual([], skel[self.bone_name]["en"])
+        self.assertNotIn("fr", skel[self.bone_name])
+
+    def test_singleValueFromClient(self):
+        from viur.core.bones import TextBone
+        from viur.core.bones import ReadFromClientError
+        from viur.core.bones import ReadFromClientErrorSeverity
+        bone = TextBone()
+        skel = {}
+        res = bone.singleValueFromClient("Foo", skel, self.bone_name, None)
+        self.assertEqual(("Foo", None), res)
+        res = bone.singleValueFromClient("", skel, self.bone_name, None)
+        self.assertEqual(("", None), res)
+        res = bone.singleValueFromClient(None, skel, self.bone_name, None)
+        # self.assertEqual(("", None), res)
+        self.assertIsInstance(res[1], list)
+        self.assertTrue(res[1])  # list is not empty (hopefully contains a ReadFromClientError)
+        self.assertIsInstance(rfce := res[1][0], ReadFromClientError)
+        self.assertIs(ReadFromClientErrorSeverity.Invalid, rfce.severity)
+
+    def test_html_parsing(self):
+        from viur.core.bones import TextBone
+        bone = TextBone()
+        skel = {}
+
+        client_value = \
+            """<h1>Headline</h1>
+            <p>This is a&nbsp;paragraph<br>
+            Next line</p>
+            <script>alert('I am evil!')</script>
+            <img onload="alert('I am evil!')" src="/logo.png">
+            <div>A div</div>
+            <span>Opened, but never closed
+            """
+        res = bone.singleValueFromClient(client_value, skel, self.bone_name, None)
+        escaped_value = (
+            """<h1>Headline</h1><p>This is a&nbsp;paragraph<br>Next line</p> alert(&#39;I am evil!&#39;)"""
+            """<img src="/logo.png"><div>A div</div><span>Opened, but never closed</span>"""
+        )
+        self.assertEqual((escaped_value, None), res)


### PR DESCRIPTION
With the default option `convert_charrefs=True` the serializer replace HTML entities to Unicode (like `&nbsp;` to `\u00a0`). This PR disables this option.

Furthermore it adds some tests (which are adapted from `StringBone`).

fixes #1182