### PR TITLE
fix: `Skeleton.toDB()`s `is_add` determined wrong

### DIFF
--- a/src/viur/core/skeleton.py
+++ b/src/viur/core/skeleton.py
@@ -986,7 +986,7 @@ class Skeleton(BaseSkeleton, metaclass=MetaSkel):
                     continue
 
                 # Allow bones to perform outstanding "magic" operations before saving to db
-                bone.performMagic(skel, bone_name, isAdd=is_add)  # FIXME: ANY MAGIC IN OUR CODE IS DEPRECATED; REMOVE WITH VIUR4!
+                bone.performMagic(skel, bone_name, isAdd=is_add)  # FIXME VIUR4: ANY MAGIC IN OUR CODE IS DEPRECATED!!!
 
                 if not (bone_name in skel.accessedValues or bone.compute) and bone_name not in skel.dbEntity:
                     _ = skel[bone_name]  # Ensure the datastore is filled with the default value


### PR DESCRIPTION
This is a hotfix for the problem that `is_add` is being set based on if the key is set or not. Furthermore, it is determined twice, so that the "magic"-bullshit now was moved into the transaction. It is a fix for PR #973 but previous implementation was also wrong.