### PR TITLE
feat: Load Session only when needed

### DIFF
--- a/src/viur/core/config.py
+++ b/src/viur/core/config.py
@@ -596,7 +596,7 @@ class User(ConfigType):
     session_persistent_fields_on_login: Multiple[str] = ["language"]
     """If set, these Fields will survive the session.reset() called on user/login"""
 
-    session_persistent_fields_on_logout: Multiple[str] = []
+    session_persistent_fields_on_logout: Multiple[str] = ["language"]
     """If set, these Fields will survive the session.reset() called on user/logout"""
 
     max_password_length: int = 512

--- a/src/viur/core/config.py
+++ b/src/viur/core/config.py
@@ -544,11 +544,12 @@ class I18N(ConfigType):
     language_alias_map: dict[str, str] = {}
     """Allows mapping of certain languages to one translation (i.e. us->en)"""
 
-    language_method: t.Literal["session", "url", "domain"] = "session"
+    language_method: t.Literal["session", "url", "domain","header"] = "session"
     """Defines how translations are applied:
         - session: Per Session
         - url: inject language prefix in url
         - domain: one domain per language
+        - header: Per Http-Header
     """
 
     language_module_map: dict[str, dict[str, str]] = {}

--- a/src/viur/core/config.py
+++ b/src/viur/core/config.py
@@ -544,7 +544,7 @@ class I18N(ConfigType):
     language_alias_map: dict[str, str] = {}
     """Allows mapping of certain languages to one translation (i.e. us->en)"""
 
-    language_method: t.Literal["session", "url", "domain","header"] = "session"
+    language_method: t.Literal["session", "url", "domain", "header"] = "session"
     """Defines how translations are applied:
         - session: Per Session
         - url: inject language prefix in url

--- a/src/viur/core/config.py
+++ b/src/viur/core/config.py
@@ -594,7 +594,7 @@ class User(ConfigType):
     session_persistent_fields_on_login: Multiple[str] = ["language"]
     """If set, these Fields will survive the session.reset() called on user/login"""
 
-    session_persistent_fields_on_logout: Multiple[str] = ["language"]
+    session_persistent_fields_on_logout: Multiple[str] = []
     """If set, these Fields will survive the session.reset() called on user/logout"""
 
     max_password_length: int = 512

--- a/src/viur/core/modules/user.py
+++ b/src/viur/core/modules/user.py
@@ -1315,7 +1315,7 @@ class User(List):
     def getCurrentUser(self):
         session = current.session.get()
 
-        if session and (user := session.get("user")):
+        if session and session.loaded and (user := session.get("user")):
             skel = self.baseSkel()
             skel.setEntity(user)
             return skel

--- a/src/viur/core/modules/user.py
+++ b/src/viur/core/modules/user.py
@@ -1428,9 +1428,11 @@ class User(List):
         self.onLogout(user)
 
         session = current.session.get()
-        take_over = {k: v for k, v in session.items() if k in conf.user.session_persistent_fields_on_logout}
-        session.reset()
-        session |= take_over
+        if take_over := {k: v for k, v in session.items() if k in conf.user.session_persistent_fields_on_logout}:
+            session.reset()
+            session |= take_over
+        else:
+            session.clear()
         current.user.set(None)  # set user to none in context var
         return self.render.logoutSuccess()
 

--- a/src/viur/core/request.py
+++ b/src/viur/core/request.py
@@ -235,7 +235,7 @@ class Router:
                     if lang in conf.i18n.available_languages or lang in conf.i18n.language_alias_map:
                         current.language.set(lang)
         elif conf.i18n.language_method == "header":
-            if lang:=get_language_from_header():
+            if lang := get_language_from_header():
                 current.language.set(lang)
 
         return path

--- a/src/viur/core/request.py
+++ b/src/viur/core/request.py
@@ -7,6 +7,7 @@
 """
 import fnmatch
 import json
+from deprecated.sphinx import deprecated
 import logging
 import os
 import time
@@ -323,7 +324,7 @@ class Router:
             return
 
         try:
-            current.session.get().load(self)
+            current.session.get().load()
 
             # Load current user into context variable if user module is there.
             if user_mod := getattr(conf.main_app.vi, "user", None):
@@ -419,7 +420,7 @@ class Router:
             self.response.write(res.encode("UTF-8"))
 
         finally:
-            self.saveSession()
+            current.session.get().save()
             if conf.instance.is_dev_server and conf.debug.dev_server_cloud_logging:
                 # Emit the outer log only on dev_appserver (we'll use the existing request log when live)
                 SEVERITY = "DEBUG"
@@ -604,9 +605,9 @@ class Router:
         if not isinstance(res, bytes):  # Convert the result to bytes if it is not already!
             res = str(res).encode("UTF-8")
         self.response.write(res)
-
+    @deprecated(version="3.7.0", reason="Use current.session.get().save() instead", action="always")
     def saveSession(self) -> None:
-        current.session.get().save(self)
+        current.session.get().save()
 
 
 from .i18n import translate  # noqa: E402

--- a/src/viur/core/request.py
+++ b/src/viur/core/request.py
@@ -605,6 +605,7 @@ class Router:
         if not isinstance(res, bytes):  # Convert the result to bytes if it is not already!
             res = str(res).encode("UTF-8")
         self.response.write(res)
+
     @deprecated(version="3.7.0", reason="Use current.session.get().save() instead", action="always")
     def saveSession(self) -> None:
         current.session.get().save()

--- a/src/viur/core/request.py
+++ b/src/viur/core/request.py
@@ -7,7 +7,6 @@
 """
 import fnmatch
 import json
-from deprecated.sphinx import deprecated
 import logging
 import os
 import time
@@ -606,7 +605,6 @@ class Router:
             res = str(res).encode("UTF-8")
         self.response.write(res)
 
-    @deprecated(version="3.7.0", reason="Use current.session.get().save() instead", action="always")
     def saveSession(self) -> None:
         current.session.get().save()
 

--- a/src/viur/core/request.py
+++ b/src/viur/core/request.py
@@ -160,32 +160,64 @@ class Router:
             conf.i18n.language_method, we'll either try to load it from the session, determine it by the domain
             or extract it from the URL.
         """
-        sessionReference = current.session.get()
+
+        def get_language_from_header() -> str | None:
+            accept_language = self.request.headers.get("accept-language")
+            languages = accept_language.split(",")
+            locale_q_pairs = []
+
+            for language in languages:
+                if language.split(";")[0] == language:
+                    # no q => q = 1
+                    locale_q_pairs.append((language.strip(), "1"))
+                else:
+                    locale = language.split(";")[0].strip()
+                    q = language.split(";")[1].split("=")[1]
+                    locale_q_pairs.append((locale, q))
+            for locale_q_pair in locale_q_pairs:
+                if "-" in locale_q_pair[0]:  # Check for de-DE
+                    lang = locale_q_pair[0].split("-")[0]
+                else:
+                    lang = locale_q_pair[0]
+                if lang in conf.i18n.available_languages + list(conf.i18n.language_alias_map.keys()):
+                    return lang
+            return None
+
         if not conf.i18n.available_languages:
             # This project doesn't use the multi-language feature, nothing to do here
             return path
         if conf.i18n.language_method == "session":
-            # We store the language inside the session, try to load it from there
-            if "lang" not in sessionReference:
-                if "X-Appengine-Country" in self.request.headers:
-                    lng = self.request.headers["X-Appengine-Country"].lower()
-                    if lng in conf.i18n.available_languages + list(conf.i18n.language_alias_map.keys()):
-                        sessionReference["lang"] = lng
-                        current.language.set(lng)
-                    else:
-                        sessionReference["lang"] = conf.i18n.default_language
-            else:
-                current.language.set(sessionReference["lang"])
+            current_session = current.session.get()
+            lang = conf.i18n.default_language
+            # We save the language in the session, if it exists, and try to load it from there
+            if "lang" in current_session:
+                current.language.set(current_session["lang"])
+                return path
+
+            if header_lang := get_language_from_header():
+                lang = header_lang
+                current.language.set(lang)
+
+            elif header_lang := self.request.headers.get("X-Appengine-Country"):
+                header_lang = str(header_lang).lower()
+                if header_lang in conf.i18n.available_languages + list(conf.i18n.language_alias_map.keys()):
+                    lang = header_lang
+
+            if current_session.loaded:
+                current_session["lang"] = lang
+            current.language.set(lang)
+
         elif conf.i18n.language_method == "domain":
             host = self.request.host_url.lower()
             host = host[host.find("://") + 3:].strip(" /")  # strip http(s)://
             if host.startswith("www."):
                 host = host[4:]
-            if host in conf.i18n.domain_language_mapping:
-                current.language.set(conf.i18n.domain_language_mapping[host])
-            else:  # We have no language configured for this domain, try to read it from session
-                if "lang" in sessionReference:
-                    current.language.set(sessionReference["lang"])
+            if lang := conf.i18n.domain_language_mapping.get(host):
+                current.language.set(lang)
+            # We have no language configured for this domain, try to read it from the HTTP Header
+            elif lang := get_language_from_header():
+                current.language.set(lang)
+
         elif conf.i18n.language_method == "url":
             tmppath = urlparse(path).path
             tmppath = [unquote(x) for x in tmppath.lower().strip("/").split("/")]
@@ -196,12 +228,16 @@ class Router:
                 current.language.set(tmppath[0])
                 return path[len(tmppath[0]) + 1:]  # Return the path stripped by its language segment
             else:  # This URL doesnt contain an language prefix, try to read it from session
-                if "lang" in sessionReference:
-                    current.language.set(sessionReference["lang"])
-                elif "X-Appengine-Country" in self.request.headers.keys():
-                    lng = self.request.headers["X-Appengine-Country"].lower()
-                    if lng in conf.i18n.available_languages or lng in conf.i18n.language_alias_map:
-                        current.language.set(lng)
+                if header_lang := get_language_from_header():
+                    current.language.set(header_lang)
+                elif header_lang := self.request.headers.get("X-Appengine-Country"):
+                    lang = str(header_lang).lower()
+                    if lang in conf.i18n.available_languages or lang in conf.i18n.language_alias_map:
+                        current.language.set(lang)
+        elif conf.i18n.language_method == "header":
+            if lang:=get_language_from_header():
+                current.language.set(lang)
+
         return path
 
     def _process(self):

--- a/src/viur/core/request.py
+++ b/src/viur/core/request.py
@@ -162,7 +162,8 @@ class Router:
         """
 
         def get_language_from_header() -> str | None:
-            accept_language = self.request.headers.get("accept-language")
+            if not (accept_language := self.request.headers.get("accept-language")):
+                return None
             languages = accept_language.split(",")
             locale_q_pairs = []
 

--- a/src/viur/core/securitykey.py
+++ b/src/viur/core/securitykey.py
@@ -60,8 +60,14 @@ def create(
 
     entity = db.Entity(db.Key(SECURITYKEY_KINDNAME, key))
     entity |= custom_data
+    if session_bound:
+        if not current.session.get().loaded:
+            current.session.get().reset()
+        entity["viur_session"] = current.session.get().cookie_key
 
-    entity["viur_session"] = current.session.get().cookie_key if session_bound else None
+    else:
+        entity["viur_session"] = None
+
     entity["viur_until"] = utils.utcNow() + utils.parse.timedelta(duration)
 
 

--- a/src/viur/core/securitykey.py
+++ b/src/viur/core/securitykey.py
@@ -61,9 +61,10 @@ def create(
     entity = db.Entity(db.Key(SECURITYKEY_KINDNAME, key))
     entity |= custom_data
     if session_bound:
-        if not current.session.get().loaded:
-            current.session.get().reset()
-        entity["viur_session"] = current.session.get().cookie_key
+        session = current.session.get()
+        if not session.loaded:
+            session.reset()
+        entity["viur_session"] = session.cookie_key
 
     else:
         entity["viur_session"] = None

--- a/src/viur/core/session.py
+++ b/src/viur/core/session.py
@@ -3,7 +3,7 @@ import logging
 import time
 from viur.core.tasks import DeleteEntitiesIter
 from viur.core.config import conf  # this import has to stay alone due partial import
-from viur.core import db, utils, tasks
+from viur.core import db, utils, tasks,current
 import typing as t
 
 """
@@ -59,14 +59,15 @@ class Session(db.Entity):
         self.static_security_key = None
         self.loaded = False
 
-    def load(self, req):
+    def load(self):
         """
             Initializes the Session.
 
             If the client supplied a valid Cookie, the session is read from the datastore, otherwise a new,
             empty session will be initialized.
         """
-        if cookie_key := req.request.cookies.get(self.cookie_name):
+
+        if cookie_key := current.request.get().request.cookies.get(self.cookie_name):
             cookie_key = str(cookie_key)
             if data := db.Get(db.Key(self.kindName, cookie_key)):  # Loaded successfully
                 if data["lastseen"] < time.time() - conf.user.session_life_time:
@@ -87,17 +88,18 @@ class Session(db.Entity):
             else:
                 self.reset()
 
-    def save(self, req):
+    def save(self):
         """
             Writes the session into the database.
 
             Does nothing, in case the session hasn't been changed in the current request.
         """
+
         if not self.changed:
             return
-
+        current_request = current.request.get()
         # We will not issue sessions over http anymore
-        if not (req.isSSLConnection or conf.instance.is_dev_server):
+        if not (current_request.isSSLConnection or conf.instance.is_dev_server):
             return
 
         # Get the current user's key
@@ -130,7 +132,7 @@ class Session(db.Entity):
             f"Max-Age={conf.user.session_life_time}" if not self.use_session_cookie else None,
         )
 
-        req.response.headerlist.append(
+        current_request.response.headerlist.append(
             ("Set-Cookie", f"{self.cookie_name}={self.cookie_key};{';'.join([f for f in flags if f])}")
         )
 
@@ -161,15 +163,11 @@ class Session(db.Entity):
 
             :warning: Everything is flushed.
         """
-        if self.cookie_key:
-            db.Delete(db.Key(self.kindName, self.cookie_key))
-            from viur.core import securitykey
-            securitykey.clear_session_skeys(self.cookie_key)
 
+        self.clear()
         self.cookie_key = utils.string.random(42)
         self.static_security_key = utils.string.random(13)
         self.loaded = True
-        self.clear()
         self.changed = True
 
     def __delitem__(self, key: str) -> None:
@@ -210,8 +208,13 @@ class Session(db.Entity):
         return default
 
     def clear(self) -> None:
-        if self:
-            self.changed = True
+        if self.cookie_key:
+            db.Delete(db.Key(self.kindName, self.cookie_key))
+            from viur.core import securitykey
+            securitykey.clear_session_skeys(self.cookie_key)
+        current.request.get().response.delete_cookie(self.cookie_name)
+        self.loaded=False
+        self.cookie_key = None
         super().clear()
 
     def popitem(self) -> t.Tuple[t.Any, t.Any]:

--- a/src/viur/core/session.py
+++ b/src/viur/core/session.py
@@ -67,7 +67,7 @@ class Session(db.Entity):
             empty session will be initialized.
         """
         if cookie_key := req.request.cookies.get(self.cookie_name):
-            cookie_key=str(cookie_key)
+            cookie_key = str(cookie_key)
             if data := db.Get(db.Key(self.kindName, cookie_key)):  # Loaded successfully
                 if data["lastseen"] < time.time() - conf.user.session_life_time:
                     # This session is too old
@@ -211,11 +211,11 @@ class Session(db.Entity):
 
     def clear(self) -> None:
         if self:
-            self.changed=True
+            self.changed = True
         super().clear()
 
-    def popitem(self)-> t.Tuple[t.Any, t.Any]:
-        self.changed=True
+    def popitem(self) -> t.Tuple[t.Any, t.Any]:
+        self.changed = True
         return super().popitem()
 
     def setdefault(self, __key, __default=None) -> t.Any:

--- a/src/viur/core/session.py
+++ b/src/viur/core/session.py
@@ -3,7 +3,7 @@ import logging
 import time
 from viur.core.tasks import DeleteEntitiesIter
 from viur.core.config import conf  # this import has to stay alone due partial import
-from viur.core import db, utils, tasks,current
+from viur.core import db, utils, tasks, current
 import typing as t
 
 """
@@ -213,7 +213,7 @@ class Session(db.Entity):
             from viur.core import securitykey
             securitykey.clear_session_skeys(self.cookie_key)
         current.request.get().response.delete_cookie(self.cookie_name)
-        self.loaded=False
+        self.loaded = False
         self.cookie_key = None
         super().clear()
 

--- a/src/viur/core/session.py
+++ b/src/viur/core/session.py
@@ -218,10 +218,10 @@ class Session(db.Entity):
         self.changed = True
         return super().popitem()
 
-    def setdefault(self, __key, __default=None) -> t.Any:
-        if __key not in self:
+    def setdefault(self, key, default=None) -> t.Any:
+        if key not in self:
             self.changed = True
-        return super().setdefault(__key, __default)
+        return super().setdefault(key, default)
 
 
 


### PR DESCRIPTION
This PR fix #1276.

1. Language is only stored in the Session when a Session exist. 
2. When no Session exists the `Accept-Language` Header is used to determine the language.
3. `clear`, `popitem`, `setdefault` added to the Session class
4. The Session is only fetched from db if a Cookie is provided