### PR TITLE
fix: Cast category to str() for ascii check

### DIFF
--- a/src/viur/core/render/html/env/viur.py
+++ b/src/viur/core/render/html/env/viur.py
@@ -635,7 +635,7 @@ def renderEditForm(render: Render,
 
         res += sectionTpl.render(
             categoryName=category,
-            categoryClassName="".join([x for x in str(category) if x in string.ascii_letters]),
+            categoryClassName="".join(ch for ch in str(category) if ch in string.ascii_letters),
             categoryContent=categoryContent,
             allReadOnly=allReadOnly,
             allHidden=allHidden

--- a/src/viur/core/render/html/env/viur.py
+++ b/src/viur/core/render/html/env/viur.py
@@ -635,7 +635,7 @@ def renderEditForm(render: Render,
 
         res += sectionTpl.render(
             categoryName=category,
-            categoryClassName="".join([x for x in category if x in string.ascii_letters]),
+            categoryClassName="".join([x for x in str(category) if x in string.ascii_letters]),
             categoryContent=categoryContent,
             allReadOnly=allReadOnly,
             allHidden=allHidden


### PR DESCRIPTION
Fix the error
```
File "/home/foo/.local/share/virtualenvs/bessershop-0UKlbQ2G/lib/python3.12/site-packages/viur/core/render/html/env/viur.py", line 638, in renderEditForm
    categoryClassName="".join([x for x in category if x in string.ascii_letters]),
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: 'translate' object is not iterable
```