### PR TITLE
fix: `Skeleton.processRemovedRelations` unable to handle empty values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file documents any relevant changes done to ViUR-core since version 3.
 
+## [3.6.21]
+
+- fix: `Skeleton.processRemovedRelations` unable to handle empty values (#1288)
+
 ## [3.6.20]
 
 - fix: `File.parse_download_url()`: `too many values to unpack` (#1287)

--- a/src/viur/core/version.py
+++ b/src/viur/core/version.py
@@ -3,7 +3,7 @@
 # This will mark it as a pre-release as well on PyPI.
 # See CONTRIBUTING.md for further information.
 
-__version__ = "3.6.20"
+__version__ = "3.6.21"
 
 assert __version__.count(".") >= 2 and "".join(__version__.split(".", 3)[:3]).isdigit(), \
     "Semantic __version__ expected!"


### PR DESCRIPTION
Fixes occured error `NotImplementedError: No handling for type(relVal)=<class 'NoneType'>`