### PR TITLE
fix: `JsonBone` validate `object` and `list` too

### DIFF
--- a/src/viur/core/bones/json.py
+++ b/src/viur/core/bones/json.py
@@ -68,14 +68,14 @@ class JsonBone(RawBone):
                             ReadFromClientError(ReadFromClientErrorSeverity.Invalid, f"Invalid JSON supplied: {e!s}")
                         ]
 
-                try:
-                    jsonschema.validate(value, self.schema)
-                except (jsonschema.exceptions.ValidationError, jsonschema.exceptions.SchemaError) as e:
-                    return self.getEmptyValue(), [
-                        ReadFromClientError(
-                            ReadFromClientErrorSeverity.Invalid,
-                            f"Invalid JSON for schema supplied: {e!s}")
-                        ]
+            try:
+                jsonschema.validate(value, self.schema)
+            except (jsonschema.exceptions.ValidationError, jsonschema.exceptions.SchemaError) as e:
+                return self.getEmptyValue(), [
+                    ReadFromClientError(
+                        ReadFromClientErrorSeverity.Invalid,
+                        f"Invalid JSON for schema supplied: {e!s}")
+                    ]
 
         return super().singleValueFromClient(value, skel, bone_name, client_data)
 


### PR DESCRIPTION
This PR fix the Bug that only `str` is validated by the JsonBone.

Example :
```python
testjson = JsonBone(schema={
		"type": "object",
		"properties": {
			"price": {"type": "number"},
			"name": {"type": "string"},
		},
	})

```
```python
print(skel.setBoneValue("testjson",{"name" : "Eggs", "price" : "invalid"}))
print(skel["testjson"])
```

```python
True
{'name': 'Eggs', 'price': 'invalid'}
```
>---
```python
print(skel.setBoneValue("testjson",json.dumps({"name" : "Eggs", "price" : "invalid"})))
print(skel["testjson"])
```

```python
False
{'name': 'Eggs', 'price': 1}
```



