### PR TITLE
fix: Correct `translation_key_prefix_skeleton_bonename` and `translation_key_prefix_bonename`

### DIFF
--- a/src/viur/core/bones/select.py
+++ b/src/viur/core/bones/select.py
@@ -24,13 +24,13 @@ SelectBoneMultiple = list[SelectBoneValue]
 
 
 def translation_key_prefix_skeleton_bonename(bones_instance: BaseBone) -> str:
-    """Generate a translation key prefix based on the skeleton name"""
+    """Generate a translation key prefix based on the skeleton and bone name"""
     return f'skeleton.{bones_instance.skel_cls.__name__.lower().removesuffix("skel")}.{bones_instance.name}.'
 
 
 def translation_key_prefix_bonename(bones_instance: BaseBone) -> str:
-    """Generate a translation key prefix based on the skeleton and bone name"""
-    return f'skeleton.{bones_instance.skel_cls.__name__.lower().removesuffix("skel")}.{bones_instance.name}.'
+    """Generate a translation key prefix based on the bone name"""
+    return f'bone.{bones_instance.name}.'
 
 
 class SelectBone(BaseBone):


### PR DESCRIPTION
Both had the same implementations, but different names and swapped descriptions