### PR TITLE
fix: `MultipleConstraints` as intended

### DIFF
--- a/src/viur/core/bones/base.py
+++ b/src/viur/core/bones/base.py
@@ -128,17 +128,17 @@ class UniqueValue:  # Mark a bone as unique (it must have a different value for 
 
 
 @dataclass
-class MultipleConstraints:  # Used to define constraints on multiple bones
+class MultipleConstraints:
     """
     The MultipleConstraints class is used to define constraints on multiple bones, such as the minimum
-    and maximum number of entries allowed and whether duplicate values are allowed.
+    and maximum number of entries allowed and whether value duplicates are allowed.
     """
-    min: int = 0  # Lower bound of how many entries can be submitted
+    min: int = 0
     """An integer representing the lower bound of how many entries can be submitted (default: 0)."""
-    max: int = 0  # Upper bound of how many entries can be submitted
-    """An integer representing the upper bound of how many entries can be submitted (default: 0)."""
-    duplicates: bool = True  # Prevent the same value of being used twice
-    """A boolean value indicating if the same value can be used twice (default: True)."""
+    max: int = 0
+    """An integer representing the upper bound of how many entries can be submitted (default: 0 = unlimited)."""
+    duplicates: bool = False
+    """A boolean indicating if the same value can be used multiple times (default: False)."""
 
 
 class ComputeMethod(Enum):

--- a/src/viur/core/bones/base.py
+++ b/src/viur/core/bones/base.py
@@ -628,11 +628,17 @@ class BaseBone(object):
 
         return value
 
-    def _validate_multiple_contraints(self, constraints: MultipleConstraints, skel: 'SkeletonInstance', name: str) -> list[ReadFromClientError]:
+    def _validate_multiple_contraints(
+        self,
+        constraints: MultipleConstraints,
+        skel: 'SkeletonInstance',
+        name: str
+    ) -> list[ReadFromClientError]:
         """
         Validates the value of a bone against its multiple constraints and returns a list of ReadFromClientError
         objects for each violation, such as too many items or duplicates.
 
+        :param constraints: The MultipleConstraints definition to apply.
         :param skel: A SkeletonInstance object where the values should be validated.
         :param name: A string representing the bone's name.
         :return: A list of ReadFromClientError objects for each constraint violation.

--- a/src/viur/core/bones/record.py
+++ b/src/viur/core/bones/record.py
@@ -85,6 +85,9 @@ class RecordBone(BaseBone):
 
         return value.serialize(parentIndexed=False)
 
+    def _get_single_destinct_hash(self, value):
+        return tuple(bone._get_destinct_hash(value[name]) for name, bone in self.using.__boneMap__.items())
+
     def parseSubfieldsFromClient(self) -> bool:
         """
         Determines if the current request should attempt to parse subfields received from the client.

--- a/src/viur/core/bones/relational.py
+++ b/src/viur/core/bones/relational.py
@@ -508,8 +508,14 @@ class RelationalBone(BaseBone):
 
         return True
 
-    def _get_destinct_hash(self, value):
-        return value["dest"]["key"]
+    def _get_single_destinct_hash(self, value):
+        parts = [value["dest"]["key"]]
+
+        if self.using:
+            for name, bone in self.using.__boneMap__.items():
+                parts.append(bone._get_destinct_hash(value["rel"][name]))
+
+        return tuple(parts)
 
     def delete(self, skel: 'viur.core.skeleton.SkeletonInstance', name: str):
         """

--- a/src/viur/core/bones/relational.py
+++ b/src/viur/core/bones/relational.py
@@ -508,6 +508,9 @@ class RelationalBone(BaseBone):
 
         return True
 
+    def _get_destinct_hash(self, value):
+        return value["dest"]["key"]
+
     def delete(self, skel: 'viur.core.skeleton.SkeletonInstance', name: str):
         """
         Clear any outgoing relational locks when deleting a skeleton.


### PR DESCRIPTION
Fixes `MultipleConstraints`
    
- requirement for a hashed tuple
- renamed dataclass members*
- required modularization for `RelationalBone` and `RecordBone`
    
*) yes, this is a breaking change, BUT this feature isn't used in any ViUR project so far, I'm sure.
