### PR TITLE
fix: null-key always written into `viur-relations`

### DIFF
--- a/src/viur/core/bones/relational.py
+++ b/src/viur/core/bones/relational.py
@@ -562,6 +562,8 @@ class RelationalBone(BaseBone):
         srcEntity = skel.dbEntity
         parentValues.key = srcEntity.key
         for boneKey in (self.parentKeys or []):
+            if boneKey == "key":  # this is a relcit from viur2, as the key is encoded in the embedded entity
+                continue
             parentValues[boneKey] = srcEntity.get(boneKey)
         dbVals = db.Query("viur-relations")
         dbVals.filter("viur_src_kind =", skel.kindName)


### PR DESCRIPTION
Don't write the "key" value, which is always None, into the src-property of `viur-relations`. The key is encoded into the embedded Entity and used this way everywhere, respective using `src.__key__` in queries.

This is only a minor bug, as it didn't influence that viur works properly, but it was annoying during debug.

Relates to #1236 + #1237 