### PR TITLE
fix: Re-Implement `RelationalConsistency.PreventDeletion` validation

### DIFF
--- a/src/viur/core/bones/relational.py
+++ b/src/viur/core/bones/relational.py
@@ -477,7 +477,7 @@ class RelationalBone(BaseBone):
         elif not indexed and name not in skel.dbEntity.exclude_from_indexes:
             skel.dbEntity.exclude_from_indexes.add(name)
 
-        # FIXME VIUR4: Delete legacy property
+        # Delete legacy property (PR #1244)  #TODO: Remove in ViUR4
         skel.dbEntity.pop(f"{name}_outgoingRelationalLocks", None)
 
         return True
@@ -869,10 +869,8 @@ class RelationalBone(BaseBone):
         origFilter = dbFilter.queries
         if origFilter is None or not "orderby" in rawFilter:  # This query is unsatisfiable or not sorted
             return dbFilter
-        if (
-            "orderby" in rawFilter and isinstance(rawFilter["orderby"], str)
-            and rawFilter["orderby"].startswith(f"{name}.")
-        ):
+        if "orderby" in rawFilter and isinstance(rawFilter["orderby"], str) and rawFilter["orderby"].startswith(
+                f"{name}."):
             if not dbFilter.getKind() == "viur-relations" and self.multiple:  # This query has not been rewritten (yet)
                 name, skel, dbFilter, rawFilter = self._rewriteQuery(name, skel, dbFilter, rawFilter)
             key = rawFilter["orderby"]
@@ -1157,7 +1155,7 @@ class RelationalBone(BaseBone):
         assert not (bool(self.languages) ^ bool(language)), "Language is required or not supported"
         assert not append or self.multiple, "Can't append - bone is not multiple"
         if not self.multiple and not self.using:
-            if not (isinstance(value, str) or isinstance(value, db.Key)):
+            if not isinstance(value, (str, db.Key)):
                 logging.error(value)
                 logging.error(type(value))
                 raise ValueError(f"You must supply exactly one Database-Key to {boneName}")
@@ -1165,14 +1163,14 @@ class RelationalBone(BaseBone):
         elif not self.multiple and self.using:
             if (
                 not isinstance(value, tuple) or len(value) != 2
-                or not (isinstance(value[0], str) or isinstance(value[0], db.Key))
+                or not isinstance(value[0], (str, db.Key))
                 or not isinstance(value[1], self._skeletonInstanceClassRef)
             ):
                 raise ValueError(f"You must supply a tuple of (Database-Key, relSkel) to {boneName}")
             realValue = value
         elif self.multiple and not self.using:
             if (
-                not (isinstance(value, str) or isinstance(value, db.Key))
+                not isinstance(value, (str, db.Key))
                 and not (isinstance(value, list))
                 and all(isinstance(k, (str, db.Key)) for k in value)
             ):
@@ -1183,8 +1181,7 @@ class RelationalBone(BaseBone):
                 realValue = [(value, None)]
         else:  # which means (self.multiple and self.using)
             if (
-                not (isinstance(value, tuple) and len(value) == 2 and
-                     (isinstance(value[0], str) or isinstance(value[0], db.Key))
+                not (isinstance(value, tuple) and len(value) == 2 and isinstance(value[0], (str, db.Key))
                      and isinstance(value[1], self._skeletonInstanceClassRef))
                 and not (isinstance(value, list)
                          and all((isinstance(x, tuple) and len(x) == 2 and (isinstance(x[0], (str, db.Key)))

--- a/src/viur/core/bones/relational.py
+++ b/src/viur/core/bones/relational.py
@@ -7,14 +7,15 @@ import json
 import logging
 import typing as t
 import warnings
-from enum import Enum
 from itertools import chain
 from time import time
+
 from viur.core import db, utils
 from viur.core.bones.base import BaseBone, ReadFromClientError, ReadFromClientErrorSeverity, getSystemInitialized
 
 if t.TYPE_CHECKING:
     from viur.core.skeleton import SkeletonInstance
+
 
 class RelationalConsistency(enum.IntEnum):
     """
@@ -869,7 +870,7 @@ class RelationalBone(BaseBone):
         if origFilter is None or not "orderby" in rawFilter:  # This query is unsatisfiable or not sorted
             return dbFilter
         if "orderby" in rawFilter and isinstance(rawFilter["orderby"], str) and rawFilter["orderby"].startswith(
-                f"{name}."):
+            f"{name}."):
             if not dbFilter.getKind() == "viur-relations" and self.multiple:  # This query has not been rewritten (yet)
                 name, skel, dbFilter, rawFilter = self._rewriteQuery(name, skel, dbFilter, rawFilter)
             key = rawFilter["orderby"]
@@ -1164,12 +1165,12 @@ class RelationalBone(BaseBone):
         elif not self.multiple and self.using:
             if not isinstance(value, tuple) or len(value) != 2 or \
                 not (isinstance(value[0], str) or isinstance(value[0], db.Key)) or \
-                    not isinstance(value[1], self._skeletonInstanceClassRef):
+                not isinstance(value[1], self._skeletonInstanceClassRef):
                 raise ValueError(f"You must supply a tuple of (Database-Key, relSkel) to {boneName}")
             realValue = value
         elif self.multiple and not self.using:
             if not (isinstance(value, str) or isinstance(value, db.Key)) and not (isinstance(value, list)) \
-                    and all([isinstance(x, str) or isinstance(x, db.Key) for x in value]):
+                and all([isinstance(x, str) or isinstance(x, db.Key) for x in value]):
                 raise ValueError(f"You must supply a Database-Key or a list hereof to {boneName}")
             if isinstance(value, list):
                 realValue = [(x, None) for x in value]

--- a/src/viur/core/bones/relational.py
+++ b/src/viur/core/bones/relational.py
@@ -14,7 +14,7 @@ from viur.core import db, utils
 from viur.core.bones.base import BaseBone, ReadFromClientError, ReadFromClientErrorSeverity, getSystemInitialized
 
 if t.TYPE_CHECKING:
-    from viur.core.skeleton import SkeletonInstance
+    from viur.core.skeleton import SkeletonInstance, RelSkel
 
 
 class RelationalConsistency(enum.IntEnum):
@@ -158,7 +158,7 @@ class RelationalBone(BaseBone):
         parentKeys: t.Optional[t.Iterable[str]] = {"name"},
         refKeys: t.Optional[t.Iterable[str]] = {"name"},
         updateLevel: RelationalUpdateLevel = RelationalUpdateLevel.Always,
-        using: t.Optional['viur.core.skeleton.RelSkel'] = None,
+        using: t.Optional["RelSkel"] = None,
         **kwargs
     ):
         """
@@ -739,7 +739,7 @@ class RelationalBone(BaseBone):
     def buildDBFilter(
         self,
         name: str,
-        skel: 'viur.core.skeleton.SkeletonInstance',
+        skel: "SkeletonInstance",
         dbFilter: db.Query,
         rawFilter: dict,
         prefix: t.Optional[str] = None
@@ -845,7 +845,7 @@ class RelationalBone(BaseBone):
     def buildDBSort(
         self,
         name: str,
-        skel: 'viur.core.skeleton.SkeletonInstance',
+        skel: "SkeletonInstance",
         dbFilter: db.Query,
         rawFilter: dict
     ) -> t.Optional[db.Query]:
@@ -964,7 +964,7 @@ class RelationalBone(BaseBone):
                 raise RuntimeError()
             return f"src.{param}", value
 
-    def orderHook(self, name, query, orderings):  # FIXME
+    def orderHook(self, name: str, query: db.Query, orderings):  # FIXME
         """
         Hook installed by buildDbFilter that rewrites orderings added to the query to match the layout of the
         viur-relations index and performs sanity checks on the query.
@@ -973,8 +973,8 @@ class RelationalBone(BaseBone):
         has been executed. It ensures that the orderings are compatible with the structure of the viur-relations
         index and checks if the query is possible.
 
-        :param str name: The name of the bone.
-        :param db.Query query: The datastore query to be modified.
+        :param name: The name of the bone.
+        :param query: The datastore query to be modified.
         :param orderings: A list or tuple of orderings to be checked and potentially modified.
         :type orderings: List[Union[str, Tuple[str, db.SortOrder]]] or Tuple[Union[str, Tuple[str, db.SortOrder]]]
 
@@ -1023,7 +1023,7 @@ class RelationalBone(BaseBone):
                         res.append(f"src.{orderKey}")
         return res
 
-    def refresh(self, skel, boneName):
+    def refresh(self, skel: "SkeletonInstance", boneName: str):
         """
         Refreshes all values that might be cached from other entities in the provided skeleton.
 
@@ -1069,18 +1069,17 @@ class RelationalBone(BaseBone):
                 for k in skel[boneName]:
                     updateInplace(k)
 
-    def getSearchTags(self, skel: 'viur.core.skeleton.SkeletonInstance', name: str) -> set[str]:
+    def getSearchTags(self, skel: "SkeletonInstance", name: str) -> set[str]:
         """
         Retrieves the search tags for the given RelationalBone in the provided skeleton.
 
         This method iterates over the values of the relational bone and gathers search tags from the
         reference and using skeletons. It combines all the tags into a set to avoid duplicates.
 
-        :param SkeletonInstance skel: The skeleton containing the bone for which search tags are to be retrieved.
-        :param str name: The name of the bone for which search tags are to be retrieved.
+        :param skel: The skeleton containing the bone for which search tags are to be retrieved.
+        :param name: The name of the bone for which search tags are to be retrieved.
 
         :return: A set of search tags for the specified relational bone.
-        :rtype: Set[str]
         """
         result = set()
 
@@ -1135,7 +1134,7 @@ class RelationalBone(BaseBone):
 
     def setBoneValue(
         self,
-        skel: 'SkeletonInstance',
+        skel: "SkeletonInstance",
         boneName: str,
         value: t.Any,
         append: bool,
@@ -1233,7 +1232,7 @@ class RelationalBone(BaseBone):
                     skel[boneName] = tmpRes
         return True
 
-    def getReferencedBlobs(self, skel: 'viur.core.skeleton.SkeletonInstance', name: str) -> set[str]:
+    def getReferencedBlobs(self, skel: "SkeletonInstance", name: str) -> set[str]:
         """
         Retrieves the set of referenced blobs from the specified bone in the given skeleton instance.
 

--- a/src/viur/core/bones/relational.py
+++ b/src/viur/core/bones/relational.py
@@ -477,7 +477,7 @@ class RelationalBone(BaseBone):
         elif not indexed and name not in skel.dbEntity.exclude_from_indexes:
             skel.dbEntity.exclude_from_indexes.add(name)
 
-        # Delete legacy property
+        # FIXME VIUR4: Delete legacy property
         skel.dbEntity.pop(f"{name}_outgoingRelationalLocks", None)
 
         return True

--- a/src/viur/core/bones/relational.py
+++ b/src/viur/core/bones/relational.py
@@ -582,7 +582,7 @@ class RelationalBone(BaseBone):
         query.filter("viur_dest_kind =", self.kind)
         query.filter("viur_src_property =", boneName)
         query.filter("src.__key__ =", key)
-        db.Delete([x for x in query.run()])
+        db.Delete([entity for entity in query.run()])
 
     def isInvalid(self, key) -> None:
         """

--- a/src/viur/core/bones/relational.py
+++ b/src/viur/core/bones/relational.py
@@ -1174,7 +1174,7 @@ class RelationalBone(BaseBone):
             if (
                 not (isinstance(value, str) or isinstance(value, db.Key))
                 and not (isinstance(value, list))
-                and all(isinstance(x, (str, db.Key)) for x in value)
+                and all(isinstance(k, (str, db.Key)) for k in value)
             ):
                 raise ValueError(f"You must supply a Database-Key or a list hereof to {boneName}")
             if isinstance(value, list):

--- a/src/viur/core/skeleton.py
+++ b/src/viur/core/skeleton.py
@@ -1049,7 +1049,7 @@ class Skeleton(BaseSkeleton, metaclass=MetaSkel):
                         else:
                             logging.critical("Detected Database corruption! Could not delete stale lock-object!")
 
-            # Delete legacy property
+            # Delete legacy property (PR #1244)  #TODO: Remove in ViUR4
             db_obj.pop("viur_incomming_relational_locks", None)
 
             # Ensure the SEO-Keys are up-to-date

--- a/src/viur/core/skeleton.py
+++ b/src/viur/core/skeleton.py
@@ -14,7 +14,8 @@ from itertools import chain
 from time import time
 
 from viur.core import conf, current, db, email, errors, translate, utils
-from viur.core.bones import BaseBone, DateBone, KeyBone, RelationalBone, RelationalUpdateLevel, SelectBone, StringBone
+from viur.core.bones import BaseBone, DateBone, KeyBone, RelationalBone, RelationalConsistency, RelationalUpdateLevel, \
+    SelectBone, StringBone
 from viur.core.bones.base import Compute, ComputeInterval, ComputeMethod, ReadFromClientError, \
     ReadFromClientErrorSeverity, getSystemInitialized
 from viur.core.tasks import CallDeferred, CallableTask, CallableTaskBase, QueryIter
@@ -1048,6 +1049,9 @@ class Skeleton(BaseSkeleton, metaclass=MetaSkel):
                         else:
                             logging.critical("Detected Database corruption! Could not delete stale lock-object!")
 
+            # Delete legacy property
+            db_obj.pop("viur_incomming_relational_locks", None)
+
             # Ensure the SEO-Keys are up-to-date
             last_requested_seo_keys = db_obj["viur"].get("viurLastRequestedSeoKeys") or {}
             last_set_seo_keys = db_obj["viur"].get("viurCurrentSeoKeys") or {}
@@ -1088,7 +1092,6 @@ class Skeleton(BaseSkeleton, metaclass=MetaSkel):
                 db_obj["viur"]["viurCurrentSeoKeys"][language] = last_set_seo_keys[language]
 
             db_obj["viur"].setdefault("viurActiveSeoKeys", [])
-
             for language, seo_key in last_set_seo_keys.items():
                 if db_obj["viur"]["viurCurrentSeoKeys"][language] not in db_obj["viur"]["viurActiveSeoKeys"]:
                     # Ensure the current, active seo key is in the list of all seo keys
@@ -1103,6 +1106,7 @@ class Skeleton(BaseSkeleton, metaclass=MetaSkel):
 
             # mark entity as "dirty" when update_relations is set, to zero otherwise.
             db_obj["viur"]["delayedUpdateTag"] = time() if update_relations else 0
+
             db_obj = skel.preProcessSerializedData(db_obj)
 
             # Allow the custom DB Adapter to apply last minute changes to the object
@@ -1132,7 +1136,6 @@ class Skeleton(BaseSkeleton, metaclass=MetaSkel):
             db.Put(db_obj)
 
             # Now write the blob-lock object
-
             blob_list = skel.preProcessBlobLocks(blob_list)
             if blob_list is None:
                 raise ValueError("Did you forget to return the blob_list somewhere inside getReferencedBlobs()?")
@@ -1247,31 +1250,40 @@ class Skeleton(BaseSkeleton, metaclass=MetaSkel):
             Deletes the entity associated with the current Skeleton from the data store.
         """
 
-        def txnDelete(skel: SkeletonInstance):
-            skelKey = skel["key"]
-            dbObj = db.Get(skelKey)  # Fetch the raw object as we might have to clear locks
-            viurData = dbObj.get("viur") or {}
-            if dbObj.get("viur_incomming_relational_locks"):
-                raise errors.Locked("This entry is locked!")
+        def txnDelete(skel: SkeletonInstance) -> db.Entity:
+            skel_key = skel["key"]
+            entity = db.Get(skel_key)  # Fetch the raw object as we might have to clear locks
+            viur_data = entity.get("viur") or {}
+
+            # Is there any relation to this Skeleton which prevents the deletion?
+            locked_relation = (
+                db.Query("viur-relations")
+                .filter("dest.__key__ =", skel_key)
+                .filter("viur_relational_consistency =", RelationalConsistency.PreventDeletion.value)
+            ).getEntry()
+            if locked_relation is not None:
+                raise errors.Locked("This entry is still referenced by other Skeletons, which prevents deleting!")
+
             for boneName, bone in skel.items():
                 # Ensure that we delete any value-lock objects remaining for this entry
                 bone.delete(skel, boneName)
                 if bone.unique:
                     flushList = []
-                    for lockValue in viurData.get(f"{boneName}_uniqueIndexValue") or []:
+                    for lockValue in viur_data.get(f"{boneName}_uniqueIndexValue") or []:
                         lockKey = db.Key(f"{skel.kindName}_{boneName}_uniquePropertyIndex", lockValue)
                         lockObj = db.Get(lockKey)
                         if not lockObj:
                             logging.error(f"{lockKey=} missing!")
-                        elif lockObj["references"] != dbObj.key.id_or_name:
+                        elif lockObj["references"] != entity.key.id_or_name:
                             logging.error(
                                 f"""{skel["key"]!r} does not hold lock for {lockKey!r}""")
                         else:
                             flushList.append(lockObj)
                     if flushList:
                         db.Delete(flushList)
+
             # Delete the blob-key lock object
-            lockObjectKey = db.Key("viur-blob-locks", dbObj.key.id_or_name)
+            lockObjectKey = db.Key("viur-blob-locks", entity.key.id_or_name)
             lockObj = db.Get(lockObjectKey)
             if lockObj is not None:
                 if lockObj["old_blob_references"] is None and lockObj["active_blob_references"] is None:
@@ -1287,13 +1299,13 @@ class Skeleton(BaseSkeleton, metaclass=MetaSkel):
                     lockObj["is_stale"] = True
                     lockObj["has_old_blob_references"] = True
                     db.Put(lockObj)
-            db.Delete(skelKey)
-            processRemovedRelations(skelKey)
-            return dbObj
+            db.Delete(skel_key)
+            processRemovedRelations(skel_key)
+            return entity
 
         key = skelValues["key"]
         if key is None:
-            raise ValueError("This skeleton is not in the database (anymore?)!")
+            raise ValueError("This skeleton has no key!")
         skel = skeletonByKind(skelValues.kindName)()
         if not skel.fromDB(key):
             raise ValueError("This skeleton is not in the database (anymore?)!")
@@ -1404,14 +1416,17 @@ class SkelList(list):
 
 @CallDeferred
 def processRemovedRelations(removedKey, cursor=None):
-    updateListQuery = db.Query("viur-relations").filter("dest.__key__ =", removedKey) \
-        .filter("viur_relational_consistency >", 2)
+    updateListQuery = (
+        db.Query("viur-relations")
+        .filter("dest.__key__ =", removedKey)
+        .filter("viur_relational_consistency >", RelationalConsistency.PreventDeletion.value)
+    )
     updateListQuery = updateListQuery.setCursor(cursor)
     updateList = updateListQuery.run(limit=5)
     for entry in updateList:
         skel = skeletonByKind(entry["viur_src_kind"])()
         assert skel.fromDB(entry["src"].key)
-        if entry["viur_relational_consistency"] == 3:  # Set Null
+        if entry["viur_relational_consistency"] == RelationalConsistency.SetNull.value:
             for key, _bone in skel.items():
                 if isinstance(_bone, RelationalBone):
                     relVal = skel[key]
@@ -1452,9 +1467,12 @@ def updateRelations(destKey: db.Key, minChangeTime: int, changedBone: t.Optional
             defer again.
     """
     logging.debug(f"Starting updateRelations for {destKey} ; {minChangeTime=},{changedBone=}, {cursor=}")
-    updateListQuery = db.Query("viur-relations").filter("dest.__key__ =", destKey) \
-        .filter("viur_delayed_update_tag <", minChangeTime).filter("viur_relational_updateLevel =",
-                                                                   RelationalUpdateLevel.Always.value)
+    updateListQuery = (
+        db.Query("viur-relations")
+        .filter("dest.__key__ =", destKey)
+        .filter("viur_delayed_update_tag <", minChangeTime)
+        .filter("viur_relational_updateLevel =", RelationalUpdateLevel.Always.value)
+    )
     if changedBone:
         updateListQuery.filter("viur_foreign_keys =", changedBone)
     if cursor:


### PR DESCRIPTION
You can set `consistency` on a `RelationalBone` to `RelationalConsistency.PreventDeletion` to disallow the deletion of the referenced Skeleton (if there is a relation from this bone to it).

This works fine as long a Skeleton is referenced by only few other Skeleton. But if thousands of Skeletons has a reference to the same Skeleton (10000:1 relation) the `viur_incomming_relational_locks` list has to hold 10000 keys, which exceeds the size limit of the entity. Furthermore the transaction limit would be exceeded during writing on 10000 entites the `"{bonename}_outgoingRelationalLocks"` property too.
We cannot carry a list, neither in the one way nor in the other. (Yes, okay, theoretically you could write _outgoingRelationalLocks outside the transaction, maybe in a task. But even here it can be dangerous if a skeleton contains many (multiple) `RelationalBone`. Even if the number of outgoing ones will probably be smaller than the number of incoming ones.  But this is still an insane overhead).


That's why I thought about what I could use to solve this. And in my opinion, we can simply use what we already have: The `viur-relations` entities. The `consistency` is already stored in this. 
So I have removed everything that relates to the maintenance of these lock lists, ensured that these lists will no longer be present in the datastore entites in future and replaced the "can delete" check with a query on the `viur-relations`.
In my tests this works very well and we should even save some runtime and memory.

