### PR TITLE
fix: `KeyBone.singleValueUnseralize()` doesn't handle None

### DIFF
--- a/src/viur/core/bones/key.py
+++ b/src/viur/core/bones/key.py
@@ -76,7 +76,9 @@ class KeyBone(BaseBone):
         return key, None
 
     def singleValueUnserialize(self, val):
-        if isinstance(val, db.Key):
+        if not val:
+            rval = None
+        elif isinstance(val, db.Key):
             rval = db.normalizeKey(val)
         else:
             rval, err = self.singleValueFromClient(val, parse_only=True)

--- a/src/viur/core/modules/file.py
+++ b/src/viur/core/modules/file.py
@@ -405,7 +405,7 @@ class FileLeafSkel(TreeSkel):
             if importData:
                 if not skelValues["downloadUrl"]:
                     skelValues["downloadUrl"] = importData
-                skelValues["pendingparententry"] = False
+                skelValues["pendingparententry"] = None
 
         conf.main_app.file.inject_serving_url(skelValues)
 


### PR DESCRIPTION
This fixes above bug. Additionally, the "pendingparententry" value is set to None instead of False in `Skeleton.refresh()`, which is invalid.