### PR TITLE
fix: `Session.__delitem__` causes endless recursion

### DIFF
--- a/src/viur/core/session.py
+++ b/src/viur/core/session.py
@@ -171,7 +171,7 @@ class Session(db.Entity):
             Removes a *key* from the session.
             This key must exist.
         """
-        del self[key]
+        super().__delitem__(key)
         self.changed = True
 
     def __ior__(self, other: dict) -> t.Self:


### PR DESCRIPTION
Fixes an endless recursion, this part of the new session was not tested before.