### PR TITLE
feat: Public translations interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This file documents any relevant changes done to ViUR-core since version 3.
 ## [3.6.24]
 
 - feat: `SkelModule.structure()` with actions and with access control (#1321)
+- feat: Public translations interface (#1323)
 
 ## [3.6.23]
 

--- a/src/viur/core/i18n.py
+++ b/src/viur/core/i18n.py
@@ -177,7 +177,7 @@ class translate:
             as the key/defaultText may have different meanings in the
             target language.
         :param force_lang: Use this language instead the one of the request.
-        :param public:
+        :param public: Flag for public translations, which can be obtained via /json/_translate/get_public.
         """
         super().__init__()
 

--- a/src/viur/core/i18n.py
+++ b/src/viur/core/i18n.py
@@ -150,9 +150,23 @@ class translate:
     translation issues with bones, which can now take an instance of this class as it's description/hints.
     """
 
-    __slots__ = ["key", "defaultText", "hint", "translationCache", "force_lang"]
+    __slots__ = (
+        "key",
+        "defaultText",
+        "hint",
+        "translationCache",
+        "force_lang",
+        "public",
+    )
 
-    def __init__(self, key: str, defaultText: str = None, hint: str = None, force_lang: str = None):
+    def __init__(
+        self,
+        key: str,
+        defaultText: str = None,
+        hint: str = None,
+        force_lang: str = None,
+        public: bool = False,
+    ):
         """
         :param key: The unique key defining this text fragment.
             Usually it's a path/filename and a unique descriptor in that file
@@ -163,16 +177,20 @@ class translate:
             as the key/defaultText may have different meanings in the
             target language.
         :param force_lang: Use this language instead the one of the request.
+        :param public:
         """
         super().__init__()
-        key = str(key)  # ensure key is a str
-        self.key = key.lower()
+
+        self.key = str(key).lower()
         self.defaultText = defaultText or key
         self.hint = hint
+
         self.translationCache = None
         if force_lang is not None and force_lang not in conf.i18n.available_dialects:
             raise ValueError(f"The language {force_lang=} is not available")
+
         self.force_lang = force_lang
+        self.public = public
 
     def __repr__(self) -> str:
         return f"<translate object for {self.key} with force_lang={self.force_lang}>"
@@ -211,6 +229,7 @@ class translate:
                     default_text=self.defaultText,
                     filename=filename,
                     lineno=lineno,
+                    public=self.public,
                 )
 
             self.translationCache = self.merge_alias(systemTranslations.get(self.key, {}))
@@ -272,15 +291,19 @@ class TranslationExtension(jinja2.Extension):
     force the use of a specific language, not the language of the request.
     """
 
-    tags = {"translate"}
+    tags = {
+        "translate",
+    }
 
     def parse(self, parser):
         # Parse the translate tag
         global systemTranslations
+
         args = []  # positional args for the `_translate()` method
         kwargs = {}  # keyword args (force_lang + substitute vars) for the `_translate()` method
         lineno = parser.stream.current.lineno
         filename = parser.stream.filename
+
         # Parse arguments (args and kwargs) until the current block ends
         lastToken = None
         while parser.stream.current.type != 'block_end':
@@ -301,14 +324,19 @@ class TranslationExtension(jinja2.Extension):
                 else:
                     raise SyntaxError()
                 lastToken = None
+
         if lastToken:  # TODO: what's this? what it is doing?
             logging.debug(f"final append {lastToken = }")
             args.append(lastToken.value)
+
         if not 0 < len(args) <= 3:
             raise SyntaxError("Translation-Key missing or excess parameters!")
+
         args += [""] * (3 - len(args))
         args += [kwargs]
         tr_key = args[0].lower()
+        public = kwargs.pop("_public_", False) or False
+
         if tr_key not in systemTranslations:
             add_missing_translation(
                 key=tr_key,
@@ -317,6 +345,7 @@ class TranslationExtension(jinja2.Extension):
                 filename=filename,
                 lineno=lineno,
                 variables=list(kwargs.keys()),
+                public=public,
             )
 
         translations = translate.merge_alias(systemTranslations.get(tr_key, {}))
@@ -369,7 +398,9 @@ def initializeTranslations() -> None:
 
         translations = {
             "_default_text_": entity.get("default_text") or None,
+            "_public_": entity.get("public") or False,
         }
+
         for lang, translation in entity["translations"].items():
             if lang not in conf.i18n.available_dialects:
                 # Don't store unknown languages in the memory
@@ -378,6 +409,7 @@ def initializeTranslations() -> None:
                 # Skip empty values
                 continue
             translations[lang] = translation
+
         systemTranslations[entity["tr_key"]] = translations
 
 
@@ -390,6 +422,7 @@ def add_missing_translation(
     filename: str | None = None,
     lineno: int | None = None,
     variables: list[str] = None,
+    public: bool = False,
 ) -> None:
     """Add missing translations to datastore"""
     try:
@@ -426,11 +459,13 @@ def add_missing_translation(
     skel["usage_lineno"] = lineno
     skel["usage_variables"] = variables or []
     skel["creator"] = Creator.VIUR
+    skel["public"] = public
     skel.toDB()
 
     # Add to system translation to avoid triggering this method again
     systemTranslations[key] = {
         "_default_text_": default_text or None,
+        "_public_": public,
     }
 
 

--- a/src/viur/core/modules/translation.py
+++ b/src/viur/core/modules/translation.py
@@ -189,6 +189,13 @@ class Translation(List):
     def get_public(self, *, languages: list[str] = None) -> dict[str, str] | dict[str, dict[str, str]]:
         """
         Dumps public translations as JSON.
+
+        Example calls:
+
+        - `/json/_translation/get_public` get public translations for current language
+        - `/json/_translation/get_public?languages=en` for english translations
+        - `/json/_translation/get_public?languages=en&languages=de` for english and german translations
+        - `/json/_translation/get_public?languages=*` for all available languages
         """
         if not utils.string.is_prefix(self.render.kind, "json"):
             raise errors.BadRequest("Can only use this function on JSON-based renders")


### PR DESCRIPTION
This interface was already implemented in some projects, and was now cleaned and standardised. It allows to set translate()-objects to public, so that an unauthorized client can request them without further authentication.

The function /json/_translate/get_public was made available to dump translations.

Example calls:

- `/json/_translation/get_public` get public translations for current language
- `/json/_translation/get_public?languages=en` for english translations
- `/json/_translation/get_public?languages=en&languages=de` for english and german translations
- `/json/_translation/get_public?languages=*` for all available languages