### PR TITLE
refactor: `Skeleton`-API rework

### DIFF
--- a/src/viur/core/bones/base.py
+++ b/src/viur/core/bones/base.py
@@ -1329,7 +1329,7 @@ class BaseBone(object):
 
             if issubclass(skel.skeletonCls, RefSkel):  # we have a ref skel we must load the complete skeleton
                 cloned_skel = skeletonByKind(skel.kindName)()
-                cloned_skel.fromDB(skel["key"])
+                cloned_skel.read(skel["key"])
             else:
                 cloned_skel = skel.clone()
             cloned_skel[bone_name] = None  # remove value form accessedValues to avoid endless recursion

--- a/src/viur/core/bones/file.py
+++ b/src/viur/core/bones/file.py
@@ -38,7 +38,7 @@ def ensureDerived(key: db.Key, srcKey, deriveMap: dict[str, t.Any], refreshKey: 
     from viur.core.skeleton import skeletonByKind, updateRelations
     deriveFuncMap = conf.file_derivations
     skel = skeletonByKind("file")()
-    if not skel.fromDB(key):
+    if not skel.read(key):
         logging.info("File-Entry went missing in ensureDerived")
         return
     if not skel["derived"]:
@@ -88,10 +88,10 @@ def ensureDerived(key: db.Key, srcKey, deriveMap: dict[str, t.Any], refreshKey: 
         if refreshKey:
             def refreshTxn():
                 skel = skeletonByKind(refreshKey.kind)()
-                if not skel.fromDB(refreshKey):
+                if not skel.read(refreshKey):
                     return
                 skel.refresh()
-                skel.toDB(update_relations=False)
+                skel.write(update_relations=False)
 
             db.RunInTransaction(refreshTxn)
 
@@ -268,7 +268,7 @@ class FileBone(TreeLeafBone):
         def recreateFileEntryIfNeeded(val):
             # Recreate the (weak) filenetry referenced by the relation *val*. (ViUR2 might have deleted them)
             skel = skeletonByKind("file")()
-            if skel.fromDB(val["key"]):  # This file-object exist, no need to recreate it
+            if skel.read(val["key"]):  # This file-object exist, no need to recreate it
                 return
             skel["key"] = val["key"]
             skel["name"] = val["name"]
@@ -279,7 +279,7 @@ class FileBone(TreeLeafBone):
             skel["height"] = val["height"]
             skel["weak"] = True
             skel["pending"] = False
-            k = skel.toDB()
+            k = skel.write()
 
         from viur.core.modules.file import importBlobFromViur2
         super().refresh(skel, boneName)

--- a/src/viur/core/i18n.py
+++ b/src/viur/core/i18n.py
@@ -425,7 +425,7 @@ def add_missing_translation(
     skel["usage_lineno"] = lineno
     skel["usage_variables"] = variables or []
     skel["creator"] = Creator.VIUR
-    skel.toDB()
+    skel.write()
 
     # Add to system translation to avoid triggering this method again
     systemTranslations[key] = {
@@ -456,7 +456,7 @@ def migrate_translation(
     skel.setEntity(entity)
     skel["key"] = key
     try:
-        skel.toDB()
+        skel.write()
     except ValueError as exc:
         logging.exception(exc)
         if "unique value" in exc.args[0] and "recently claimed" in exc.args[0]:

--- a/src/viur/core/modules/moduleconf.py
+++ b/src/viur/core/modules/moduleconf.py
@@ -142,7 +142,7 @@ class ModuleConf(List):
     def get_by_module_name(cls, module_name: str) -> None | skeleton.SkeletonInstance:
         db_key = db.Key(MODULECONF_KINDNAME, module_name)
         skel = conf.main_app.vi._moduleconf.viewSkel()
-        if not skel.fromDB(db_key):
+        if not skel.read(db_key):
             logging.error(f"module({module_name}) not found")
             return None
 
@@ -178,7 +178,7 @@ class ModuleConf(List):
                     skel = conf.main_app.vi._moduleconf.addSkel()
                     skel["key"] = db.Key(MODULECONF_KINDNAME, module_name)
                     skel["name"] = module_name
-                    skel.toDB()
+                    skel.write()
 
                 # Collect children
                 collect_modules(module, depth=depth + 1, prefix=f"{module_name}.")

--- a/src/viur/core/modules/script.py
+++ b/src/viur/core/modules/script.py
@@ -138,7 +138,7 @@ class Script(Tree):
             # only update when path changed
             if new_path != skel["path"]:
                 skel["path"] = new_path  # self.onEdit() is NOT required, as it resolves the path again.
-                skel.toDB()
+                skel.write()
                 self.onEdited(skel_type, skel)  # triggers this recursion for nodes, again.
 
         if cursor := query.getCursor():
@@ -153,7 +153,7 @@ class Script(Tree):
         key = skel["parententry"]
         while key:
             parent_skel = self.viewSkel("node")
-            if not parent_skel.fromDB(key) or parent_skel["key"] == skel["parentrepo"]:
+            if not parent_skel.read(key) or parent_skel["key"] == skel["parentrepo"]:
                 break
 
             path.insert(0, parent_skel["name"])

--- a/src/viur/core/modules/translation.py
+++ b/src/viur/core/modules/translation.py
@@ -109,10 +109,10 @@ class TranslationSkel(Skeleton):
     )
 
     @classmethod
-    def toDB(cls, skelValues: SkeletonInstance, **kwargs) -> db.Key:
+    def write(cls, skelValues: SkeletonInstance, **kwargs) -> db.Key:
         # Ensure we have only lowercase keys
         skelValues["tr_key"] = skelValues["tr_key"].lower()
-        return super().toDB(skelValues, **kwargs)
+        return super().write(skelValues, **kwargs)
 
     @classmethod
     def preProcessSerializedData(cls, skelValues: SkeletonInstance, entity: db.Entity) -> db.Entity:

--- a/src/viur/core/modules/user.py
+++ b/src/viur/core/modules/user.py
@@ -138,7 +138,7 @@ class UserSkel(skeleton.Skeleton):
         return super().__new__(cls)
 
     @classmethod
-    def toDB(cls, skel, *args, **kwargs):
+    def write(cls, skel, *args, **kwargs):
         # Roles
         if skel["roles"] and "custom" not in skel["roles"]:
             # Collect access rights through rules
@@ -178,7 +178,7 @@ class UserSkel(skeleton.Skeleton):
 
             skel["access"] = list(access)
 
-        return super().toDB(skel, *args, **kwargs)
+        return super().write(skel, *args, **kwargs)
 
 
 class UserAuthentication(Module, abc.ABC):
@@ -355,7 +355,7 @@ class UserPassword(UserPrimaryAuthentication):
             # re-hash the password with more iterations
             # FIXME: This must be done within a transaction!
             user_skel["password"] = password  # will be hashed on serialize
-            user_skel.toDB(update_relations=False)
+            user_skel.write(update_relations=False)
 
         return self.next_or_finish(user_skel)
 
@@ -461,7 +461,7 @@ class UserPassword(UserPrimaryAuthentication):
 
         # Update the password, save the user, reset his session and show the success-template
         user_skel["password"] = skel["password"]
-        user_skel.toDB(update_relations=False)
+        user_skel.write(update_relations=False)
 
         return self._user_module.render.view(
             None,
@@ -496,12 +496,12 @@ class UserPassword(UserPrimaryAuthentication):
     def verify(self, data):
         def transact(key):
             skel = self._user_module.editSkel()
-            if not key or not skel.fromDB(key):
+            if not key or not skel.read(key):
                 return None
             skel["status"] = Status.WAITING_FOR_ADMIN_VERIFICATION \
                 if self.registrationAdminVerificationRequired else Status.ACTIVE
 
-            skel.toDB(update_relations=False)
+            skel.write(update_relations=False)
             return skel
 
         if not isinstance(data, dict) or not (skel := db.RunInTransaction(transact, data.get("user_key"))):
@@ -562,7 +562,7 @@ class UserPassword(UserPrimaryAuthentication):
             # render the skeleton in the version it could as far as it could be read.
             return self._user_module.render.add(skel)
         self._user_module.onAdd(skel)
-        skel.toDB()
+        skel.write()
         if self.registrationEmailVerificationRequired and skel["status"] == Status.WAITING_FOR_EMAIL_VERIFICATION:
             # The user will have to verify his email-address. Create a skey and send it to his address
             skey = securitykey.create(duration=datetime.timedelta(days=7), session_bound=False,
@@ -671,7 +671,7 @@ class GoogleAccount(UserPrimaryAuthentication):
                     update = True
 
         if update:
-            assert user_skel.toDB()
+            assert user_skel.write()
 
         return self.next_or_finish(user_skel)
 
@@ -793,7 +793,7 @@ class TimeBasedOTP(UserSecondFactorAuthentication):
             )
 
         user_skel = self._user_module.baseSkel()
-        if not user_skel.fromDB(user_key):
+        if not user_skel.read(user_key):
             raise errors.NotFound("The previously authenticated user is gone.")
 
         if not (otp_user_conf := self.get_config(user_skel)):
@@ -1328,7 +1328,7 @@ class User(List):
         """
         skel = self.baseSkel()
 
-        if not skel.fromDB(user_key):
+        if not skel.read(user_key):
             raise errors.NotFound("User was not found.")
 
         if not provider.can_handle(skel):
@@ -1390,7 +1390,7 @@ class User(List):
             :param key: The (DB-)Key of the user we shall authenticate
         """
         skel = self.baseSkel()
-        if not skel.fromDB(key):
+        if not skel.read(key):
             raise ValueError(f"Unable to authenticate unknown user {key}")
 
         # Verify that this user account is active
@@ -1452,7 +1452,7 @@ class User(List):
             # Conserve DB-Writes: Update the user max once in 30 Minutes (why??)
             if not skel["lastlogin"] or ((now - skel["lastlogin"]) > datetime.timedelta(minutes=30)):
                 skel["lastlogin"] = now
-                skel.toDB(update_relations=False)
+                skel.write(update_relations=False)
 
         logging.info(f"""User {skel["name"]} logged in""")
 
@@ -1540,7 +1540,7 @@ class User(List):
             raise errors.Unauthorized()
 
         skel = self.baseSkel()
-        if not skel.fromDB(key):
+        if not skel.read(key):
             raise errors.NotFound()
 
         match action:
@@ -1593,7 +1593,7 @@ def createNewUserIfNotExists():
             addSkel["password"] = pw
 
             try:
-                addSkel.toDB()
+                addSkel.write()
             except Exception as e:
                 logging.critical(f"Something went wrong when trying to add admin user {uname!r} with Password {pw!r}")
                 logging.exception(e)

--- a/src/viur/core/prototypes/list.py
+++ b/src/viur/core/prototypes/list.py
@@ -157,7 +157,7 @@ class List(SkelModule):
             :raises: :exc:`viur.core.errors.Unauthorized`, if the current user does not have the required permissions.
         """
         skel = self.viewSkel()
-        if not skel.fromDB(key):
+        if not skel.read(key):
             raise errors.NotFound()
 
         if not self.canView(skel):
@@ -239,7 +239,7 @@ class List(SkelModule):
             :raises: :exc:`viur.core.errors.PreconditionFailed`, if the *skey* could not be verified.
         """
         skel = self.editSkel()
-        if not skel.fromDB(key):
+        if not skel.read(key):
             raise errors.NotFound()
 
         if not self.canEdit(skel):
@@ -255,7 +255,7 @@ class List(SkelModule):
             return self.render.edit(skel)
 
         self.onEdit(skel)
-        skel.toDB()  # write it!
+        skel.write()  # write it!
         self.onEdited(skel)
 
         return self.render.editSuccess(skel)
@@ -292,7 +292,7 @@ class List(SkelModule):
             return self.render.add(skel)
 
         self.onAdd(skel)
-        skel.toDB()
+        skel.write()
         self.onAdded(skel)
 
         return self.render.addSuccess(skel)
@@ -316,7 +316,7 @@ class List(SkelModule):
             :raises: :exc:`viur.core.errors.PreconditionFailed`, if the *skey* could not be verified.
         """
         skel = self.editSkel()
-        if not skel.fromDB(key):
+        if not skel.read(key):
             raise errors.NotFound()
 
         if not self.canDelete(skel):
@@ -382,7 +382,7 @@ class List(SkelModule):
         """
 
         skel = self.cloneSkel()
-        if not skel.fromDB(key):
+        if not skel.read(key):
             raise errors.NotFound()
 
         # a clone-operation is some kind of edit and add...
@@ -404,7 +404,7 @@ class List(SkelModule):
             return self.render.edit(skel, action="clone")
 
         self.onClone(skel, src_skel=src_skel)
-        assert skel.toDB()
+        assert skel.write()
         self.onCloned(skel, src_skel=src_skel)
 
         return self.render.editSuccess(skel, action="cloneSuccess")

--- a/src/viur/core/prototypes/singleton.py
+++ b/src/viur/core/prototypes/singleton.py
@@ -110,7 +110,7 @@ class Singleton(SkelModule):
 
         key = db.Key(self.editSkel().kindName, self.getKey())
 
-        if not skel.fromDB(key):
+        if not skel.read(key):
             raise errors.NotFound()
 
         self.onView(skel)
@@ -139,7 +139,7 @@ class Singleton(SkelModule):
 
         key = db.Key(self.editSkel().kindName, self.getKey())
         skel = self.editSkel()
-        if not skel.fromDB(key):  # Its not there yet; we need to set the key again
+        if not skel.read(key):  # Its not there yet; we need to set the key again
             skel["key"] = key
 
         if (
@@ -151,7 +151,7 @@ class Singleton(SkelModule):
             return self.render.edit(skel)
 
         self.onEdit(skel)
-        skel.toDB()
+        skel.write()
         self.onEdited(skel)
         return self.render.editSuccess(skel)
 
@@ -164,7 +164,7 @@ class Singleton(SkelModule):
         skel = self.viewSkel()
         key = db.Key(self.viewSkel().kindName, self.getKey())
 
-        if not skel.fromDB(key):
+        if not skel.read(key):
             return None
 
         return skel

--- a/src/viur/core/render/html/env/viur.py
+++ b/src/viur/core/render/html/env/viur.py
@@ -173,7 +173,7 @@ def getSkel(render: Render, module: str, key: str = None, skel: str = "viewSkel"
             return False
 
         if "canView" in dir(obj):
-            if not skel.fromDB(key):
+            if not skel.read(key):
                 logging.info(f"getSkel: Entry {key} not found")
                 return None
             if isinstance(obj, prototypes.singleton.Singleton):
@@ -201,7 +201,7 @@ def getSkel(render: Render, module: str, key: str = None, skel: str = "viewSkel"
                 return None
 
         else:  # No Access-Test for this module
-            if not skel.fromDB(key):
+            if not skel.read(key):
                 return None
         skel.renderPreparation = render.renderBoneValue
         return skel

--- a/src/viur/core/skeleton.py
+++ b/src/viur/core/skeleton.py
@@ -35,6 +35,7 @@ from viur.core.tasks import CallDeferred, CallableTask, CallableTaskBase, QueryI
 
 _UNDEFINED = object()
 ABSTRACT_SKEL_CLS_SUFFIX = "AbstractSkel"
+KeyType: t.TypeAlias = db.Key | str | int
 
 
 class MetaBaseSkel(type):
@@ -970,7 +971,7 @@ class Skeleton(BaseSkeleton, metaclass=MetaSkel):
         return complete
 
     @classmethod
-    def fromDB(cls, skel: SkeletonInstance, key: db.Key | int | str) -> bool:
+    def fromDB(cls, skel: SkeletonInstance, key: KeyType) -> bool:
         """
         Deprecated function, replaced by Skeleton.read().
         """
@@ -978,7 +979,7 @@ class Skeleton(BaseSkeleton, metaclass=MetaSkel):
         return bool(cls.read(skel, key))
 
     @classmethod
-    def read(cls, skel: SkeletonInstance, key: db.Key | int | str) -> t.Optional[SkeletonInstance]:
+    def read(cls, skel: SkeletonInstance, key: KeyType) -> t.Optional[SkeletonInstance]:
         """
             Read entity with *key* from the datastore into the Skeleton.
 

--- a/src/viur/core/skeleton.py
+++ b/src/viur/core/skeleton.py
@@ -9,6 +9,7 @@ import string
 import sys
 import typing as t
 import warnings
+from deprecated.sphinx import deprecated
 from functools import partial
 from itertools import chain
 from time import time
@@ -971,11 +972,15 @@ class Skeleton(BaseSkeleton, metaclass=MetaSkel):
         return complete
 
     @classmethod
+    @deprecated(
+        version="3.7.0",
+        reason="Use skel.read() instead of skel.fromDB()",
+        action="always"
+    )
     def fromDB(cls, skel: SkeletonInstance, key: KeyType) -> bool:
         """
         Deprecated function, replaced by Skeleton.read().
         """
-        logging.warning("skel.fromDB() is deprecated, use skel.read()")
         return bool(cls.read(skel, key))
 
     @classmethod
@@ -1008,23 +1013,25 @@ class Skeleton(BaseSkeleton, metaclass=MetaSkel):
         return skel
 
     @classmethod
+    @deprecated(
+        version="3.7.0",
+        reason="Use skel.write() instead of skel.toDB()",
+        action="always"
+    )
     def toDB(cls, skel: SkeletonInstance, update_relations: bool = True, **kwargs) -> db.Key:
         """
         Deprecated function, replaced by Skeleton.write().
         """
-        logging.warning("skel.toDB() is deprecated, use skel.write()")
-
-        # fixme: Remove in viur-core >= 4
         if "clearUpdateTag" in kwargs:
             msg = "clearUpdateTag was replaced by update_relations"
             warnings.warn(msg, DeprecationWarning, stacklevel=3)
             logging.warning(msg, stacklevel=3)
             update_relations = not kwargs["clearUpdateTag"]
 
-        return cls.write(skel, update_relations)
+        return cls.write(skel, update_relations=update_relations)
 
     @classmethod
-    def write(cls, skel: SkeletonInstance, update_relations: bool = True) -> db.Key:
+    def write(cls, skel: SkeletonInstance, *, update_relations: bool = True) -> db.Key:
         """
             Write current Skeleton entity to the datastore.
 

--- a/src/viur/core/skeleton.py
+++ b/src/viur/core/skeleton.py
@@ -975,10 +975,10 @@ class Skeleton(BaseSkeleton, metaclass=MetaSkel):
         Deprecated function, replaced by Skeleton.read().
         """
         logging.warning("skel.fromDB() is deprecated, use skel.read()")
-        return cls.read(skel, key)
+        return bool(cls.read(skel, key))
 
     @classmethod
-    def read(cls, skel: SkeletonInstance, key: db.Key | int | str) -> bool:
+    def read(cls, skel: SkeletonInstance, key: db.Key | int | str) -> t.Optional[SkeletonInstance]:
         """
             Read entity with *key* from the datastore into the Skeleton.
 
@@ -990,20 +990,20 @@ class Skeleton(BaseSkeleton, metaclass=MetaSkel):
 
             :param key: A :class:`viur.core.DB.Key`, string, or int; from which the data shall be fetched.
 
-            :returns: True on success; False if the given key could not be found or can not be parsed.
+            :returns: None on error, or the given SkeletonInstance on success.
 
         """
         assert skel.renderPreparation is None, "Cannot modify values while rendering"
         try:
             db_key = db.keyHelper(key, skel.kindName)
         except ValueError:  # This key did not parse
-            return False
+            return None
 
         if not (db_res := db.Get(db_key)):
-            return False
+            return None
 
         skel.setEntity(db_res)
-        return True
+        return skel
 
     @classmethod
     def toDB(cls, skel: SkeletonInstance, update_relations: bool = True, **kwargs) -> db.Key:

--- a/src/viur/core/skeleton.py
+++ b/src/viur/core/skeleton.py
@@ -986,7 +986,8 @@ class Skeleton(BaseSkeleton, metaclass=MetaSkel):
     @classmethod
     def read(cls, skel: SkeletonInstance, key: t.Optional[KeyType] = None) -> t.Optional[SkeletonInstance]:
         """
-            Read entity with *key* from the datastore into the Skeleton.
+            Read Skeleton with *key* from the datastore into the Skeleton.
+            If not key is given, skel["key"] will be used.
 
             Reads all available data of entity kind *kindName* and the key *key*
             from the Datastore into the Skeleton structure's bones. Any previous
@@ -1041,7 +1042,7 @@ class Skeleton(BaseSkeleton, metaclass=MetaSkel):
         update_relations: bool = True
     ) -> SkeletonInstance:
         """
-            Write current Skeleton entity to the datastore.
+            Write current Skeleton to the datastore.
 
             Stores the current data of this instance into the database.
             If an *key* value is set to the object, this entity will ne updated;
@@ -1053,7 +1054,7 @@ class Skeleton(BaseSkeleton, metaclass=MetaSkel):
             :param update_relations: If False, this entity won't be marked dirty;
                 This avoids from being fetched by the background task updating relations.
 
-            :returns: The datastore key of the entity.
+            :returns: The Skeleton.
         """
         assert skel.renderPreparation is None, "Cannot modify values while rendering"
 

--- a/src/viur/core/skeleton.py
+++ b/src/viur/core/skeleton.py
@@ -1380,7 +1380,6 @@ class Skeleton(BaseSkeleton, metaclass=MetaSkel):
         for adapter in skel.database_adapters:
             adapter.delete(skel)
 
-
     @classmethod
     def preProcessBlobLocks(cls, skel: SkeletonInstance, locks):
         """

--- a/src/viur/core/skeleton.py
+++ b/src/viur/core/skeleton.py
@@ -979,7 +979,7 @@ class Skeleton(BaseSkeleton, metaclass=MetaSkel):
         return bool(cls.read(skel, key))
 
     @classmethod
-    def read(cls, skel: SkeletonInstance, key: KeyType) -> t.Optional[SkeletonInstance]:
+    def read(cls, skel: SkeletonInstance, key: t.Optional[KeyType] = None) -> t.Optional[SkeletonInstance]:
         """
             Read entity with *key* from the datastore into the Skeleton.
 
@@ -995,8 +995,9 @@ class Skeleton(BaseSkeleton, metaclass=MetaSkel):
 
         """
         assert skel.renderPreparation is None, "Cannot modify values while rendering"
+
         try:
-            db_key = db.keyHelper(key, skel.kindName)
+            db_key = db.keyHelper(key or skel["key"], skel.kindName)
         except ValueError:  # This key did not parse
             return None
 


### PR DESCRIPTION
- [x] Rename `Skeleton.toDB()` into `Skeleton.write()`
- [x] Rename `Skeleton.fromDB()` into `Skeleton.read()`
- [x] Rename any `skelValues` variable into `skel`
- [x] Clean-up `Skeleton.delete()`
- [x] Improve `Skeleton.read()`, `Skeleton.write()` and `Skeleton.delete()` to accept key-parameter
- [x] Deprecation handling
- [x] Added support for legacy fromDB/toDB definitions in project-specific Skeletons

This pull request is a first, backward-compatible milestone on #630.