### PR TITLE
fix: add `servingurl`  to `FileBone`s default `refKeys` setting

### DIFF
--- a/src/viur/core/bones/file.py
+++ b/src/viur/core/bones/file.py
@@ -146,6 +146,7 @@ class FileBone(TreeLeafBone):
             "height",
             "derived",
             "public",
+            "servingurl"
         ),
         public: bool = False,
         **kwargs

--- a/src/viur/core/bones/file.py
+++ b/src/viur/core/bones/file.py
@@ -146,7 +146,7 @@ class FileBone(TreeLeafBone):
             "height",
             "derived",
             "public",
-            "servingurl"
+            "servingurl",
         ),
         public: bool = False,
         **kwargs

--- a/src/viur/core/modules/file.py
+++ b/src/viur/core/modules/file.py
@@ -387,6 +387,9 @@ class FileLeafSkel(TreeSkel):
     serving_url = StringBone(
         descr="Serving-URL",
         readOnly=True,
+        params={
+            "tooltip": "The 'serving_url' is only available in public file repositories.",
+        }
     )
 
     def preProcessBlobLocks(self, locks):
@@ -1263,7 +1266,7 @@ class File(Tree):
                 and skel["mimetype"].startswith("image/") and not skel["serving_url"]:
 
             try:
-                bucket = File.get_bucket(skel['dlkey'])
+                bucket = File.get_bucket(skel["dlkey"])
                 skel["serving_url"] = images.get_serving_url(
                     None,
                     secure_url=True,


### PR DESCRIPTION
just add servingurl to default refkeys in filebone.
Enhancement for #1241.