### PR TITLE
feat: Render `SelectBone` values in dict-style

### DIFF
--- a/src/viur/core/bones/select.py
+++ b/src/viur/core/bones/select.py
@@ -138,5 +138,5 @@ class SelectBone(BaseBone):
 
     def structure(self) -> dict:
         return super().structure() | {
-            "values": [(k, str(v)) for k, v in self.values.items()],
+            "values": {k: str(v) for k, v in self.values.items()},
         }

--- a/src/viur/core/bones/select.py
+++ b/src/viur/core/bones/select.py
@@ -2,7 +2,7 @@ import enum
 import typing as t
 from collections import OrderedDict
 from numbers import Number
-
+from viur.core.config import conf
 from viur.core.bones.base import BaseBone, ReadFromClientError, ReadFromClientErrorSeverity
 from viur.core.i18n import translate
 
@@ -138,5 +138,8 @@ class SelectBone(BaseBone):
 
     def structure(self) -> dict:
         return super().structure() | {
-            "values": {k: str(v) for k, v in self.values.items()},
+            "values":
+                {k: str(v) for k, v in self.values.items()}  # new-style dict
+                if "bone.select.structure.values.keytuple" not in conf.compatibility
+                else [(k, str(v)) for k, v in self.values.items()]  # old-style key-tuple
         }

--- a/src/viur/core/config.py
+++ b/src/viur/core/config.py
@@ -649,12 +649,14 @@ class Conf(ConfigType):
     """If set, this function will be called for each cache-attempt
     and the result will be included in the computed cache-key"""
 
+    # FIXME VIUR4: REMOVE ALL COMPATIBILITY MODES!
     compatibility: Multiple[str] = [
         "json.bone.structure.camelcasenames",  # use camelCase attribute names (see #637 for details)
         "json.bone.structure.keytuples",  # use classic structure notation: `"structure = [["key", {...}] ...]` (#649)
         "json.bone.structure.inlists",  # dump skeleton structure with every JSON list response (#774 for details)
+        "bone.select.structure.values.keytuple",  # render old-style tuple-list in SelectBone's values structure (#1203)
     ]
-    """Backward compatibility flags; Remove to enforce new layout."""
+    """Backward compatibility flags; Remove to enforce new style."""
 
     db_engine: str = "viur.datastore"
     """Database engine module"""


### PR DESCRIPTION
This change should be considered and relates closely to viur-framework/vi-vue-utils#12.

To enable new style, add
```py
conf.compatibility.remove("bone.select.structure.values.keytuple")
```
to your main.py.
