### PR TITLE
feat: Introduce `conf.email.sender_default`

### DIFF
--- a/src/viur/core/config.py
+++ b/src/viur/core/config.py
@@ -548,6 +548,12 @@ class Email(ConfigType):
     (overriding the 'dests'-parameter in email.sendEmail)
     """
 
+    sender_default: str = f"viur@{_project_id}.appspotmail.com"
+    """This sender is used by default for emails.
+    It can be overridden for a specific email by passing the `sender` argument
+    to :meth:`core.email.send_email` or for all emails with :attr:`sender_override`.
+    """
+
     sender_override: str | None = None
     """If set, this sender will be used, regardless of what the templates advertise as sender"""
 

--- a/src/viur/core/email.py
+++ b/src/viur/core/email.py
@@ -378,7 +378,7 @@ def send_email(
     if conf.email.sender_override:
         sender = conf.email.sender_override
     elif sender is None:
-        sender = f'viur@{conf.instance.project_id}.appspotmail.com'
+        sender = conf.email.sender_default
 
     subject, body = conf.emailRenderer(dests, tpl, stringTemplate, skel, **kwargs)
 


### PR DESCRIPTION
This adds the possibilty to set the sender once without touching every `send_email` call.

The sender order is now (Low to Hight):
- Use `conf.email.sender_default` as default
- Use `sender` from `send_email` call (if provided)
- Use `conf.email.sender_override` (if set)