### PR TITLE
fix: Store written db_obj in `toDB` on source skel

### DIFF
--- a/src/viur/core/skeleton.py
+++ b/src/viur/core/skeleton.py
@@ -1179,11 +1179,15 @@ class Skeleton(BaseSkeleton, metaclass=MetaSkel):
 
         # END of __txn_update subfunction
 
+        src_skel = skel
+
         # Run our SaveTxn
         if db.IsInTransaction():
             key, db_obj, skel, change_list, is_add = __txn_update(skel)
         else:
             key, db_obj, skel, change_list, is_add = db.RunInTransaction(__txn_update, skel)
+
+        src_skel.dbEntity = db_obj
 
         for bone_name, bone in skel.items():
             bone.postSavedHandler(skel, bone_name, key)


### PR DESCRIPTION
If you create a new skel, call `toDB` and then access `skel.dbEntity` it was still None, this made problems with compute bones