### PR TITLE
fix: Remove check if logged-in in `UserPassword.login()`

### DIFF
--- a/src/viur/core/modules/user.py
+++ b/src/viur/core/modules/user.py
@@ -312,9 +312,6 @@ class UserPassword(UserPrimaryAuthentication):
     @force_ssl
     @skey(allow_empty=True)
     def login(self, *, name: str | None = None, password: str | None = None, **kwargs):
-        if current.user.get():  # User is already logged in, nothing to do.
-            return self._user_module.render.loginSucceeded()
-
         if not name or not password:
             return self._user_module.render.login(self.LoginSkel(), action="login")
 
@@ -600,7 +597,6 @@ class GoogleAccount(UserPrimaryAuthentication):
     @force_ssl
     @skey(allow_empty=True)
     def login(self, token: str | None = None, *args, **kwargs):
-        # FIXME: Check if already logged in
         if not conf.user.google_client_id:
             raise errors.PreconditionFailed("Please configure conf.user.google_client_id!")
 


### PR DESCRIPTION
Recent use cases have shown that the current logic is confusing, especially because it is only implemented in UserPassword.

If a user logs in with GoogleLogin but does not have sufficient rights, they are redirected back to the start page or the login page. When attempting to log in via UserPassword, the login attempt is immediately acknowledged with loginSucceeded(), and it is pretended that the login was successful - although no credentials were checked.

This is confusing and inconsistent. Removing this check allows to just login into a fresh session with the given credentials, and everything is more convenient.
