### PR TITLE
refactor: Send emails from `EmailTransport` instances instead of class

### DIFF
--- a/docs/doc_tutorial/advanced/05_training_config.rst
+++ b/docs/doc_tutorial/advanced/05_training_config.rst
@@ -140,7 +140,7 @@ viur.emailRecipientOverride
 Override recipients for all outgoing email. This should be done for testing purposes only.
 
 If set, all outgoing emails will be send to this address
-(always overriding the ``dests``-parameter in `core.email.sendEMail`_).
+(always overriding the ``dests``-parameter in `core.email.send_email`_).
 
 ::
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ name = "viur-core"
 dynamic = ["version"]
 dependencies = [
     "appengine-python-standard~=1.0",
+    "Deprecated~=1.2",
     "google-api-core[grpc]~=2.0",
     "google-auth~=2.0",
     "google-cloud-datastore~=2.0",

--- a/src/viur/core/config.py
+++ b/src/viur/core/config.py
@@ -483,25 +483,9 @@ class Email(ConfigType):
     log_retention: datetime.timedelta = datetime.timedelta(days=30)
     """For how long we'll keep successfully send emails in the viur-emails table"""
 
-    transport_class: t.Type["EmailTransport"] = None
-    """Class that actually delivers the email using the service provider
+    transport_class: "EmailTransport" = None
+    """EmailTransport instance that actually delivers the email using the service provider
     of choice. See email.py for more details
-    """
-
-    mailjet_api_key: t.Optional[str] = None
-    """API Key for MailJet"""
-
-    mailjet_api_secret: t.Optional[str] = None
-    """API Secret for MailJet"""
-
-    sendinblue_api_key: t.Optional[str] = None
-    """API Key for SendInBlue (now Brevo) for the EmailTransportSendInBlue
-    """
-
-    sendinblue_thresholds: tuple[int] | list[int] = (1000, 500, 100)
-    """Warning thresholds for remaining email quota
-
-    Used by email.EmailTransportSendInBlue.check_sib_quota
     """
 
     send_from_local_development_server: bool = False

--- a/src/viur/core/email.py
+++ b/src/viur/core/email.py
@@ -1,16 +1,15 @@
-from urllib import request
-
 import base64
 import datetime
+import json
 import logging
 import os
-import requests
 import typing as t
 from abc import ABC, abstractmethod
+from urllib import request
+
+import requests
 from deprecated import deprecated
 from google.appengine.api.mail import Attachment as GAE_Attachment, SendMail as GAE_SendMail
-
-import json
 from viur.core import db, utils
 from viur.core.bones.text import HtmlSerializer
 from viur.core.config import conf
@@ -211,7 +210,7 @@ def send_email_deferred(key: db.Key):
 
     :param key: Datastore key of the email to send
     """
-    logging.debug(f"Sending deferred e-mail {key!r}")
+    logging.debug(f"Sending deferred email {key!r}")
     if not (queued_email := db.Get(key)):
         raise ValueError(f"Email queue entity with {key=!r} went missing!")
 
@@ -285,8 +284,8 @@ def send_email(
     **kwargs,
 ) -> bool:
     """
-    General purpose function for sending e-mail.
-    This function allows for sending e-mails, also with generated content using the Jinja2 template engine.
+    General purpose function for sending email.
+    This function allows for sending emails, also with generated content using the Jinja2 template engine.
     Your have to implement a method which should be called to send the prepared email finally. For this you have
     to allocate *viur.email.transport_class* in conf.
 
@@ -438,7 +437,7 @@ def send_email_to_admins(subject: str, body: str, *args, **kwargs) -> bool:
             success = True
             return ret
         else:
-            logging.warning("There are no recipients for admin e-mails available.")
+            logging.warning("There are no recipients for admin emails available.")
 
     finally:
         if not success:
@@ -589,11 +588,11 @@ class EmailTransportBrevo(EmailTransport):
                 break
         else:
             credits = -1
-        logging.info(f"SIB E-Mail credits: {credits}")
+        logging.info(f"Brevo email credits: {credits}")
 
         # Keep track of the last credits and the limit for which a email has
         # already been sent. This way, emails for the same limit will not be
-        # sent more than once and the remaining e-mail credits will not be wasted.
+        # sent more than once and the remaining email credits will not be wasted.
         key = db.Key("viur-email-conf", "sib-credits")
         if not (entity := db.Get(key)):
             logging.debug(f"{entity = }")
@@ -625,7 +624,7 @@ class EmailTransportBrevo(EmailTransport):
         db.Put(entity)
 
 
-@deprecated(version="3.7.0", reason="Sendinblue is now brevo; Use EmailTransportBrevo instead", action="always")
+@deprecated(version="3.7.0", reason="Sendinblue is now Brevo; Use EmailTransportBrevo instead", action="always")
 class EmailTransportSendInBlue(EmailTransportBrevo):
     ...
 

--- a/src/viur/core/email.py
+++ b/src/viur/core/email.py
@@ -167,18 +167,14 @@ class EmailTransport(ABC):
     def validate_attachment(self, attachment: Attachment) -> None:
         """Validate attachment before queueing the email"""
         if not isinstance(attachment, dict):
-            raise TypeError(
-                f"Attachment must be a dict, not {type(attachment)}")
+            raise TypeError(f"Attachment must be a dict, not {type(attachment)}")
         if "filename" not in attachment:
             raise ValueError(f"Attachment {attachment} must have a filename")
-        if not any(prop in attachment for prop in
-                   ("content", "file_key", "gcsfile")):
+        if not any(prop in attachment for prop in ("content", "file_key", "gcsfile")):
             raise ValueError(
                 f"Attachment {attachment} must have content, file_key or gcsfile")
-        if "content" in attachment and not isinstance(attachment["content"],
-                                                      bytes):
-            raise ValueError(
-                f"Attachment content must be bytes, not {type(attachment['content'])}")
+        if "content" in attachment and not isinstance(attachment["content"], bytes):
+            raise ValueError(f"Attachment content must be bytes, not {type(attachment['content'])}")
 
     def fetch_attachment(self, attachment: Attachment) -> AttachmentInline:
         """Fetch attachment (if necessary) in send_email_deferred deferred task

--- a/src/viur/core/email.py
+++ b/src/viur/core/email.py
@@ -85,17 +85,17 @@ class EmailTransport(ABC):
 
     @abstractmethod
     def deliverEmail(
-        self,
-        *,
-        sender: str,
-        dests: list[str],
-        cc: list[str],
-        bcc: list[str],
-        subject: str,
-        body: str,
-        headers: dict[str, str],
-        attachments: list[Attachment],
-        **kwargs: t.Any,
+            self,
+            *,
+            sender: str,
+            dests: list[str],
+            cc: list[str],
+            bcc: list[str],
+            subject: str,
+            body: str,
+            headers: dict[str, str],
+            attachments: list[Attachment],
+            **kwargs: t.Any,
     ) -> t.Any:
         """
         The actual email delivery must be implemented here. All email-addresses can be either in the form of
@@ -248,18 +248,18 @@ def normalize_to_list(value: None | t.Any | list[t.Any] | t.Callable[[], list]) 
 
 
 def sendEMail(
-    *,
-    tpl: str = None,
-    stringTemplate: str = None,
-    skel: t.Union[None, dict, "SkeletonInstance", list["SkeletonInstance"]] = None,
-    sender: str = None,
-    dests: str | list[str] = None,
-    cc: str | list[str] = None,
-    bcc: str | list[str] = None,
-    headers: dict[str, str] = None,
-    attachments: list[Attachment] = None,
-    context: db.DATASTORE_BASE_TYPES | list[db.DATASTORE_BASE_TYPES] | db.Entity = None,
-    **kwargs,
+        *,
+        tpl: str = None,
+        stringTemplate: str = None,
+        skel: t.Union[None, dict, "SkeletonInstance", list["SkeletonInstance"]] = None,
+        sender: str = None,
+        dests: str | list[str] = None,
+        cc: str | list[str] = None,
+        bcc: str | list[str] = None,
+        headers: dict[str, str] = None,
+        attachments: list[Attachment] = None,
+        context: db.DATASTORE_BASE_TYPES | list[db.DATASTORE_BASE_TYPES] | db.Entity = None,
+        **kwargs,
 ) -> bool:
     """
     General purpose function for sending e-mail.
@@ -293,7 +293,8 @@ def sendEMail(
     """
     # First, ensure we're able to send email at all
     transport_class = conf.email.transport_class  # First, ensure we're able to send email at all
-    assert isinstance(transport_class, EmailTransport), "No or invalid email transportclass specified!"
+    if not isinstance(transport_class, EmailTransport):
+        raise ValueError(f"No or invalid email transportclass specified! ({transport_class=})")
 
     # Ensure that all recipient parameters (dest, cc, bcc) are a list
     dests = normalize_to_list(dests)
@@ -427,10 +428,10 @@ class EmailTransportSendInBlue(EmailTransport):
                          "xls", "xlsx", "ppt", "tar", "ez"}
 
     def __init__(
-        self,
-        *,
-        api_key: str,
-        thresholds: tuple[int] | list[int] = (1000, 500, 100),
+            self,
+            *,
+            api_key: str,
+            thresholds: tuple[int] | list[int] = (1000, 500, 100),
     ) -> None:
         """
         :param api_key: API key
@@ -441,17 +442,17 @@ class EmailTransportSendInBlue(EmailTransport):
         self.thresholds = thresholds
 
     def deliverEmail(
-        self,
-        *,
-        sender: str,
-        dests: list[str],
-        cc: list[str],
-        bcc: list[str],
-        subject: str,
-        body: str,
-        headers: dict[str, str],
-        attachments: list[Attachment],
-        **kwargs: t.Any,
+            self,
+            *,
+            sender: str,
+            dests: list[str],
+            cc: list[str],
+            bcc: list[str],
+            subject: str,
+            body: str,
+            headers: dict[str, str],
+            attachments: list[Attachment],
+            **kwargs: t.Any,
     ) -> str:
         """
             Internal function for delivering Emails using Send in Blue. This function requires the
@@ -585,27 +586,27 @@ class EmailTransportSendInBlue(EmailTransport):
 if mailjet_dependencies:
     class EmailTransportMailjet(EmailTransport):
         def __init__(
-            self,
-            *,
-            api_key: str,
-            secret_key: str,
+                self,
+                *,
+                api_key: str,
+                secret_key: str,
         ) -> None:
             super().__init__()
             self.api_key = api_key
             self.secret_key = secret_key
 
         def deliverEmail(
-            self,
-            *,
-            sender: str,
-            dests: list[str],
-            cc: list[str],
-            bcc: list[str],
-            subject: str,
-            body: str,
-            headers: dict[str, str],
-            attachments: list[Attachment],
-            **kwargs: t.Any,
+                self,
+                *,
+                sender: str,
+                dests: list[str],
+                cc: list[str],
+                bcc: list[str],
+                subject: str,
+                body: str,
+                headers: dict[str, str],
+                attachments: list[Attachment],
+                **kwargs: t.Any,
         ) -> str:
             if not (self.api_key and self.secret_key):
                 raise RuntimeError("Mailjet config invalid, check 'api_key' and 'secret_key'")
@@ -650,27 +651,35 @@ if mailjet_dependencies:
 class EmailTransportSendgrid(EmailTransport):
     """Send emails with SendGrid"""
 
-    @staticmethod
+    def __init__(
+            self,
+            *,
+            api_key: str,
+    ) -> None:
+        super().__init__()
+        self.api_key = api_key
+
     def deliverEmail(
-        *,
-        sender: str,
-        dests: list[str],
-        cc: list[str],
-        bcc: list[str],
-        subject: str,
-        body: str,
-        headers: dict[str, str],
-        attachments: list[Attachment],
-        **kwargs: t.Any,
+            self,
+            *,
+            sender: str,
+            dests: list[str],
+            cc: list[str],
+            bcc: list[str],
+            subject: str,
+            body: str,
+            headers: dict[str, str],
+            attachments: list[Attachment],
+            **kwargs: t.Any,
     ) -> dict[str, str]:
         data = {
             "personalizations": [
                 personalization := {
-                    "to": [EmailTransportSendgrid.splitAddress(val) for val in dests],
+                    "to": [self.splitAddress(val) for val in dests],
                     "subject": subject,
                 }
             ],
-            "from": EmailTransportSendgrid.splitAddress(sender),
+            "from": self.splitAddress(sender),
             "content": [{
                 "type": "text/html",
                 "value": body,
@@ -683,9 +692,9 @@ class EmailTransportSendgrid(EmailTransport):
         }
 
         if cc:
-            personalization["cc"] = [EmailTransportSendgrid.splitAddress(val) for val in cc]
+            personalization["cc"] = [self.splitAddress(val) for val in cc]
         if bcc:
-            personalization["bcc"] = [EmailTransportSendgrid.splitAddress(val) for val in bcc]
+            personalization["bcc"] = [self.splitAddress(val) for val in bcc]
 
         if attachments:
             assert isinstance(attachments, list)
@@ -696,7 +705,7 @@ class EmailTransportSendgrid(EmailTransport):
                     "type": attachment["mimetype"],
                     "disposition": "attachment",
                 }
-                for attachment in map(EmailTransportSendInBlue.fetch_attachment, attachments)
+                for attachment in map(self.fetch_attachment, attachments)
             ]
 
         if headers:
@@ -706,7 +715,7 @@ class EmailTransportSendgrid(EmailTransport):
         req = requests.post(
             "https://api.sendgrid.com/v3/mail/send",
             headers={
-                "Authorization": f"Bearer {conf.email.sendgrid_api_key}",
+                "Authorization": f"Bearer {self.api_key}",
                 "Accept": "application/json"
             },
             json=data,
@@ -722,17 +731,17 @@ class EmailTransportAppengine(EmailTransport):
     """
 
     def deliverEmail(
-        self,
-        *,
-        sender: str,
-        dests: list[str],
-        cc: list[str],
-        bcc: list[str],
-        subject: str,
-        body: str,
-        headers: dict[str, str],
-        attachments: list[Attachment],
-        **kwargs: t.Any,
+            self,
+            *,
+            sender: str,
+            dests: list[str],
+            cc: list[str],
+            bcc: list[str],
+            subject: str,
+            body: str,
+            headers: dict[str, str],
+            attachments: list[Attachment],
+            **kwargs: t.Any,
     ) -> None:
         # need to build a silly dict because the google.appengine mail api doesn't accept None or empty values ...
         params = {

--- a/src/viur/core/email.py
+++ b/src/viur/core/email.py
@@ -171,8 +171,7 @@ class EmailTransport(ABC):
         if "filename" not in attachment:
             raise ValueError(f"Attachment {attachment} must have a filename")
         if not any(prop in attachment for prop in ("content", "file_key", "gcsfile")):
-            raise ValueError(
-                f"Attachment {attachment} must have content, file_key or gcsfile")
+            raise ValueError(f"Attachment {attachment} must have content, file_key or gcsfile")
         if "content" in attachment and not isinstance(attachment["content"], bytes):
             raise ValueError(f"Attachment content must be bytes, not {type(attachment['content'])}")
 
@@ -525,8 +524,7 @@ class EmailTransportBrevo(EmailTransport):
                 attachment = self.fetch_attachment(attachment)
                 dataDict["attachment"].append({
                     "name": attachment["filename"],
-                    "content": base64.b64encode(attachment["content"]).decode(
-                        "ASCII")
+                    "content": base64.b64encode(attachment["content"]).decode("ASCII")
                 })
         payload = json.dumps(dataDict).encode("UTF-8")
         headers = {

--- a/src/viur/core/modules/formmailer.py
+++ b/src/viur/core/modules/formmailer.py
@@ -34,13 +34,13 @@ class Formmailer(Module):
         # Get recipients
         rcpts = self.getRcpts(skel)
 
-        # Get additional options for sendEMail
+        # Get additional options for send_email
         opts = self.getOptions(skel)
         if not isinstance(opts, dict):
             opts = {}
 
         # Send the email!
-        email.sendEMail(dests=rcpts, tpl=self.mailTemplate, skel=skel, **opts)
+        email.send_email(dests=rcpts, tpl=self.mailTemplate, skel=skel, **opts)
         self.onAdded(skel)
 
         return self.render.addSuccess(skel)

--- a/src/viur/core/modules/user.py
+++ b/src/viur/core/modules/user.py
@@ -478,7 +478,7 @@ class UserPassword(UserPrimaryAuthentication):
         """
         if user_skel := self._user_module.viewSkel().all().filter("name.idx =", user_name).getSkel():
             user_agent = user_agents.parse(user_agent)
-            email.sendEMail(
+            email.send_email(
                 tpl=self.passwordRecoveryMail,
                 skel=user_skel,
                 dests=[user_name],
@@ -569,7 +569,7 @@ class UserPassword(UserPrimaryAuthentication):
                                       name=skel["name"])
             skel.skey = BaseBone(descr="Skey")
             skel["skey"] = skey
-            email.sendEMail(dests=[skel["name"]], tpl=self._user_module.verifyEmailAddressMail, skel=skel)
+            email.send_email(dests=[skel["name"]], tpl=self._user_module.verifyEmailAddressMail, skel=skel)
         self._user_module.onAdded(skel)  # Call onAdded on our parent user module
         return self._user_module.render.addSuccess(skel)
 

--- a/src/viur/core/skeleton.py
+++ b/src/viur/core/skeleton.py
@@ -1610,7 +1610,7 @@ class RebuildSearchIndex(QueryIter):
             f"{totalCount} records updated in total on this kind."
         )
         try:
-            email.sendEMail(dests=customData["notify"], stringTemplate=txt, skel=None)
+            email.send_email(dests=customData["notify"], stringTemplate=txt, skel=None)
         except Exception as exc:  # noqa; OverQuota, whatever
             logging.exception(f'Failed to notify {customData["notify"]}')
 
@@ -1682,7 +1682,7 @@ def processVacuumRelationsChunk(
             f"{count_removed} entries removed"
         )
         try:
-            email.sendEMail(dests=notify, stringTemplate=txt, skel=None)
+            email.send_email(dests=notify, stringTemplate=txt, skel=None)
         except Exception as exc:  # noqa; OverQuota, whatever
             logging.exception(f"Failed to notify {notify}")
 

--- a/src/viur/core/tasks.py
+++ b/src/viur/core/tasks.py
@@ -411,7 +411,7 @@ def retry_n_times(retries: int, email_recipients: None | str | list[str] = None,
                         signature = ", ".join(args_repr + kwargs_repr)
                         try:
                             from viur.core import email
-                            email.sendEMail(
+                            email.send_email(
                                 dests=email_recipients,
                                 tpl=tpl,
                                 stringTemplate=string_template if tpl is None else string_template,


### PR DESCRIPTION
This allows to store the credentials and other settings on the instance itself and reduce the config size.
Furthermore I think this is more pythonic, combines what belongs together and makes `abc` meaningful.

This a small **breaking change**.
Instead of 
```py
conf.email.mailjet_api_key = secret.get("api-mailjet-key")
conf.email.mailjet_api_secret = secret.get("api-mailjet-secret")
conf.email.transport_class = EmailTransportMailjet
```

you write now
```py
conf.email.transport_class = EmailTransportMailjet(
    api_key=secret.get("api-mailjet-key"),
    secret_key=secret.get("api-mailjet-secret"),
)
```

--- 
### Furthermore 
* Enforce pep8 compliant `snake_case` names as requested by @phorward 
* `email.sendEMail` is now `email.send_email`
* `email.sendEMailToAdmins` is now `email.send_email_to_admins`
* We use the [`deprecated`](https://deprecated.readthedocs.io/en/latest/) package, which is not working smooth as expected, but this can be done later ...
* Add and update a bunch of documentation
* Fixing not used `max_retries` variable
* Introduce some constants (so things can be changed with monkey patching or are clearly reserved and fixed names)

Resolves #813