### PR TITLE
fix: @access-decorator

### DIFF
--- a/src/viur/core/module.py
+++ b/src/viur/core/module.py
@@ -265,28 +265,30 @@ class Method:
 
                 raise errors.Unauthorized(self.access["message"]) if self.access["message"] else errors.Unauthorized()
 
-            ok = False
-            for acc in self.access["access"]:
-                if trace:
-                    logging.debug(f"@access checking {acc=}")
+            ok = "root" in user["access"]
 
-                # Callable directly tests access
-                if callable(acc):
-                    if acc():
+            if not ok and self.access["access"]:
+                for acc in self.access["access"]:
+                    if trace:
+                        logging.debug(f"@access checking {acc=}")
+
+                    # Callable directly tests access
+                    if callable(acc):
+                        if acc():
+                            ok = True
+                            break
+
+                        continue
+
+                    # Otherwise, check for access rights
+                    if isinstance(acc, str):
+                        acc = (acc, )
+
+                    assert isinstance(acc, (tuple, list, set))
+
+                    if all(a in user["access"] for a in acc):
                         ok = True
                         break
-
-                    continue
-
-                # Otherwise, check for access rights
-                if isinstance(acc, str):
-                    acc = (acc, )
-
-                assert isinstance(acc, (tuple, list, set))
-
-                if not set(acc).difference(user["access"]):
-                    ok = True
-                    break
 
             if trace:
                 logging.debug(f"@access {ok=}")


### PR DESCRIPTION
- "root" is always allowed to pass
- the set().difference() method check didn't work as expected, therefore changed to an all(a in user["access"]) check.