### PR TITLE
fix: Improve `NumericBone.singleValueFromClient`

### DIFF
--- a/src/viur/core/bones/numeric.py
+++ b/src/viur/core/bones/numeric.py
@@ -14,32 +14,34 @@ if t.TYPE_CHECKING:
 MIN = -(sys.maxsize - 1)
 """Constant for the minimum possible value in the system"""
 MAX = sys.maxsize
-"""Constant for the maximum possible value in the system"""
+"""Constant for the maximum possible value in the system
+Also limited by the datastore (8 bytes). Halved for positive and negative values.
+Which are around 2 ** (8 * 8 - 1) negative and 2 ** (8 * 8 - 1) positive values.
+"""
 
 
 class NumericBone(BaseBone):
     """
-        A bone for storing numeric values, either integers or floats.
-        For floats, the precision can be specified in decimal-places.
-
-        :param precision: How may decimal places should be saved. Zero casts the value to int instead of
-            float.
-        :param min: Minimum accepted value (including).
-        :param max: Maximum accepted value (including).
+    A bone for storing numeric values, either integers or floats.
+    For floats, the precision can be specified in decimal-places.
     """
     type = "numeric"
 
     def __init__(
         self,
         *,
-        max: int | float = MAX,
         min: int | float = MIN,
-        mode=None,  # deprecated!
+        max: int | float = MAX,
         precision: int = 0,
+        mode=None,  # deprecated!
         **kwargs
     ):
         """
-            Initializes a new NumericBone.
+        Initializes a new NumericBone.
+
+        :param min: Minimum accepted value (including).
+        :param max: Maximum accepted value (including).
+        :param precision: How may decimal places should be saved. Zero casts the value to int instead of float.
         """
         super().__init__(**kwargs)
 
@@ -119,22 +121,39 @@ class NumericBone(BaseBone):
         return value == self.getEmptyValue()
 
     def singleValueFromClient(self, value, skel, bone_name, client_data):
-        try:
-            value = str(value).replace(",", ".", 1)
-        except:
-            return self.getEmptyValue(), [ReadFromClientError(ReadFromClientErrorSeverity.Invalid, "Invalid Value")]
+        if not isinstance(value, (int, float)):
+            # Replace , with .
+            try:
+                value = str(value).replace(",", ".", 1)
+            except TypeError:
+                return self.getEmptyValue(), [ReadFromClientError(
+                    ReadFromClientErrorSeverity.Invalid, "Cannot handle this value"
+                )]
+            # Convert to float or int -- depending on the precision
+            # Since we convert direct to int if precision=0, a float value isn't valid
+            try:
+                value = float(value) if self.precision else int(value)
+            except ValueError:
+                return self.getEmptyValue(), [ReadFromClientError(
+                    ReadFromClientErrorSeverity.Invalid,
+                    f'Not a valid {"float" if self.precision else "int"} value'
+                )]
+
+        assert isinstance(value, (int, float))
+        if self.precision:
+            value = round(float(value), self.precision)
         else:
-            if self.precision and (str(value).replace(".", "", 1).replace("-", "", 1).isdigit()) and float(
-                    value) >= self.min and float(value) <= self.max:
-                value = round(float(value), self.precision)
-            elif not self.precision and (str(value).replace("-", "", 1).isdigit()) and int(
-                    value) >= self.min and int(value) <= self.max:
-                value = int(value)
-            else:
-                return self.getEmptyValue(), [ReadFromClientError(ReadFromClientErrorSeverity.Invalid, "Invalid Value")]
-        err = self.isInvalid(value)
-        if err:
+            value = int(value)
+
+        # Check the limits after rounding, as the rounding may change the value.
+        if not (self.min <= value <= self.max):
+            return self.getEmptyValue(), [ReadFromClientError(
+                ReadFromClientErrorSeverity.Invalid, f"Value not between {self.min} and {self.max}"
+            )]
+
+        if err := self.isInvalid(value):
             return self.getEmptyValue(), [ReadFromClientError(ReadFromClientErrorSeverity.Invalid, err)]
+
         return value, None
 
     def buildDBFilter(

--- a/tests/bones/test_numeric_bone.py
+++ b/tests/bones/test_numeric_bone.py
@@ -1,5 +1,9 @@
 import unittest
 
+LARGE_INT = 123_465 * 10 ** 12
+LARGE_FLOAT = 123_465.0 * 10 ** 12
+SMALL_FLOAT = 123_465.0 * 10 ** -12
+
 
 class TestNumericBone(unittest.TestCase):
     @classmethod
@@ -29,6 +33,10 @@ class TestNumericBone(unittest.TestCase):
         self.assertFalse(bone.isEmpty("123.456"))
         self.assertFalse(bone.isEmpty("123,456"))
         self.assertFalse(bone.isEmpty(123.456))
+        self.assertFalse(bone.isEmpty(LARGE_INT))
+        self.assertFalse(bone.isEmpty(LARGE_FLOAT))
+        if bone.precision != 0:
+            self.assertFalse(bone.isEmpty(SMALL_FLOAT), msg=vars(bone))
 
         self.assertTrue(bone.isEmpty(""))
         self.assertTrue(bone.isEmpty(None))
@@ -65,3 +73,165 @@ class TestNumericBone(unittest.TestCase):
         with self.assertRaises(ValueError):
             bone._convert_to_numeric("123.456,5")
         self.assertIsInstance(bone._convert_to_numeric(42), int)
+
+
+class TestNumericBone_fromClient(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        from main import monkey_patch
+        monkey_patch()
+        cls.bone_name = "my_numeric_bone"
+
+    def test_fromClient_int(self):
+        from viur.core.bones import NumericBone
+        from viur.core.bones.base import ReadFromClientError
+        bone = NumericBone(precision=0)
+        skel = {}
+        # okay: int as str
+        data = {self.bone_name: "1234"}
+        self.assertIsNone(bone.fromClient(skel, self.bone_name, data))  # None = no error
+        self.assertIn(self.bone_name, skel)
+        self.assertEqual(1234, skel[self.bone_name])
+        self.assertIsInstance(skel[self.bone_name], int)
+        # okay: large int as str
+        data = {self.bone_name: str(LARGE_INT)}
+        self.assertIsNone(bone.fromClient(skel, self.bone_name, data))  # None = no error
+        self.assertIn(self.bone_name, skel)
+        self.assertEqual(LARGE_INT, skel[self.bone_name])
+        self.assertIsInstance(skel[self.bone_name], int)
+        # okay: int as int
+        data = {self.bone_name: 1234}
+        self.assertIsNone(bone.fromClient(skel, self.bone_name, data))  # None = no error
+        self.assertIn(self.bone_name, skel)
+        self.assertEqual(1234, skel[self.bone_name])
+        self.assertIsInstance(skel[self.bone_name], int)
+        # okay: large int as int
+        data = {self.bone_name: LARGE_INT}
+        self.assertIsNone(bone.fromClient(skel, self.bone_name, data))  # None = no error
+        self.assertIn(self.bone_name, skel)
+        self.assertEqual(LARGE_INT, skel[self.bone_name])
+        # invalid: precision=0 allows only ints
+        data = {self.bone_name: "1234.0"}
+        self.assertIsInstance(res := bone.fromClient(skel, self.bone_name, data), list)
+        self.assertTrue(res)  # list not empty
+        self.assertIsInstance(res[0], ReadFromClientError)
+        # invalid data
+        data = {self.bone_name: ""}
+        self.assertIsInstance(res := bone.fromClient(skel, self.bone_name, data), list)
+        self.assertTrue(res)  # list not empty
+        self.assertIsInstance(res[0], ReadFromClientError)
+        # invalid data
+        data = {self.bone_name: None}
+        self.assertIsInstance(res := bone.fromClient(skel, self.bone_name, data), list)
+        self.assertTrue(res)  # list not empty
+        self.assertIsInstance(res[0], ReadFromClientError)
+        # invalid data
+        data = {self.bone_name: "abc"}
+        self.assertIsInstance(res := bone.fromClient(skel, self.bone_name, data), list)
+        self.assertTrue(res)  # list not empty
+        self.assertIsInstance(res[0], ReadFromClientError)
+        # invalid data: too large
+        data = {self.bone_name: 10 ** 20}
+        self.assertIsInstance(res := bone.fromClient(skel, self.bone_name, data), list)
+        self.assertTrue(res)  # list not empty
+        self.assertIsInstance(res[0], ReadFromClientError)
+        # invalid data: too small
+        data = {self.bone_name: -10 ** 20}
+        self.assertIsInstance(res := bone.fromClient(skel, self.bone_name, data), list)
+        self.assertTrue(res)  # list not empty
+        self.assertIsInstance(res[0], ReadFromClientError)
+
+    def test_fromClient_float(self):
+        from viur.core.bones import NumericBone
+        from viur.core.bones.base import ReadFromClientError
+        bone = NumericBone(precision=8)
+        skel = {}
+        # okay: int as str
+        data = {self.bone_name: "1234"}
+        self.assertIsNone(bone.fromClient(skel, self.bone_name, data))  # None = no error
+        self.assertIn(self.bone_name, skel)
+        self.assertEqual(1234.0, skel[self.bone_name])
+        self.assertIsInstance(skel[self.bone_name], float)
+        # okay: float as str
+        data = {self.bone_name: "1234.5"}
+        self.assertIsNone(bone.fromClient(skel, self.bone_name, data))  # None = no error
+        self.assertIn(self.bone_name, skel)
+        self.assertEqual(1234.5, skel[self.bone_name])
+        self.assertIsInstance(skel[self.bone_name], float)
+        # okay: float as str with comma
+        data = {self.bone_name: "1234,5"}
+        self.assertIsNone(bone.fromClient(skel, self.bone_name, data))  # None = no error
+        self.assertIn(self.bone_name, skel)
+        self.assertEqual(1234.5, skel[self.bone_name])
+        self.assertIsInstance(skel[self.bone_name], float)
+        # okay: large int as str
+        data = {self.bone_name: str(LARGE_INT)}
+        self.assertIsNone(bone.fromClient(skel, self.bone_name, data))  # None = no error
+        self.assertIn(self.bone_name, skel)
+        self.assertEqual(LARGE_INT, skel[self.bone_name])
+        self.assertIsInstance(skel[self.bone_name], float)
+        # okay: large float as str
+        data = {self.bone_name: str(LARGE_FLOAT)}
+        self.assertIsNone(bone.fromClient(skel, self.bone_name, data))  # None = no error
+        self.assertIn(self.bone_name, skel)
+        self.assertEqual(LARGE_INT, skel[self.bone_name])
+        self.assertIsInstance(skel[self.bone_name], float)
+        # okay: int as int
+        data = {self.bone_name: 1234}
+        self.assertIsNone(bone.fromClient(skel, self.bone_name, data))  # None = no error
+        self.assertIn(self.bone_name, skel)
+        self.assertEqual(1234.0, skel[self.bone_name])
+        self.assertIsInstance(skel[self.bone_name], float)
+        # okay: float as float
+        data = {self.bone_name: 1234.5}
+        self.assertIsNone(bone.fromClient(skel, self.bone_name, data))  # None = no error
+        self.assertIn(self.bone_name, skel)
+        self.assertEqual(1234.5, skel[self.bone_name])
+        self.assertIsInstance(skel[self.bone_name], float)
+        # invalid data
+        data = {self.bone_name: ""}
+        self.assertIsInstance(res := bone.fromClient(skel, self.bone_name, data), list)
+        self.assertTrue(res)  # list not empty
+        self.assertIsInstance(res[0], ReadFromClientError)
+        # invalid data
+        data = {self.bone_name: None}
+        self.assertIsInstance(res := bone.fromClient(skel, self.bone_name, data), list)
+        self.assertTrue(res)  # list not empty
+        self.assertIsInstance(res[0], ReadFromClientError)
+        # invalid data
+        data = {self.bone_name: "abc"}
+        self.assertIsInstance(res := bone.fromClient(skel, self.bone_name, data), list)
+        self.assertTrue(res)  # list not empty
+        self.assertIsInstance(res[0], ReadFromClientError)
+        # invalid data: too large
+        data = {self.bone_name: 10.0 ** 20}
+        self.assertIsInstance(res := bone.fromClient(skel, self.bone_name, data), list)
+        self.assertTrue(res)  # list not empty
+        self.assertIsInstance(res[0], ReadFromClientError)
+        # invalid data: too small
+        data = {self.bone_name: -10.0 ** 20}
+        self.assertIsInstance(res := bone.fromClient(skel, self.bone_name, data), list)
+        self.assertTrue(res)  # list not empty
+        self.assertIsInstance(res[0], ReadFromClientError)
+
+        # tests where the provided values has a higher precision
+        bone = NumericBone(precision=2)
+        skel = {}
+        # okay: float as str
+        data = {self.bone_name: "1234.56789"}
+        self.assertIsNone(bone.fromClient(skel, self.bone_name, data))  # None = no error
+        self.assertIn(self.bone_name, skel)
+        self.assertEqual(1234.57, skel[self.bone_name])
+        self.assertIsInstance(skel[self.bone_name], float)
+        # okay: float as float
+        data = {self.bone_name: 1234.56789}
+        self.assertIsNone(bone.fromClient(skel, self.bone_name, data))  # None = no error
+        self.assertIn(self.bone_name, skel)
+        self.assertEqual(1234.57, skel[self.bone_name])
+        self.assertIsInstance(skel[self.bone_name], float)
+        # okay: float as float, force to round down
+        data = {self.bone_name: 1234.56289}
+        self.assertIsNone(bone.fromClient(skel, self.bone_name, data))  # None = no error
+        self.assertIn(self.bone_name, skel)
+        self.assertEqual(1234.56, skel[self.bone_name])
+        self.assertIsInstance(skel[self.bone_name], float)


### PR DESCRIPTION
Resolves #1234 (in some ways)

I actually wanted to make it possible to save large values. In the end, however, I found out that this is limited by the datastore. Due to a completely messed up implementation and bad error handling, I didn't recognise this. This PR now improves that.