### PR TITLE
fix: Calling `db.KeyHelper` with `None` raises a unhandled `NotImplementedError`

### DIFF
--- a/src/viur/core/skeleton.py
+++ b/src/viur/core/skeleton.py
@@ -1098,7 +1098,7 @@ class Skeleton(BaseSkeleton, metaclass=MetaSkel):
 
         try:
             db_key = db.keyHelper(key or skel["key"], skel.kindName)
-        except ValueError:  # This key did not parse
+        except (ValueError, NotImplementedError):  # This key did not parse
             return None
 
         if not (db_res := db.Get(db_key)):


### PR DESCRIPTION


See https://github.com/viur-framework/viur-datastore/blob/45deae60afad6699a518ab88ab0ead3771926376/src/viur/datastore/utils.py#L92

Discovered during testing of https://github.com/viur-framework/viur-core/pull/1267