### PR TITLE
fix: `default_order` and `query.queries` can be a list

### DIFF
--- a/src/viur/core/modules/moduleconf.py
+++ b/src/viur/core/modules/moduleconf.py
@@ -106,6 +106,7 @@ class ModuleConf(List):
     MODULES = set()  # will be filled by read_all_modules
     kindName = MODULECONF_KINDNAME
     accessRights = ["edit"]
+    default_order = None  # disable default ordering for ModuleConf
 
     def adminInfo(self):
         return conf.moduleconf_admin_info or {}

--- a/src/viur/core/prototypes/list.py
+++ b/src/viur/core/prototypes/list.py
@@ -194,7 +194,7 @@ class List(SkelModule):
         """
         # The general access control is made via self.listFilter()
         query = self.listFilter(self.viewSkel().all().mergeExternalFilter(kwargs))
-        if query and query.queries:
+        if query and query.queries and not isinstance(query.queries, list):
             # Apply default order when specified
             if self.default_order and not query.queries.orders and not current.request.get().kwargs.get("search"):
                 # TODO: refactor: Duplicate code in prototypes.Tree

--- a/src/viur/core/prototypes/tree.py
+++ b/src/viur/core/prototypes/tree.py
@@ -293,7 +293,7 @@ class Tree(SkelModule):
 
         # The general access control is made via self.listFilter()
         query = self.listFilter(self.viewSkel(skelType).all().mergeExternalFilter(kwargs))
-        if query and query.queries:
+        if query and query.queries and not isinstance(query.queries, list):
             # Apply default order when specified
             if self.default_order and not query.queries.orders and not current.request.get().kwargs.get("search"):
                 # TODO: refactor: Duplicate code in prototypes.List


### PR DESCRIPTION
Hotfix for a special error that occured with the ModuleConf-module when the authenticated user is NOT root, viur-core failed with error 500.

The data formats used by viur-datastore are a heavy mess and must be clarified asap.