### PR TITLE
fix: `File.parse_download_url()`: `too many values to unpack`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file documents any relevant changes done to ViUR-core since version 3.
 
+## [3.6.20]
+
+- fix: `File.parse_download_url()`: `too many values to unpack` (#1287)
+
 ## [3.6.19]
 
 - fix: Rename `type_postfix` on `BaseBone` into `type_suffix` (#1275)

--- a/src/viur/core/bones/text.py
+++ b/src/viur/core/bones/text.py
@@ -70,7 +70,7 @@ class CollectBlobKeys(HTMLParser):
         if tag in ["a", "img"]:
             for k, v in attrs:
                 if k == "src":
-                    file = getattr(conf.main_app.vi, "file", None)
+                    file = getattr(conf.main_app, "file", None)
                     if file and (filepath := file.parse_download_url(v)):
                         self.blobs.add(filepath.dlkey)
 
@@ -178,7 +178,7 @@ class HtmlSerializer(HTMLParser):  # html.parser.HTMLParser
                     if not (checker.startswith("http://") or checker.startswith("https://") or checker.startswith("/")):
                         continue
 
-                    file = getattr(conf.main_app.vi, "file", None)
+                    file = getattr(conf.main_app, "file", None)
                     if file and (filepath := file.parse_download_url(v)):
                         v = file.create_download_url(
                             filepath.dlkey,

--- a/src/viur/core/bones/text.py
+++ b/src/viur/core/bones/text.py
@@ -70,7 +70,7 @@ class CollectBlobKeys(HTMLParser):
         if tag in ["a", "img"]:
             for k, v in attrs:
                 if k == "src":
-                    file = getattr(conf.main_app, "file", None)
+                    file = getattr(conf.main_app.vi, "file", None)
                     if file and (filepath := file.parse_download_url(v)):
                         self.blobs.add(filepath.dlkey)
 
@@ -178,7 +178,7 @@ class HtmlSerializer(HTMLParser):  # html.parser.HTMLParser
                     if not (checker.startswith("http://") or checker.startswith("https://") or checker.startswith("/")):
                         continue
 
-                    file = getattr(conf.main_app, "file", None)
+                    file = getattr(conf.main_app.vi, "file", None)
                     if file and (filepath := file.parse_download_url(v)):
                         v = file.create_download_url(
                             filepath.dlkey,

--- a/src/viur/core/modules/file.py
+++ b/src/viur/core/modules/file.py
@@ -506,9 +506,9 @@ class File(Tree):
         data = base64.urlsafe_b64decode(data).decode("UTF-8")
 
         match data.count("\0"):
-            case 3:
-                dlpath, valid_until, _ = data.split("\0")
             case 2:
+                dlpath, valid_until, _ = data.split("\0")
+            case 1:
                 # It's the old format, without an downloadFileName
                 dlpath, valid_until = data.split("\0")
             case _:

--- a/src/viur/core/version.py
+++ b/src/viur/core/version.py
@@ -3,7 +3,7 @@
 # This will mark it as a pre-release as well on PyPI.
 # See CONTRIBUTING.md for further information.
 
-__version__ = "3.6.19"
+__version__ = "3.6.20"
 
 assert __version__.count(".") >= 2 and "".join(__version__.split(".", 3)[:3]).isdigit(), \
     "Semantic __version__ expected!"


### PR DESCRIPTION
Truly amazing that this bug has not yet surfaced in the entire, huge, worldwide ViUR community with its thousands of projects... wow. It seems that none of those millions or trillions of projects worldwide have ever saved a TextBone with a link to a local file.

```
[2024-10-15 22:55:09,930] /.../viur/core/request.py:331 [ERROR] ViUR has caught an unhandled exception!
[2024-10-15 22:55:09,930] /.../viur/core/request.py:332 [ERROR] too many values to unpack (expected 2)
Traceback (most recent call last):
  File "~/myproject/.venv/lib/python3.12/site-packages/viur/core/request.py", line 306, in _process
    self._route(path)
  File "~/myproject/.venv/lib/python3.12/site-packages/viur/core/request.py", line 565, in _route
    res = caller(*self.args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/myproject/.venv/lib/python3.12/site-packages/viur/core/module.py", line 301, in __call__
    return self._func(self._instance, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/myproject/.venv/lib/python3.12/site-packages/viur/core/prototypes/list.py", line 258, in edit
    skel.toDB()  # write it!
    ^^^^^^^^^^^
  File "~/myproject/.venv/lib/python3.12/site-packages/viur/core/skeleton.py", line 1186, in toDB
    key, db_obj, skel, change_list, is_add = db.RunInTransaction(__txn_update, skel)
                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "src/viur/datastore/transport.pyx", line 819, in viur.datastore.transport.RunInTransaction
  File "src/viur/datastore/transport.pyx", line 816, in viur.datastore.transport.RunInTransaction
  File "~/myproject/.venv/lib/python3.12/site-packages/viur/core/skeleton.py", line 1008, in __txn_update
    blob_list.update(bone.getReferencedBlobs(skel, bone_name))
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/myproject/.venv/lib/python3.12/site-packages/viur/core/bones/text.py", line 421, in getReferencedBlobs
    collector.feed(value)
  File "/usr/lib/python3.12/html/parser.py", line 111, in feed
    self.goahead(0)
  File "/usr/lib/python3.12/html/parser.py", line 171, in goahead
    k = self.parse_starttag(i)
        ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/html/parser.py", line 338, in parse_starttag
    self.handle_starttag(tag, attrs)
  File "~/myproject/.venv/lib/python3.12/site-packages/viur/core/bones/text.py", line 74, in handle_starttag
    if file and (filepath := file.parse_download_url(v)):
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/myproject/.venv/lib/python3.12/site-packages/viur/core/modules/file.py", line 513, in parse_download_url
    dlpath, valid_until = data.split("\0")
    ^^^^^^^^^^^^^^^^^^^
ValueError: too many values to unpack (expected 2)
```
