### PR TITLE
fix: Lower deprecations for `Skeleton.fromDB/toDB`

### DIFF
--- a/src/viur/core/skeleton.py
+++ b/src/viur/core/skeleton.py
@@ -1098,7 +1098,7 @@ class Skeleton(BaseSkeleton, metaclass=MetaSkel):
     @deprecated(
         version="3.7.0",
         reason="Use skel.read() instead of skel.fromDB()",
-        action="always"
+        action="once"
     )
     def fromDB(cls, skel: SkeletonInstance, key: KeyType) -> bool:
         """
@@ -1153,7 +1153,7 @@ class Skeleton(BaseSkeleton, metaclass=MetaSkel):
     @deprecated(
         version="3.7.0",
         reason="Use skel.write() instead of skel.toDB()",
-        action="always"
+        action="once"
     )
     def toDB(cls, skel: SkeletonInstance, update_relations: bool = True, **kwargs) -> db.Key:
         """


### PR DESCRIPTION
Remove fromDB() and toDB() deprecation warnings for now?

I think it's still too early, especially because there are API changes that may lead to unwanted errors and breaking.

Pros:
- fromDB() and toDB() already use read() and write() internally
- API remains compatible

Cons:
- Projects may not be willing to change their API calls.