### PR TITLE
fix: `SpamBone`'s descr not available without session

### DIFF
--- a/src/viur/core/bones/base.py
+++ b/src/viur/core/bones/base.py
@@ -38,10 +38,11 @@ def setSystemInitialized():
     """
     global __system_initialized
     from viur.core.skeleton import iterAllSkelClasses
-    __system_initialized = True
+
     for skelCls in iterAllSkelClasses():
         skelCls.setSystemInitialized()
 
+    __system_initialized = True
 
 def getSystemInitialized():
     """

--- a/src/viur/core/bones/spam.py
+++ b/src/viur/core/bones/spam.py
@@ -3,6 +3,7 @@ import random
 import typing as t
 from viur.core import i18n, current
 from viur.core.bones import NumericBone
+from viur.core.bones.base import getSystemInitialized
 
 
 class SpamBone(NumericBone):
@@ -46,10 +47,11 @@ class SpamBone(NumericBone):
         """
         The descr-property is generated and uses session variables to construct the question.
         """
-
-        # The session is not available during startup
-        if not (session := current.session.get()):
+        # This descr can only be evaluated on initialized systems.
+        if not getSystemInitialized():
             return None
+
+        session = current.session.get()
 
         a = session.get("spambone.value.a")
         b = session.get("spambone.value.b")


### PR DESCRIPTION
This bug is a regression of #1277 and #1227.

The `__system_initialized`-bool should be set *after* all setSystemInitialized() functions where invoked, as the system is defined to be initialized *after* the stuff where worked.

Otherwise, `SpamBone.descr` cannot determine whether it is executed in an uninitialized or initialized system.