### PR TITLE
fix: `Skeleton.subskel()` and `SkeletonInstance.clone()`

### DIFF
--- a/src/viur/core/skeleton.py
+++ b/src/viur/core/skeleton.py
@@ -149,8 +149,8 @@ class SkeletonInstance:
         *,
         bones: t.Iterable[str] = (),
         bone_map: t.Optional[t.Dict[str, BaseBone]] = None,
-        full_clone: bool = False,
-        # BELOW IS DEPRECATED!
+        clone: bool = False,
+        # FIXME: BELOW IS DEPRECATED!
         clonedBoneMap: t.Optional[t.Dict[str, BaseBone]] = None,
     ):
         """
@@ -160,7 +160,7 @@ class SkeletonInstance:
         :param bones: If given, defines an iterable of bones that are take into the SkeletonInstance.
             The order of the bones defines the order in the SkeletonInstance.
         :param bone_map: A pre-defined bone map to use, or extend.
-        :param full_clone: If set True, performs a full clone of the used bone map, to be entirely stand-alone.
+        :param clone: If set True, performs a cloning of the used bone map, to be entirely stand-alone.
         """
 
         # TODO: Remove with ViUR-core 3.8; required by viur-datastore :'-(
@@ -187,27 +187,32 @@ class SkeletonInstance:
                 else:
                     keys.extend(fnmatch.filter(skel_cls.__boneMap__.keys(), name))
 
-            if full_clone:
+            if clone:
                 bone_map |= {k: copy.deepcopy(skel_cls.__boneMap__[k]) for k in keys if skel_cls.__boneMap__[k]}
             else:
                 bone_map |= {k: skel_cls.__boneMap__[k] for k in keys if skel_cls.__boneMap__[k]}
 
-        elif full_clone:
-            bone_map |= copy.deepcopy(skel_cls.__boneMap__)
+        elif clone:
+            if bone_map:
+                bone_map = copy.deepcopy(bone_map)
+            else:
+                bone_map = copy.deepcopy(skel_cls.__boneMap__)
 
         # generated or use provided bone_map
         if bone_map:
             self.boneMap = bone_map
-            for v in self.boneMap.values():
-                v.isClonedInstance = True
 
         else:  # No Subskel, no Clone
             self.boneMap = skel_cls.__boneMap__.copy()
 
+        if clone:
+            for v in self.boneMap.values():
+                v.isClonedInstance = True
+
         self.accessedValues = {}
         self.dbEntity = None
         self.errors = []
-        self.is_cloned = full_clone
+        self.is_cloned = clone
         self.renderAccessedValues = {}
         self.renderPreparation = None
         self.skeletonCls = skel_cls
@@ -397,7 +402,7 @@ class SkeletonInstance:
         Clones a SkeletonInstance into a modificable, stand-alone instance.
         This will also allow to modify the underlying data model.
         """
-        res = SkeletonInstance(self.skeletonCls, full_clone=True)
+        res = SkeletonInstance(self.skeletonCls, bone_map=self.boneMap, clone=True)
         res.accessedValues = copy.deepcopy(self.accessedValues)
         res.dbEntity = copy.deepcopy(self.dbEntity)
         res.is_cloned = True
@@ -460,15 +465,15 @@ class BaseSkeleton(object, metaclass=MetaBaseSkel):
         reason="Function renamed. Use subskel function as alternative implementation.",
         action="always"
     )
-    def subSkel(cls, *subskel_names, full_clone: bool = False, **kwargs) -> SkeletonInstance:
-        return cls.subskel(*subskel_names, full_clone=full_clone)  # FIXME: REMOVE WITH VIUR4
+    def subSkel(cls, *subskel_names, fullClone: bool = False, **kwargs) -> SkeletonInstance:
+        return cls.subskel(*subskel_names, clone=fullClone)  # FIXME: REMOVE WITH VIUR4
 
     @classmethod
     def subskel(
         cls,
         *names: str,
         bones: t.Iterable[str] = (),
-        full_clone: bool = False,
+        clone: bool = False,
     ) -> SkeletonInstance:
         """
             Creates a new sub-skeleton from the current skeleton.
@@ -509,7 +514,7 @@ class BaseSkeleton(object, metaclass=MetaBaseSkel):
             :param bones: Allows to specify an iterator of bone names (more precisely, fnmatch-wildards) which allow
                 to freely define a subskel. If *only* this parameter is given, the order of the specification also
                 defines, the order of the list. Otherwise, the original order as defined in the skeleton is kept.
-            :param full_clone: If set True, performs a full clone of the used bone map, to be entirely stand-alone.
+            :param clone: If set True, performs a cloning of the used bone map, to be entirely stand-alone.
 
             :return: The sub-skeleton of the specified type.
         """
@@ -536,7 +541,7 @@ class BaseSkeleton(object, metaclass=MetaBaseSkel):
         if not bones:
             raise ValueError("The given subskel definition doesn't contain any bones!")
 
-        return cls(bones=bones, full_clone=full_clone)
+        return cls(bones=bones, clone=clone)
 
     @classmethod
     def setSystemInitialized(cls):


### PR DESCRIPTION
Due the changes in #1259, the cloning behavior was broken.

This pull requests fixes the following:

1. Any subskel'ed SkeletonInstance globally modified bones, as they where flagged as "cloned" but wheren't.
2. `SkeletonInstance.clone()` caused a sub-skel lose its boneMap, so it contained all bones again.
3. Renamed `full_clone` into just `clone` to make it more familiar with what it does. A `Skeleton.subskel(clone=True)` does now return a standalone clone of the skeleton which can be modified.
4. Deprecated `Skeleton.subSkel()` (camel-case) now accepts old `fullClone`-parameter again to stay backward compatible.