### PR TITLE
fix: Add `__set_name__` in `__setattr__` for bones

### DIFF
--- a/src/viur/core/skeleton.py
+++ b/src/viur/core/skeleton.py
@@ -362,6 +362,7 @@ class SkeletonInstance:
             if value is None:
                 del self.boneMap[key]
             else:
+                value.__set_name__(self.skeletonCls, key)
                 self.boneMap[key] = value
         elif key == "renderPreparation":
             super().__setattr__(key, value)


### PR DESCRIPTION
This PR fixes the bug when you clone a skeleton and then add a bone neither the name nor the skelcls are set for this bone.

```python
skel=self.viewSkel().clone()
select = SelectBone(values={"a":1})
skel.__setattr__("x",select)
return self.render.view(skel)
```
Produce
```
File "/viur/src/viur/core/bones/select.py", line 102, in __getattribute__
    f"value {key} for {self.name}<{type(self).__name__}> in {self.skel_cls.__name__} in {self.skel_cls}"
AttributeError: 'NoneType' object has no attribute '__name__'.
```
Many thanks to @skoegl for the find and the report.