### PR TITLE
fix: multiple bones with languages have the wrong default value

### DIFF
--- a/src/viur/core/bones/base.py
+++ b/src/viur/core/bones/base.py
@@ -272,22 +272,19 @@ class BaseBone(object):
         # Default value
         # Convert a None default-value to the empty container that's expected if the bone is
         # multiple or has languages
+        default = [] if defaultValue is None and self.multiple else defaultValue
         if self.languages:
-            if not isinstance(defaultValue, dict):
-                if callable(defaultValue):
-                    self.defaultValue = defaultValue
-                else:
-                    self.defaultValue = {lang: defaultValue for lang in self.languages}
+            if callable(defaultValue):
+                self.defaultValue = defaultValue
+            elif not isinstance(defaultValue, dict):
+                self.defaultValue = {lang: default for lang in self.languages}
             elif "__default__" in defaultValue:
                 self.defaultValue = {lang: defaultValue.get(lang, defaultValue["__default__"])
                                      for lang in self.languages}
             else:
-                self.defaultValue = defaultValue
-
-        elif defaultValue is None and self.multiple:
-            self.defaultValue = []
+                self.defaultValue = defaultValue  # default will have the same value at this point
         else:
-            self.defaultValue = defaultValue
+            self.defaultValue = default
 
         # Unique values
         if unique:


### PR DESCRIPTION
The language value needs to be a `list` as default value, not `None`.

A simple add failed already on unserialize:
```py
skel = ExampleSkel()
skel.write()
```


```py
[2024-10-10 02:06:18,911] viur/core/skeleton.py:1208 [ERROR] Failed to serialize Test_Bone_select_multi_lang <viur.core.bones.select.SelectBone object at 0x7fd69253ee40> {'de': None, 'en': None}
[2024-10-10 02:06:18,947] viur/core/request.py:331 [ERROR] ViUR has caught an unhandled exception!
[2024-10-10 02:06:18,947] viur/core/request.py:332 [ERROR] 'NoneType' object is not iterable
Traceback (most recent call last):
  File "/.../deploy/viur/core/request.py", line 306, in _process
    self._route(path)
  File "/.../deploy/viur/core/request.py", line 565, in _route
    res = caller(*self.args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/.../deploy/viur/core/module.py", line 301, in __call__
    return self._func(self._instance, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/.../deploy/modules/example.py", line 208, in test_add1
    assert skel.write()
           ^^^^^^^^^^^^
  File "/.../deploy/viur/core/skeleton.py", line 1400, in write
    key, skel, change_list, is_add = db.RunInTransaction(__txn_write, skel)
                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "src/viur/datastore/transport.pyx", line 819, in viur.datastore.transport.RunInTransaction
  File "src/viur/datastore/transport.pyx", line 816, in viur.datastore.transport.RunInTransaction
  File "/.../deploy/viur/core/skeleton.py", line 1206, in __txn_write
    bone.serialize(skel, bone_name, True)
  File "/.../deploy/viur/core/bones/base.py", line 776, in serialize
    for singleValue in newVal[language]:
                       ~~~~~~^^^^^^^^^^
TypeError: 'NoneType' object is not iterable
```

Discovered during testing https://github.com/viur-framework/viur-core/pull/1267