### PR TITLE
feat: Make SkeletonInstance json serializable

### DIFF
--- a/src/viur/core/bones/json.py
+++ b/src/viur/core/bones/json.py
@@ -49,7 +49,7 @@ class JsonBone(RawBone):
         if isinstance(val, (str, bytes, bytearray)):
             return utils.json.loads(val)
 
-        return val
+        return utils.json.loads(utils.json.dumps(val))
 
     def singleValueFromClient(self, value: str | list | dict, skel, bone_name, client_data):
         if value:

--- a/src/viur/core/bones/json.py
+++ b/src/viur/core/bones/json.py
@@ -46,7 +46,10 @@ class JsonBone(RawBone):
         return utils.json.dumps(skel.accessedValues[name])
 
     def singleValueUnserialize(self, val):
-        return utils.json.loads(val)
+        if isinstance(val, (str, bytes, bytearray)):
+            return utils.json.loads(val)
+
+        return utils.json.loads(utils.json.dumps(val))
 
     def singleValueFromClient(self, value: str | list | dict, skel, bone_name, client_data):
         if value:

--- a/src/viur/core/bones/json.py
+++ b/src/viur/core/bones/json.py
@@ -48,8 +48,7 @@ class JsonBone(RawBone):
     def singleValueUnserialize(self, val):
         if isinstance(val, (str, bytes, bytearray)):
             return utils.json.loads(val)
-
-        return utils.json.loads(utils.json.dumps(val))
+        return val
 
     def singleValueFromClient(self, value: str | list | dict, skel, bone_name, client_data):
         if value:

--- a/src/viur/core/bones/json.py
+++ b/src/viur/core/bones/json.py
@@ -49,7 +49,7 @@ class JsonBone(RawBone):
         if isinstance(val, (str, bytes, bytearray)):
             return utils.json.loads(val)
 
-        return utils.json.loads(utils.json.dumps(val))
+        return val
 
     def singleValueFromClient(self, value: str | list | dict, skel, bone_name, client_data):
         if value:

--- a/src/viur/core/render/json/default.py
+++ b/src/viur/core/render/json/default.py
@@ -1,5 +1,4 @@
 import json
-import logging
 from enum import Enum
 
 from viur.core import bones, utils, db, current

--- a/src/viur/core/render/json/default.py
+++ b/src/viur/core/render/json/default.py
@@ -24,6 +24,8 @@ class CustomJsonEncoder(json.JSONEncoder):
             return db.encodeKey(o)
         elif isinstance(o, Enum):
             return o.value
+        elif isinstance(o, set):
+            return tuple(o)
         return json.JSONEncoder.default(self, o)
 
 

--- a/src/viur/core/render/json/default.py
+++ b/src/viur/core/render/json/default.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from enum import Enum
 
 from viur.core import bones, utils, db, current
@@ -16,6 +17,7 @@ class CustomJsonEncoder(json.JSONEncoder):
     """
 
     def default(self, o: t.Any) -> t.Any:
+
         if isinstance(o, translate):
             return str(o)
         elif isinstance(o, datetime):
@@ -26,6 +28,8 @@ class CustomJsonEncoder(json.JSONEncoder):
             return o.value
         elif isinstance(o, set):
             return tuple(o)
+        elif isinstance(o, SkeletonInstance):
+            return {bone_name: o[bone_name] for bone_name in o}
         return json.JSONEncoder.default(self, o)
 
 

--- a/src/viur/core/utils/json.py
+++ b/src/viur/core/utils/json.py
@@ -47,7 +47,7 @@ class ViURJsonEncoder(json.JSONEncoder):
         elif isinstance(obj, (list, tuple)):
             return tuple(ViURJsonEncoder.preprocess(value) for value in obj)
 
-        elif hasattr(obj, "boneMap"):  # SkeletonInstance
+        elif hasattr(obj, "__class__") and obj.__class__.__name__ == "SkeletonInstance":  # SkeletonInstance
             return {bone_name: ViURJsonEncoder.preprocess(obj[bone_name]) for bone_name in obj}
 
         return obj

--- a/src/viur/core/utils/json.py
+++ b/src/viur/core/utils/json.py
@@ -47,6 +47,9 @@ class ViURJsonEncoder(json.JSONEncoder):
         elif isinstance(obj, (list, tuple)):
             return tuple(ViURJsonEncoder.preprocess(value) for value in obj)
 
+        elif hasattr(obj, "boneMap"):  # SkeletonInstance
+            return  {bone_name:  ViURJsonEncoder.preprocess(obj[bone_name]) for bone_name in obj}
+
         return obj
 
 
@@ -74,8 +77,7 @@ def _decode_object_hook(obj: t.Any):
         elif items := obj.get(".__set__"):
             return set(items)
 
-    elif len(obj) == 2 and all(k in obj for k in (".__entity__", ".__key__")):
-        # TODO: Handle SkeletonInstance as well?
+    elif len(obj) == 2 and  all(k in obj for k in (".__entity__", ".__key__")):
         entity = db.Entity(db.Key.from_legacy_urlsafe(obj[".__key__"]) if obj[".__key__"] else None)
         entity.update(obj[".__entity__"])
         return entity

--- a/src/viur/core/utils/json.py
+++ b/src/viur/core/utils/json.py
@@ -48,7 +48,7 @@ class ViURJsonEncoder(json.JSONEncoder):
             return tuple(ViURJsonEncoder.preprocess(value) for value in obj)
 
         elif hasattr(obj, "boneMap"):  # SkeletonInstance
-            return  {bone_name:  ViURJsonEncoder.preprocess(obj[bone_name]) for bone_name in obj}
+            return {bone_name: ViURJsonEncoder.preprocess(obj[bone_name]) for bone_name in obj}
 
         return obj
 
@@ -77,7 +77,7 @@ def _decode_object_hook(obj: t.Any):
         elif items := obj.get(".__set__"):
             return set(items)
 
-    elif len(obj) == 2 and  all(k in obj for k in (".__entity__", ".__key__")):
+    elif len(obj) == 2 and all(k in obj for k in (".__entity__", ".__key__")):
         entity = db.Entity(db.Key.from_legacy_urlsafe(obj[".__key__"]) if obj[".__key__"] else None)
         entity.update(obj[".__entity__"])
         return entity


### PR DESCRIPTION
This PR is a fix for #1092 and makes SkeletonInstances now json serializable.
Like:
```python
def get_skel():
	skel = conf.main_app.country.viewSkel()
	skel.fromDB("agxoaWVyLWdpYnQtZXNyFQsSDm5pY2h0c196dXNlaGVuGLkKDA")
	return skel

foo=JsonBone(compute=Compute(fn=get_skel,interval=ComputeInterval(ComputeMethod.OnWrite),raw=True))
```
Now get in json render 

```json
"c_s": {
               "key": "agxoaWVyLWdpYnQtZXNyFQsSDm5pY2h0c196dXNlaGVuGLkKDA",
                "name": null,
                "creationdate": "2022-10-05T06:20:38+00:00",
                "changedate": "2024-02-05T13:20:46+00:00",
                "viurCurrentSeoKeys": {
                    "de": "4757066702913536",
                    "_viurLanguageWrapper_": true,
                    "en": "4757066702913536"
                },
                "country": "Nauru",
                "continent": "Oceania",
                "sortindex": 1664950838.329367
            }
```
