### PR TITLE
fix: `UserSkel.__new__()` cannot be subSkel'ed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file documents any relevant changes done to ViUR-core since version 3.
 
+## [3.6.22]
+
+- fix: `UserSkel.__new__()` cannot be subSkel'ed (#1296)
+
 ## [3.6.21]
 
 - fix: `Skeleton.processRemovedRelations` unable to handle empty values (#1288)

--- a/src/viur/core/modules/user.py
+++ b/src/viur/core/modules/user.py
@@ -120,7 +120,7 @@ class UserSkel(skeleton.Skeleton):
         visible=False
     )
 
-    def __new__(cls):
+    def __new__(cls, *args, **kwargs):
         """
         Constructor for the UserSkel-class, with the capability
         to dynamically add bones required for the configured
@@ -135,7 +135,7 @@ class UserSkel(skeleton.Skeleton):
             provider.patch_user_skel(cls)
 
         cls.__boneMap__ = skeleton.MetaBaseSkel.generate_bonemap(cls)
-        return super().__new__(cls)
+        return super().__new__(cls, *args, **kwargs)
 
     @classmethod
     def toDB(cls, skel, *args, **kwargs):

--- a/src/viur/core/version.py
+++ b/src/viur/core/version.py
@@ -3,7 +3,7 @@
 # This will mark it as a pre-release as well on PyPI.
 # See CONTRIBUTING.md for further information.
 
-__version__ = "3.6.21"
+__version__ = "3.6.22"
 
 assert __version__.count(".") >= 2 and "".join(__version__.split(".", 3)[:3]).isdigit(), \
     "Semantic __version__ expected!"


### PR DESCRIPTION
This hotfixes the bug that a skeleton inherited from UserSkel cannot be subSkel'ed, as an exception `TypeError: UserSkel.__new__() got an unexpected keyword argument 'bones'` occurs.

The above exception is from viur-core 3.7, but it will raise a similar exception in viur-core 3.6. I found this bug by porting a project from viur-core 3.5 directly to viur-core 3.7.