### PR TITLE
feat: Improve `CaptchaBone`

### DIFF
--- a/src/viur/core/bones/captcha.py
+++ b/src/viur/core/bones/captcha.py
@@ -1,10 +1,14 @@
-import json
-import urllib.parse
-import urllib.request
+import logging
 import typing as t
+
+import requests
 
 from viur.core import conf, current
 from viur.core.bones.base import BaseBone, ReadFromClientError, ReadFromClientErrorSeverity
+from viur.shop.types.price import logger
+
+if t.TYPE_CHECKING:
+    from viur.core.skeleton import SkeletonInstance
 
 
 class CaptchaBone(BaseBone):
@@ -12,18 +16,36 @@ class CaptchaBone(BaseBone):
     The CaptchaBone is used to ensure that a user is not a bot.
 
     The Captcha bone uses the Google reCAPTCHA API to perform the Captcha
-    validation and is derived from the BaseBone.
-
-    :param publicKey: The public key for the Captcha validation.
-    :param privateKey: The private key for the Captcha validation.
-    :param \**kwargs: Additional arguments to pass to the base class constructor.
+    validation and supports v2 and v3.
     """
+
     type = "captcha"
 
-    def __init__(self, *, publicKey=None, privateKey=None, **kwargs):
+    def __init__(
+        self,
+        *,
+        publicKey: str = None,
+        privateKey: str = None,
+        score_threshold: float = 0.5,
+        **kwargs: t.Any
+    ):
+        """
+        Initializes a new CaptchaBone.
+
+        publicKey and privateKey can be omitted, if they are set globally
+        in :attr:`conf.security.captcha_default_credentials`.
+
+        :param publicKey: The public key for the Captcha validation.
+        :param privateKey: The private key for the Captcha validation.
+        :score_threshold: If reCAPTCHA v3 is used, the score must be at least this threshold.
+            For reCAPTCHA v2 this property will be ignored.
+        """
         super().__init__(**kwargs)
         self.defaultValue = self.publicKey = publicKey
         self.privateKey = privateKey
+        if not (0 < score_threshold <= 1):
+            raise ValueError("score_threshold must be between 0 and 1.")
+        self.score_threshold = score_threshold
         if not self.defaultValue and not self.privateKey:
             # Merge these values from the side-wide configuration if set
             if conf.security.captcha_default_credentials:
@@ -31,52 +53,59 @@ class CaptchaBone(BaseBone):
                 self.privateKey = conf.security.captcha_default_credentials["secret"]
         self.required = True
 
-    def serialize(self, skel: 'SkeletonInstance', name: str, parentIndexed: bool) -> bool:
+    def serialize(self, skel: "SkeletonInstance", name: str, parentIndexed: bool) -> bool:
         """
         Serializing the Captcha bone is not possible so it return False
         """
         return False
 
-    def unserialize(self, skel, name) -> bool:
+    def unserialize(self, skel: "SkeletonInstance", name) -> t.Literal[True]:
         """
-        Unserialize the Captcha bone.
+        Stores the publicKey in the SkeletonInstance
 
-        :param skel: The SkeletonInstance containing the Captcha bone.
-        :param name: The name of the Captcha bone.
+        :param skel: The target SkeletonInstance.
+        :param name: The name of the CaptchaBone in the SkeletonInstance.
 
         :returns: boolean, that is true, as the Captcha bone is always unserialized successfully.
         """
         skel.accessedValues[name] = self.publicKey
         return True
 
-    def fromClient(self, skel: 'SkeletonInstance', name: str, data: dict) -> None | list[ReadFromClientError]:
-        """
-            Reads a value from the client.
-            If this value is valid for this bone,
-            store this value and return None.
-            Otherwise our previous value is
-            left unchanged and an error-message
-            is returned.
-
-            :param name: Our name in the skeleton
-            :param data: *User-supplied* request-data
-            :returns: None or a list of errors
-        """
+    def fromClient(self, skel: "SkeletonInstance", name: str, data: dict) -> None | list[ReadFromClientError]:
         if conf.instance.is_dev_server:  # We dont enforce captchas on dev server
             return None
         if (user := current.user.get()) and "root" in user["access"]:
-            return None  # Don't bother trusted users with this (not supported by admin/vi anyways)
-        if not "g-recaptcha-response" in data:
+            return None  # Don't bother trusted users with this (not supported by admin/vi anyway)
+        if "g-recaptcha-response" not in data:
             return [ReadFromClientError(ReadFromClientErrorSeverity.NotSet, "No Captcha given!")]
-        data = {
-            "secret": self.privateKey,
-            "remoteip": current.request.get().request.remote_addr,
-            "response": data["g-recaptcha-response"]
-        }
-        req = urllib.request.Request(url="https://www.google.com/recaptcha/api/siteverify",
-                                     data=urllib.parse.urlencode(data).encode(),
-                                     method="POST")
-        response = urllib.request.urlopen(req)
-        if json.loads(response.read()).get("success"):
-            return None
-        return [ReadFromClientError(ReadFromClientErrorSeverity.Invalid, "Invalid Captcha")]
+
+        result = requests.post(
+            url="https://www.google.com/recaptcha/api/siteverify",
+            data={
+                "secret": self.privateKey,
+                "remoteip": current.request.get().request.remote_addr,
+                "response": data["g-recaptcha-response"],
+            },
+            timeout=10,
+        )
+        if not result.ok:
+            logging.error(f"{result.status_code} {result.reason}: {result.text}")
+            raise ValueError(f"Request to reCAPTCHA failed: {result.status_code} {result.reason}")
+        data = result.json()
+        logging.debug(f"Captcha verification {data=}")
+
+        if not data.get("success"):
+            logger.error(data.get("error-codes"))
+            return [ReadFromClientError(
+                ReadFromClientErrorSeverity.Invalid,
+                f'Invalid Captcha: {", ".join(data.get("error-codes", []))}'
+            )]
+
+        if "score" in data and data["score"] < self.score_threshold:
+            # it's reCAPTCHA v3; check the score
+            return [ReadFromClientError(
+                ReadFromClientErrorSeverity.Invalid,
+                f'Invalid Captcha: {data["score"]} is lower than threshold {self.score_threshold}'
+            )]
+
+        return None  # okay

--- a/src/viur/core/bones/captcha.py
+++ b/src/viur/core/bones/captcha.py
@@ -5,7 +5,6 @@ import requests
 
 from viur.core import conf, current
 from viur.core.bones.base import BaseBone, ReadFromClientError, ReadFromClientErrorSeverity
-from viur.shop.types.price import logger
 
 if t.TYPE_CHECKING:
     from viur.core.skeleton import SkeletonInstance
@@ -103,7 +102,7 @@ class CaptchaBone(BaseBone):
         logging.debug(f"Captcha verification {data=}")
 
         if not data.get("success"):
-            logger.error(data.get("error-codes"))
+            logging.error(data.get("error-codes"))
             return [ReadFromClientError(
                 ReadFromClientErrorSeverity.Invalid,
                 f'Invalid Captcha: {", ".join(data.get("error-codes", []))}'

--- a/src/viur/core/bones/captcha.py
+++ b/src/viur/core/bones/captcha.py
@@ -51,6 +51,8 @@ class CaptchaBone(BaseBone):
                 self.defaultValue = self.publicKey = conf.security.captcha_default_credentials["sitekey"]
                 self.privateKey = conf.security.captcha_default_credentials["secret"]
         self.required = True
+        if not self.privateKey:
+            raise ValueError("privateKey must be set.")
 
     def serialize(self, skel: "SkeletonInstance", name: str, parentIndexed: bool) -> bool:
         """
@@ -80,8 +82,10 @@ class CaptchaBone(BaseBone):
         While the latter one is the preferred name.
         """
         if conf.instance.is_dev_server:  # We dont enforce captchas on dev server
+            logging.info("Skipping captcha validation on development server")
             return None
         if (user := current.user.get()) and "root" in user["access"]:
+            logging.info("Skipping captcha validation for root user")
             return None  # Don't bother trusted users with this (not supported by admin/vi anyway)
         if name not in data and "g-recaptcha-response" not in data:
             return [ReadFromClientError(ReadFromClientErrorSeverity.NotSet, "No Captcha given!")]

--- a/src/viur/core/bones/captcha.py
+++ b/src/viur/core/bones/captcha.py
@@ -16,6 +16,14 @@ class CaptchaBone(BaseBone):
 
     The Captcha bone uses the Google reCAPTCHA API to perform the Captcha
     validation and supports v2 and v3.
+
+    .. seealso::
+
+        Option :attr:`core.config.Security.captcha_default_credentials`
+        for global security settings.
+
+        Option :attr:`core.config.Security.captcha_enforce_always`
+        for developing.
     """
 
     type = "captcha"
@@ -31,8 +39,8 @@ class CaptchaBone(BaseBone):
         """
         Initializes a new CaptchaBone.
 
-        publicKey and privateKey can be omitted, if they are set globally
-        in :attr:`conf.security.captcha_default_credentials`.
+        `publicKey` and `privateKey` can be omitted, if they are set globally
+        in :attr:`core.config.Security.captcha_default_credentials`.
 
         :param publicKey: The public key for the Captcha validation.
         :param privateKey: The private key for the Captcha validation.
@@ -64,8 +72,8 @@ class CaptchaBone(BaseBone):
         """
         Stores the publicKey in the SkeletonInstance
 
-        :param skel: The target SkeletonInstance.
-        :param name: The name of the CaptchaBone in the SkeletonInstance.
+        :param skel: The target :class:`SkeletonInstance`.
+        :param name: The name of the CaptchaBone in the :class:`SkeletonInstance`.
 
         :returns: boolean, that is true, as the Captcha bone is always unserialized successfully.
         """
@@ -81,10 +89,10 @@ class CaptchaBone(BaseBone):
         So the token can be provided as "g-recaptcha-response" or the name of the CaptchaBone in the Skeleton.
         While the latter one is the preferred name.
         """
-        if conf.instance.is_dev_server:  # We dont enforce captchas on dev server
+        if not conf.security.captcha_enforce_always and conf.instance.is_dev_server:
             logging.info("Skipping captcha validation on development server")
             return None
-        if (user := current.user.get()) and "root" in user["access"]:
+        if not conf.security.captcha_enforce_always and (user := current.user.get()) and "root" in user["access"]:
             logging.info("Skipping captcha validation for root user")
             return None  # Don't bother trusted users with this (not supported by admin/vi anyway)
         if name not in data and "g-recaptcha-response" not in data:

--- a/src/viur/core/bones/numeric.py
+++ b/src/viur/core/bones/numeric.py
@@ -120,30 +120,20 @@ class NumericBone(BaseBone):
 
     def singleValueFromClient(self, value, skel, bone_name, client_data):
         try:
-            logging.debug(f"singleValueFromClient {value=}")
             value = str(value).replace(",", ".", 1)
-            logging.debug(f"singleValueFromClient {value=}")
         except:
-            logging.debug(f"singleValueFromClient {value=}")
             return self.getEmptyValue(), [ReadFromClientError(ReadFromClientErrorSeverity.Invalid, "Invalid Value")]
         else:
-            logging.debug(f"singleValueFromClient {value=}")
             if self.precision and (str(value).replace(".", "", 1).replace("-", "", 1).isdigit()) and float(
                     value) >= self.min and float(value) <= self.max:
-                logging.debug(f"singleValueFromClient {value=}")
                 value = round(float(value), self.precision)
             elif not self.precision and (str(value).replace("-", "", 1).isdigit()) and int(
                     value) >= self.min and int(value) <= self.max:
-                logging.debug(f"singleValueFromClient {value=}")
                 value = int(value)
             else:
-                logging.debug(f"singleValueFromClient {value=}")
                 return self.getEmptyValue(), [ReadFromClientError(ReadFromClientErrorSeverity.Invalid, "Invalid Value")]
-        logging.debug(f"singleValueFromClient {value=}")
         err = self.isInvalid(value)
-        logging.debug(f"singleValueFromClient {value=} {err=}")
         if err:
-            logging.debug(f"singleValueFromClient {value=} {err=}")
             return self.getEmptyValue(), [ReadFromClientError(ReadFromClientErrorSeverity.Invalid, err)]
         return value, None
 

--- a/src/viur/core/bones/numeric.py
+++ b/src/viur/core/bones/numeric.py
@@ -120,20 +120,30 @@ class NumericBone(BaseBone):
 
     def singleValueFromClient(self, value, skel, bone_name, client_data):
         try:
+            logging.debug(f"singleValueFromClient {value=}")
             value = str(value).replace(",", ".", 1)
+            logging.debug(f"singleValueFromClient {value=}")
         except:
+            logging.debug(f"singleValueFromClient {value=}")
             return self.getEmptyValue(), [ReadFromClientError(ReadFromClientErrorSeverity.Invalid, "Invalid Value")]
         else:
+            logging.debug(f"singleValueFromClient {value=}")
             if self.precision and (str(value).replace(".", "", 1).replace("-", "", 1).isdigit()) and float(
                     value) >= self.min and float(value) <= self.max:
+                logging.debug(f"singleValueFromClient {value=}")
                 value = round(float(value), self.precision)
             elif not self.precision and (str(value).replace("-", "", 1).isdigit()) and int(
                     value) >= self.min and int(value) <= self.max:
+                logging.debug(f"singleValueFromClient {value=}")
                 value = int(value)
             else:
+                logging.debug(f"singleValueFromClient {value=}")
                 return self.getEmptyValue(), [ReadFromClientError(ReadFromClientErrorSeverity.Invalid, "Invalid Value")]
+        logging.debug(f"singleValueFromClient {value=}")
         err = self.isInvalid(value)
+        logging.debug(f"singleValueFromClient {value=} {err=}")
         if err:
+            logging.debug(f"singleValueFromClient {value=} {err=}")
             return self.getEmptyValue(), [ReadFromClientError(ReadFromClientErrorSeverity.Invalid, err)]
         return value, None
 

--- a/src/viur/core/config.py
+++ b/src/viur/core/config.py
@@ -395,8 +395,15 @@ class Security(ConfigType):
     """Unless set to logical none; ViUR will emit a X-Permitted-Cross-Domain-Policies with each request"""
 
     captcha_default_credentials: t.Optional[CaptchaDefaultCredentialsType] = None
-    """The default sitekey and secret to use for the CaptchaBone.
+    """The default sitekey and secret to use for the :class:`CaptchaBone`.
     If set, must be a dictionary of "sitekey" and "secret".
+    """
+
+    captcha_enforce_always: bool = False
+    """By default a captcha of the :class:`CaptchaBone` must not be solved on a local development server
+    or by a root user. But for development it can be helpful to test the implementation
+    on a local development server. Setting this flag to True, disables this behavior and
+    enforces always a valid captcha.
     """
 
     password_recovery_key_length: int = 42

--- a/src/viur/core/config.py
+++ b/src/viur/core/config.py
@@ -379,8 +379,7 @@ class Security(ConfigType):
     Use security.enableStrictTransportSecurity to set this property"""
 
     x_frame_options: t.Optional[
-        tuple[t.Literal["deny", "sameorigin", "allow-from"],
-        t.Optional[str]]
+        tuple[t.Literal["deny", "sameorigin", "allow-from"], t.Optional[str]]
     ] = ("sameorigin", None)
     """If set, ViUR will emit an X-Frame-Options header
 

--- a/src/viur/core/config.py
+++ b/src/viur/core/config.py
@@ -2,9 +2,9 @@ import datetime
 import hashlib
 import logging
 import os
+import typing as t
 import warnings
 from pathlib import Path
-import typing as t
 
 import google.auth
 
@@ -22,7 +22,9 @@ if t.TYPE_CHECKING:  # pragma: no cover
 _T = t.TypeVar("_T")
 Multiple: t.TypeAlias = list[_T] | tuple[_T] | set[_T] | frozenset[_T]  # TODO: Refactor for Python 3.12
 
+
 class CaptchaDefaultCredentialsType(t.TypedDict):
+    """Expected type of global captcha credential, see :attr:Security.captcha_default_credentials"""
     sitekey: str
     secret: str
 
@@ -378,7 +380,7 @@ class Security(ConfigType):
 
     x_frame_options: t.Optional[
         tuple[t.Literal["deny", "sameorigin", "allow-from"],
-              t.Optional[str]]] = ("sameorigin", None)
+        t.Optional[str]]] = ("sameorigin", None)
     """If set, ViUR will emit an X-Frame-Options header
 
     In case of allow-from, the second parameters must be the host-url.

--- a/src/viur/core/config.py
+++ b/src/viur/core/config.py
@@ -22,6 +22,10 @@ if t.TYPE_CHECKING:  # pragma: no cover
 _T = t.TypeVar("_T")
 Multiple: t.TypeAlias = list[_T] | tuple[_T] | set[_T] | frozenset[_T]  # TODO: Refactor for Python 3.12
 
+class CaptchaDefaultCredentialsType(t.TypedDict):
+    sitekey: str
+    secret: str
+
 
 class ConfigType:
     """An abstract class for configurations.
@@ -390,8 +394,8 @@ class Security(ConfigType):
     x_permitted_cross_domain_policies: t.Optional[t.Literal["none", "master-only", "by-content-type", "all"]] = "none"
     """Unless set to logical none; ViUR will emit a X-Permitted-Cross-Domain-Policies with each request"""
 
-    captcha_default_credentials: t.Optional[dict[t.Literal["sitekey", "secret"], str]] = None
-    """The default sitekey and secret to use for the captcha-bone.
+    captcha_default_credentials: t.Optional[CaptchaDefaultCredentialsType] = None
+    """The default sitekey and secret to use for the CaptchaBone.
     If set, must be a dictionary of "sitekey" and "secret".
     """
 

--- a/src/viur/core/config.py
+++ b/src/viur/core/config.py
@@ -24,7 +24,7 @@ Multiple: t.TypeAlias = list[_T] | tuple[_T] | set[_T] | frozenset[_T]  # TODO: 
 
 
 class CaptchaDefaultCredentialsType(t.TypedDict):
-    """Expected type of global captcha credential, see :attr:Security.captcha_default_credentials"""
+    """Expected type of global captcha credential, see :attr:`Security.captcha_default_credentials`"""
     sitekey: str
     secret: str
 

--- a/src/viur/core/config.py
+++ b/src/viur/core/config.py
@@ -380,7 +380,8 @@ class Security(ConfigType):
 
     x_frame_options: t.Optional[
         tuple[t.Literal["deny", "sameorigin", "allow-from"],
-        t.Optional[str]]] = ("sameorigin", None)
+        t.Optional[str]]
+    ] = ("sameorigin", None)
     """If set, ViUR will emit an X-Frame-Options header
 
     In case of allow-from, the second parameters must be the host-url.


### PR DESCRIPTION
* feat: Validates score of [reCAPTCHA v3](https://developers.google.com/recaptcha/docs/v3?hl=en) challenge
* feat: Add more verbose error messages
* feat: Add config option `captcha_enforce_always`
* change: Support bone name and "g-recaptcha-response" in `fromClient`
* refactor: Use `requests`
* docs: Update docstrings and describe behavior