### PR TITLE
fix: Return a `list` instead of `None` in `RelationalBone.relskels_from_keys`

### DIFF
--- a/src/viur/core/bones/relational.py
+++ b/src/viur/core/bones/relational.py
@@ -1084,7 +1084,7 @@ class RelationalBone(BaseBone):
     def createRelSkelFromKey(self, key: db.Key, rel: dict | None = None) -> RelDict:
         return self.relskels_from_keys([(key, rel)])[0]
 
-    def relskels_from_keys(self, key_rel_list: list[tuple[db.Key, dict | None]]) -> list[RelDict] | None:
+    def relskels_from_keys(self, key_rel_list: list[tuple[db.Key, dict | None]]) -> list[RelDict]:
         """
         Creates a list of RelSkel instances valid for this bone from the given database key.
 
@@ -1095,12 +1095,11 @@ class RelationalBone(BaseBone):
         :param key_rel_list: List of tuples with the first value in the tuple is the
             key and the second is and RelSkel or None
 
-        :return: A dictionary containing a reference skeleton and optional relation data or None.
-        :rtype: dict
+        :return: A dictionary containing a reference skeleton and optional relation data.
         """
 
         if not all(db_objs := db.Get([db.keyHelper(value[0], self.kind) for value in key_rel_list])):
-            return None
+            return []  # return emtpy data when not all data is found
         res_rel_skels = []
         for (key, rel), db_obj in zip(key_rel_list, db_objs):
             dest_skel = self._refSkelCache()

--- a/src/viur/core/bones/relational.py
+++ b/src/viur/core/bones/relational.py
@@ -1081,8 +1081,10 @@ class RelationalBone(BaseBone):
 
         return result
 
-    def createRelSkelFromKey(self, key: db.Key, rel: dict | None = None) -> RelDict:
-        return self.relskels_from_keys([(key, rel)])[0]
+    def createRelSkelFromKey(self, key: db.Key, rel: dict | None = None) -> RelDict | None:
+        if rel_skel := self.relskels_from_keys([(key, rel)]):
+            return rel_skel[0]
+        return None
 
     def relskels_from_keys(self, key_rel_list: list[tuple[db.Key, dict | None]]) -> list[RelDict]:
         """


### PR DESCRIPTION
Fix the Bug that this fails when 

https://github.com/viur-framework/viur-core/blob/7801292f664957202bc14756d1d51b9ff917343d/src/viur/core/bones/relational.py#L1185-L1192
 this returns `None`
https://github.com/viur-framework/viur-core/blob/7801292f664957202bc14756d1d51b9ff917343d/src/viur/core/bones/relational.py#L1102-L1103