### PR TITLE
refactor: Move datastore index retrieval to `SkelModule`

### DIFF
--- a/src/viur/core/__init__.py
+++ b/src/viur/core/__init__.py
@@ -18,7 +18,6 @@ import warnings
 from types import ModuleType
 import typing as t
 from google.appengine.api import wrap_wsgi_app
-import yaml
 
 from viur.core import i18n, request, utils
 from viur.core.config import conf
@@ -65,27 +64,6 @@ __all__ = [
 
 # Show DeprecationWarning from the viur-core
 warnings.filterwarnings("always", category=DeprecationWarning, module=r"viur\.core.*")
-
-
-def load_indexes_from_file() -> dict[str, list]:
-    """
-        Loads all indexes from the index.yaml and stores it in a dictionary  sorted by the module(kind)
-        :return A dictionary of indexes per module
-    """
-    indexes_dict = {}
-    try:
-        with open(os.path.join(conf.instance.project_base_path, "index.yaml"), "r") as file:
-            indexes = yaml.safe_load(file)
-            indexes = indexes.get("indexes", [])
-            for index in indexes:
-                index["properties"] = [_property["name"] for _property in index["properties"]]
-                indexes_dict.setdefault(index["kind"], []).append(index)
-
-    except FileNotFoundError:
-        logging.warning("index.yaml not found")
-        return {}
-
-    return indexes_dict
 
 
 def setDefaultLanguage(lang: str):
@@ -158,7 +136,6 @@ def buildApp(modules: ModuleType | object, renderers: ModuleType | object, defau
     modules.script = Script
 
     # create module mappings
-    indexes = load_indexes_from_file()  # todo: datastore index retrieval should be done in SkelModule
     resolver = {}
 
     for module_name, module_cls in vars(modules).items():  # iterate over all modules
@@ -183,7 +160,6 @@ def buildApp(modules: ModuleType | object, renderers: ModuleType | object, defau
             module_instance = module_cls(
                 module_name, ("/" + render_name if render_name != default else "") + "/" + module_name
             )
-            module_instance.indexes = indexes.get(module_name, [])  # todo: Fix this in SkelModule (see above!)
 
             # Attach the module-specific or the default render
             if render_name == default:  # default or render (sub)namespace?

--- a/src/viur/core/prototypes/skelmodule.py
+++ b/src/viur/core/prototypes/skelmodule.py
@@ -1,4 +1,7 @@
+import os
+import yaml
 from viur.core import Module, db
+from viur.core.config import conf
 from viur.core.skeleton import skeletonByKind, Skeleton, SkeletonInstance
 import typing as t
 
@@ -19,6 +22,29 @@ Type for default sort order definitions.
 """
 
 
+def __load_indexes_from_file() -> dict[str, list]:
+    """
+        Loads all indexes from the index.yaml and stores it in a dictionary  sorted by the module(kind)
+        :return A dictionary of indexes per module
+    """
+    indexes_dict = {}
+    try:
+        with open(os.path.join(conf.instance.project_base_path, "index.yaml"), "r") as file:
+            indexes = yaml.safe_load(file)
+            indexes = indexes.get("indexes", [])
+            for index in indexes:
+                index["properties"] = [_property["name"] for _property in index["properties"]]
+                indexes_dict.setdefault(index["kind"], []).append(index)
+
+    except FileNotFoundError:
+        logging.warning("index.yaml not found")
+        return {}
+
+    return indexes_dict
+
+DATASTORE_INDEXES = __load_indexes_from_file()
+
+
 class SkelModule(Module):
     """
         This is the extended module prototype used by any other ViUR module prototype.
@@ -36,6 +62,16 @@ class SkelModule(Module):
         For more information, refer to the function :func:`~_resolveSkelCls`.
     """
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # automatically determine kindName when not set
+        if self.kindName is None:
+            self.kindName = str(type(self).__name__).lower()
+
+        # assign index descriptions from index.yaml
+        self.indexes = DATASTORE_INDEXES.get(self.kindName, [])
+
     def _resolveSkelCls(self, *args, **kwargs) -> t.Type[Skeleton]:
         """
         Retrieve the generally associated :class:`viur.core.skeleton.Skeleton` that is used by
@@ -50,7 +86,7 @@ class SkelModule(Module):
 
         :return: Returns a Skeleton class that matches the application.
         """
-        return skeletonByKind(self.kindName if self.kindName else str(type(self).__name__).lower())
+        return skeletonByKind(self.kindName)
 
     def baseSkel(self, *args, **kwargs) -> SkeletonInstance:
         """

--- a/src/viur/core/prototypes/skelmodule.py
+++ b/src/viur/core/prototypes/skelmodule.py
@@ -1,5 +1,6 @@
 import os
 import yaml
+import logging
 from viur.core import Module, db
 from viur.core.config import conf
 from viur.core.skeleton import skeletonByKind, Skeleton, SkeletonInstance

--- a/src/viur/core/prototypes/skelmodule.py
+++ b/src/viur/core/prototypes/skelmodule.py
@@ -43,6 +43,7 @@ def __load_indexes_from_file() -> dict[str, list]:
 
     return indexes_dict
 
+
 DATASTORE_INDEXES = __load_indexes_from_file()
 
 


### PR DESCRIPTION
This is also a better implementation, as the previous checked for module name, but the kind name is the important one!