### PR TITLE
fix: `SpamBone` regression of descr-property

### DIFF
--- a/src/viur/core/bones/spam.py
+++ b/src/viur/core/bones/spam.py
@@ -46,7 +46,10 @@ class SpamBone(NumericBone):
         """
         The descr-property is generated and uses session variables to construct the question.
         """
-        session = current.session.get()
+
+        # The session is not available during startup
+        if not (session := current.session.get()):
+            return None
 
         a = session.get("spambone.value.a")
         b = session.get("spambone.value.b")


### PR DESCRIPTION
This is a regression introduced by #1227 causing descr() is called before a session is available.