### PR TITLE
feat-fix: Wrap `descr` and `params.category` in `translate` object for auto translating

### DIFF
--- a/src/viur/core/bones/base.py
+++ b/src/viur/core/bones/base.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from enum import Enum
 import typing as t
-from viur.core import db, utils
+from viur.core import db, utils, i18n
 from viur.core.config import conf
 
 if t.TYPE_CHECKING:
@@ -201,7 +201,7 @@ class BaseBone(object):
         *,
         compute: Compute = None,
         defaultValue: t.Any = None,
-        descr: str = "",
+        descr: str | i18n.translate = "",
         getEmptyValueFunc: callable = None,
         indexed: bool = True,
         isEmptyFunc: callable = None,  # fixme: Rename this, see below.
@@ -220,6 +220,9 @@ class BaseBone(object):
         """
         self.isClonedInstance = getSystemInitialized()
 
+        if isinstance(descr, str):
+            descr = i18n.translate(descr, hint=f"descr of a <{type(self).__name__}>")
+
         # Standard definitions
         self.descr = descr
         self.params = params or {}
@@ -229,6 +232,9 @@ class BaseBone(object):
         self.searchable = searchable
         self.visible = visible
         self.indexed = indexed
+
+        if isinstance(category := self.params.get("category"), str):
+            self.params["category"] = i18n.translate(category, hint=f"category of a <{type(self).__name__}>")
 
         # Multi-language support
         if not (


### PR DESCRIPTION
I wondered why my bone descr aren't translated at the json renderer. The `translate` object was actually never created. It would work if I create it manually and pass it at `descr` argument, but this is not matching to the type hint. This PR fix these issues.

For reference, there are some notes which could expect a translate object:
https://github.com/viur-framework/viur-core/blob/104ac87cd92655a7aa084e182c7501dc42a5dcab/src/viur/core/bones/base.py#L168
https://github.com/viur-framework/viur-core/blob/104ac87cd92655a7aa084e182c7501dc42a5dcab/src/viur/core/bones/base.py#L1272

