### PR TITLE
fix: `RecordBone.getReferencedBlobs` should collect references for all bones

### DIFF
--- a/src/viur/core/bones/record.py
+++ b/src/viur/core/bones/record.py
@@ -1,5 +1,10 @@
 import json
+import typing as t
+
 from viur.core.bones.base import BaseBone, ReadFromClientError, ReadFromClientErrorSeverity
+
+if t.TYPE_CHECKING:
+    from ..skeleton import SkeletonInstance
 
 
 class RecordBone(BaseBone):
@@ -144,14 +149,13 @@ class RecordBone(BaseBone):
 
         return res
 
-    def getReferencedBlobs(self, skel: 'viur.core.skeleton.SkeletonInstance', name: str) -> set[str]:
+    def getReferencedBlobs(self, skel: "SkeletonInstance", name: str) -> set[str]:
         """
         Retrieves a set of referenced blobs for the given skeleton instance and name.
 
-        :param SkeletonInstance skel: The skeleton instance to process.
-        :param str name: The name of the bone to process.
+        :param skel: The skeleton instance to process.
+        :param name: The name of the bone to process.
         :return: A set of referenced blobs.
-        :rtype: set[str]
         """
         result = set()
 
@@ -160,10 +164,7 @@ class RecordBone(BaseBone):
             if value is None:
                 continue
             for key, bone in using_skel_cache.items():
-                if not bone.searchable:
-                    continue
-                for tag in bone.getReferencedBlobs(value, key):
-                    result.add(tag)
+                result |= bone.getReferencedBlobs(value, key)
 
         return result
 


### PR DESCRIPTION
The `if not bone.searchable` condition introduced in #528 due to refactorings was too much.

Without this fix, weak files are not locked and will be deleted.

Fixes #1211 


