### PR TITLE
feat: `pattern`-parameter for `Translation.get_public()`

### DIFF
--- a/src/viur/core/modules/translation.py
+++ b/src/viur/core/modules/translation.py
@@ -203,7 +203,8 @@ class Translation(List):
 
         - `/json/_translation/get_public` get public translations for current language
         - `/json/_translation/get_public?languages=en` for english translations
-        - `/json/_translation/get_public?languages=en&pattern=bool.*` for english translations, only keys starting with "bool."
+        - `/json/_translation/get_public?languages=en&pattern=bool.*` for english translations,
+            but only keys starting with "bool."
         - `/json/_translation/get_public?languages=en&languages=de` for english and german translations
         - `/json/_translation/get_public?languages=*` for all available languages
         """

--- a/src/viur/core/modules/translation.py
+++ b/src/viur/core/modules/translation.py
@@ -1,4 +1,5 @@
 import enum
+import fnmatch
 import json
 import logging
 import os
@@ -186,14 +187,23 @@ class Translation(List):
     _last_reload = None  # Cut my strings into pieces, this is my last reload...
 
     @exposed
-    def get_public(self, *, languages: list[str] = None) -> dict[str, str] | dict[str, dict[str, str]]:
+    def get_public(
+        self,
+        *,
+        languages: list[str] = [],
+        pattern: str = "*",
+    ) -> dict[str, str] | dict[str, dict[str, str]]:
         """
         Dumps public translations as JSON.
+
+        :param languages: Allows to request a specific language.
+        :param pattern: Provide an fnmatch-style key filter pattern
 
         Example calls:
 
         - `/json/_translation/get_public` get public translations for current language
         - `/json/_translation/get_public?languages=en` for english translations
+        - `/json/_translation/get_public?languages=en&pattern=bool.*` for english translations, only keys starting with "bool."
         - `/json/_translation/get_public?languages=en&languages=de` for english and german translations
         - `/json/_translation/get_public?languages=*` for all available languages
         """
@@ -217,7 +227,7 @@ class Translation(List):
                 lang: {
                     tr_key: str(translate(tr_key, force_lang=lang))
                     for tr_key, values in systemTranslations.items()
-                    if values.get("_public_")
+                    if values.get("_public_") and fnmatch.fnmatch(tr_key, pattern)
                 }
                 for lang in languages
             })
@@ -225,7 +235,7 @@ class Translation(List):
         return json.dumps({
             tr_key: str(translate(tr_key))
             for tr_key, values in systemTranslations.items()
-            if values.get("_public_")
+            if values.get("_public_") and fnmatch.fnmatch(tr_key, pattern)
         })
 
 


### PR DESCRIPTION
Allows to filter keys using an `fnmatch`-style pattern to keep request payload low.