### PR TITLE
fix: `User.is_active()` without status-bone

### DIFF
--- a/src/viur/core/modules/user.py
+++ b/src/viur/core/modules/user.py
@@ -1393,7 +1393,7 @@ class User(List):
 
             return status >= Status.ACTIVE.value
 
-        return False
+        return True
 
     def authenticateUser(self, key: db.Key, **kwargs):
         """

--- a/src/viur/core/modules/user.py
+++ b/src/viur/core/modules/user.py
@@ -439,7 +439,7 @@ class UserPassword(UserPrimaryAuthentication):
             )
 
         # If the account is locked or not yet validated, abort the process.
-        if self._user_module.is_active(user_skel) is False:
+        if not self._user_module.is_active(user_skel):
             raise errors.NotFound(
                 i18n.translate(
                     key="viur.modules.user.passwordrecovery.accountlocked",
@@ -1409,7 +1409,7 @@ class User(List):
             raise ValueError(f"Unable to authenticate unknown user {key}")
 
         # Verify that this user account is active
-        if self.is_active(skel) is False:
+        if not self.is_active(skel):
             raise errors.Forbidden("The user is disabled and cannot be authenticated.")
 
         # Update session for user


### PR DESCRIPTION
When the UserSkel has no status-bone, it should default to is_active=True.

It occured in a subskel, that didn't contain the "status"-bone, the default
```py
    def onEdited(self, skel):
        super().onEdited(skel)
        # In case the user is set to inactive, kill all sessions
        if not self.is_active(skel):
            session.killSessionByUser(skel["key"])
```

always kicks the user - just because the "status" bone was unavailable. The previous definition before #1309 was
```py
    def onEdited(self, skel):
        super().onEdited(skel)
        # In case the user is set to inactive, kill all sessions
        if "status" in skel and skel["status"] < Status.ACTIVE.value:
            session.killSessionByUser(skel["key"])
```