### PR TITLE
fix: render structure on first list (improvement of #774)

### DIFF
--- a/src/viur/core/config.py
+++ b/src/viur/core/config.py
@@ -646,7 +646,7 @@ class Conf(ConfigType):
     compatibility: Multiple[str] = [
         "json.bone.structure.camelcasenames",  # use camelCase attribute names (see #637 for details)
         "json.bone.structure.keytuples",  # use classic structure notation: `"structure = [["key", {...}] ...]` (#649)
-        "json.bone.structure.inlists",  # dump skeleton structure with every JSON list response (#774 for details)
+        "json.bone.structure.inlists",  # dump skeleton structure with every JSON list response (details: #774 & #1189)
     ]
     """Backward compatibility flags; Remove to enforce new layout."""
 

--- a/src/viur/core/render/json/default.py
+++ b/src/viur/core/render/json/default.py
@@ -189,7 +189,12 @@ class DefaultRender(object):
 
         if skellist:
             if isinstance(skellist[0], SkeletonInstance):
-                if "json.bone.structure.inlists" in conf.compatibility:
+                if (
+                        # either when no cursor was provided (first list request)
+                        not current.request.get().kwargs.get("cursor")
+                        # or when old compatibility mode is still active
+                        or "json.bone.structure.inlists" in conf.compatibility
+                ):
                     structure = DefaultRender.render_structure(skellist[0].structure())
 
                 cursor = skellist.getCursor()


### PR DESCRIPTION
This improves #774, and renders the structure on calls without cursor, so legacy systems can work better with it and still use the feature.