### PR TITLE
fix: Cleanly collect renders from Python module

### DIFF
--- a/src/viur/core/__init__.py
+++ b/src/viur/core/__init__.py
@@ -131,14 +131,25 @@ def buildApp(modules: ModuleType | object, renderers: ModuleType | object, defau
     """
     if not isinstance(renderers, dict):
         # build up the dict from viur.core.render
-        renderers, renderers_root = {}, renderers
-        for key, module in vars(renderers_root).items():
-            if "__" not in key:
-                renderers[key] = {}
-                for subkey, render in vars(module).items():
-                    if "__" not in subkey:
-                        renderers[key][subkey] = render
-        del renderers_root
+        renderers, mod = {}, renderers
+
+        from viur.core.render.abstract import AbstractRenderer
+
+        for render_name, render_mod in vars(mod).items():
+            if inspect.ismodule(render_mod):
+                for render_clsname, render_cls in vars(render_mod).items():
+                    # this is "kinda hackish..." because ViUR 3's current renderer concept is pure bulls*t...
+                    if render_clsname == "DefaultRender":
+                        continue
+
+                    if (
+                            # test for a renderer
+                            (inspect.isclass(render_cls) and issubclass(render_cls, AbstractRenderer))
+                            # bullsh*t, this must be entirely reworked!
+                            or render_clsname == "_postProcessAppObj"
+                    ):
+                        renderers.setdefault(render_name, {})
+                        renderers[render_name][render_clsname] = render_cls
 
     # instanciate root module
     if hasattr(modules, "index"):


### PR DESCRIPTION
This is still a hack, but it doesn't map any declared symbols like jinja global functions or imported stuff into the renderers-map as before.