### PR TITLE
refactor: Replace `db.encodeKey` by `str`-cast

### DIFF
--- a/src/viur/core/render/html/default.py
+++ b/src/viur/core/render/html/default.py
@@ -230,7 +230,7 @@ class Render(AbstractRenderer):
         elif bone.type == "password":
             return ""
         elif bone.type == "key":
-            return db.encodeKey(boneValue) if boneValue else None
+            return str(boneValue) if boneValue else None
 
         else:
             return boneValue

--- a/src/viur/core/render/json/default.py
+++ b/src/viur/core/render/json/default.py
@@ -22,7 +22,7 @@ class CustomJsonEncoder(json.JSONEncoder):
         elif isinstance(o, datetime):
             return o.isoformat()
         elif isinstance(o, db.Key):
-            return db.encodeKey(o)
+            return str(o)
         elif isinstance(o, Enum):
             return o.value
         elif isinstance(o, set):
@@ -233,9 +233,6 @@ class DefaultRender(AbstractRenderer):
         return json.dumps("OKAY")
 
     def listRootNodes(self, rootNodes, *args, **kwargs):
-        for rn in rootNodes:
-            rn["key"] = db.encodeKey(rn["key"])
-
         return json.dumps(rootNodes, cls=CustomJsonEncoder)
 
     def render(self, action: str, skel: t.Optional[SkeletonInstance] = None, **kwargs):

--- a/src/viur/core/utils/json.py
+++ b/src/viur/core/utils/json.py
@@ -24,7 +24,7 @@ class ViURJsonEncoder(json.JSONEncoder):
             return tuple(obj)
         # cannot be tested in tests...
         elif isinstance(obj, db.Key):
-            return {".__key__": db.encodeKey(obj)}
+            return {".__key__": str(obj)}
 
         return super().default(obj)
 
@@ -35,10 +35,9 @@ class ViURJsonEncoder(json.JSONEncoder):
         There is currently no other way to integrate with JSONEncoder.
         """
         if isinstance(obj, db.Entity):
-            # TODO: Handle SkeletonInstance as well?
             return {
                 ".__entity__": ViURJsonEncoder.preprocess(dict(obj)),
-                ".__key__": db.encodeKey(obj.key) if obj.key else None
+                ".__key__": str(obj.key) if obj.key else None
             }
         elif isinstance(obj, dict):
             return {


### PR DESCRIPTION
The function `db.encodeKey` does the same, and is obsolete. Didn't know it was deprecated.