### PR TITLE
fix: `SpamBone()` consumes default iterator once

### DIFF
--- a/src/viur/core/bones/spam.py
+++ b/src/viur/core/bones/spam.py
@@ -14,7 +14,7 @@ class SpamBone(NumericBone):
             "core.bones.spam.question",
             "What is the result of the addition of {{a}} and {{b}}?"
         ),
-        values: t.Iterable[str] = (
+        values: t.Iterable[str] = tuple(
             i18n.translate(f"core.bones.spam.value.{digit}", digit)
             for digit in ("one", "two", "three", "four", "five", "six", "seven", "eight", "nine")
         ),
@@ -34,8 +34,11 @@ class SpamBone(NumericBone):
             **kwargs
         )
 
-        self.descr_template = descr
         self.values = tuple(values)
+        if not self.values or len(self.values) == 1:
+            raise ValueError("Requires for at least 2 values!")
+
+        self.descr_template = descr
         self.msg_invalid = msg_invalid
 
     def _dice(self) -> int:


### PR DESCRIPTION
The spambone seems to consume its iteratore provided as default once. A second instance if SpamBone() raised a range-error, because `values` where empty. This fixes it.