### PR TITLE
feat: Add `check_for_changes` and `serialize`

### DIFF
--- a/src/viur/core/prototypes/list.py
+++ b/src/viur/core/prototypes/list.py
@@ -1,3 +1,4 @@
+import copy
 import logging
 import typing as t
 from viur.core import current, db, errors, utils
@@ -247,10 +248,11 @@ class List(SkelModule):
             :raises: :exc:`viur.core.errors.Unauthorized`, if the current user does not have the required permissions.
             :raises: :exc:`viur.core.errors.PreconditionFailed`, if the *skey* could not be verified.
         """
+
         skel = self.editSkel()
         if not skel.fromDB(key):
             raise errors.NotFound()
-
+        old_db_entity = copy.copy(skel.dbEntity)
         if not self.canEdit(skel):
             raise errors.Unauthorized()
 
@@ -264,7 +266,8 @@ class List(SkelModule):
             return self.render.edit(skel)
 
         self.onEdit(skel)
-        skel.toDB()  # write it!
+        if super().check_for_changes(skel, old_db_entity):
+            skel.toDB()
         self.onEdited(skel)
 
         return self.render.editSuccess(skel)

--- a/src/viur/core/prototypes/singleton.py
+++ b/src/viur/core/prototypes/singleton.py
@@ -1,3 +1,4 @@
+import copy
 import logging
 import typing as t
 from viur.core import db, current, utils, errors
@@ -141,7 +142,7 @@ class Singleton(SkelModule):
         skel = self.editSkel()
         if not skel.fromDB(key):  # Its not there yet; we need to set the key again
             skel["key"] = key
-
+        old_db_entity = copy.copy(skel.dbEntity)
         if (
             not kwargs  # no data supplied
             or not current.request.get().isPostRequest  # failure if not using POST-method
@@ -151,6 +152,8 @@ class Singleton(SkelModule):
             return self.render.edit(skel)
 
         self.onEdit(skel)
+        if super().check_for_changes(skel, old_db_entity):
+            skel.toDB()
         skel.toDB()
         self.onEdited(skel)
         return self.render.editSuccess(skel)

--- a/src/viur/core/prototypes/skelmodule.py
+++ b/src/viur/core/prototypes/skelmodule.py
@@ -62,3 +62,15 @@ class SkelModule(Module):
         By default, baseSkel is used by :func:`~viewSkel`, :func:`~addSkel`, and :func:`~editSkel`.
         """
         return self._resolveSkelCls(*args, **kwargs)()
+
+    @classmethod
+    def check_for_changes(cls, skel: SkeletonInstance, old_db_entity: db.Entity) -> bool:
+        """
+        :param skel: SkeletonInstance for the check
+        :param old_db_entity: Old db.Entity that are now in the Datastore
+        """
+        skel.serialize()
+        for key, val in skel.dbEntity.items():
+            if old_db_entity[key] != val and key != "changedate":
+                return True
+        return False

--- a/src/viur/core/prototypes/tree.py
+++ b/src/viur/core/prototypes/tree.py
@@ -1,3 +1,4 @@
+import copy
 import logging
 import typing as t
 from viur.core import utils, errors, db, current
@@ -454,7 +455,7 @@ class Tree(SkelModule):
         skel = self.editSkel(skelType)
         if not skel.fromDB(key):
             raise errors.NotFound()
-
+        old_db_entity = copy.copy(skel.dbEntity)
         if not self.canEdit(skelType, skel):
             raise errors.Unauthorized()
 
@@ -467,7 +468,8 @@ class Tree(SkelModule):
             return self.render.edit(skel)
 
         self.onEdit(skelType, skel)
-        skel.toDB()
+        if super().check_for_changes(skel,old_db_entity):
+            skel.toDB()
         self.onEdited(skelType, skel)
 
         return self.render.editSuccess(skel)

--- a/src/viur/core/prototypes/tree.py
+++ b/src/viur/core/prototypes/tree.py
@@ -468,7 +468,7 @@ class Tree(SkelModule):
             return self.render.edit(skel)
 
         self.onEdit(skelType, skel)
-        if super().check_for_changes(skel,old_db_entity):
+        if super().check_for_changes(skel, old_db_entity):
             skel.toDB()
         self.onEdited(skelType, skel)
 


### PR DESCRIPTION
This PR introduces the methods `serialize` and `check_for_changes`.
The `serialize`  method is responsible for serializing all bones in a skeleton. Method `check_for_changes` can be used to check whether data that is written to the datastore has changed. This is used to avoid unnecessary write operations 