### PR TITLE
fix: `RelationalBone.singleValueFromClient` str-cast

### DIFF
--- a/src/viur/core/bones/relational.py
+++ b/src/viur/core/bones/relational.py
@@ -666,7 +666,9 @@ class RelationalBone(BaseBone):
         else:
             destKey = value
             usingData = None
-        assert isinstance(destKey, str)
+
+        destKey = str(destKey)
+
         refSkel, usingSkel, errors = restoreSkels(destKey, usingData)
         if refSkel:
             resVal = {"dest": refSkel, "rel": usingSkel}


### PR DESCRIPTION
singleValueFromClient is always a function working with str data. In this case, I wanted to provide a db.Key through a fromClient function, which raised an AssertionError. Why the heck. This always converts the key to a str. In case the key is invalid, if will fail later on.