### PR TITLE
fix: Inconsistency raises AssertionError

### DIFF
--- a/src/viur/core/skeleton.py
+++ b/src/viur/core/skeleton.py
@@ -1408,9 +1408,13 @@ def processRemovedRelations(removedKey, cursor=None):
         .filter("viur_relational_consistency >", 2)
     updateListQuery = updateListQuery.setCursor(cursor)
     updateList = updateListQuery.run(limit=5)
+
     for entry in updateList:
         skel = skeletonByKind(entry["viur_src_kind"])()
-        assert skel.fromDB(entry["src"].key)
+        if not skel.fromDB(entry["src"].key):
+            logging.error(f"processRemovedRelations detects inconsistency on src={entry['src'].key!r}")
+            raise ValueError()
+
         if entry["viur_relational_consistency"] == 3:  # Set Null
             for key, _bone in skel.items():
                 if isinstance(_bone, RelationalBone):
@@ -1424,10 +1428,11 @@ def processRemovedRelations(removedKey, cursor=None):
                     else:
                         raise NotImplementedError(f"No handling for {type(relVal)=}")
             skel.toDB(update_relations=False)
+
         else:
             logging.critical(f"""Cascade deletion of {skel["key"]!r}""")
             skel.delete()
-            pass
+
     if len(updateList) == 5:
         processRemovedRelations(removedKey, updateListQuery.getCursor())
 

--- a/src/viur/core/skeleton.py
+++ b/src/viur/core/skeleton.py
@@ -1412,8 +1412,7 @@ def processRemovedRelations(removedKey, cursor=None):
     for entry in updateList:
         skel = skeletonByKind(entry["viur_src_kind"])()
         if not skel.fromDB(entry["src"].key):
-            logging.error(f"processRemovedRelations detects inconsistency on src={entry['src'].key!r}")
-            raise ValueError()
+            raise ValueError(f"processRemovedRelations detects inconsistency on src={entry['src'].key!r}")
 
         if entry["viur_relational_consistency"] == 3:  # Set Null
             for key, _bone in skel.items():


### PR DESCRIPTION
This change is for better debugging, but the process might still hang.

I'm quite unsure if this thing should better be ignored, or if `entry` itself should be removed, as it is an inconsistency.