### PR TITLE
fix: Delete bones set to `None` from a Skeleton

### DIFF
--- a/src/viur/core/skeleton.py
+++ b/src/viur/core/skeleton.py
@@ -290,7 +290,10 @@ class SkeletonInstance:
 
     def __setattr__(self, key, value):
         if key in self.boneMap or isinstance(value, BaseBone):
-            self.boneMap[key] = value
+            if value is None:
+                del self.boneMap[key]
+            else:
+                self.boneMap[key] = value
         elif key == "renderPreparation":
             super().__setattr__(key, value)
             self.renderAccessedValues.clear()


### PR DESCRIPTION
This little function causes the ViUR system to break in different places, because a bone None-object cannot be procesed.

```py
    def addSkel(self):
        skel = super().addSkel().clone()
        skel.status = None
        return skel
```