### PR TITLE
feat: Public-files repos and improved rootnodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ This file documents any relevant changes done to ViUR-core since version 3.
 - feat: Make SkeletonInstance json serializable (#1262)
 - feat: Provide `ignore`-parameter for `Skeleton.fromClient` (#1330)
 - feat: Provide `User.is_active()` function (#1309)
+- feat: Public-files repos and improved rootnodes
 - feat: Retrieve default `descr` from bone's name in its Skeleton (#1227)
 - feat+refactor: Improved and extended `Skeleton.subskel()` (#1259)
 - fix: `File.write()` didn't return `db.Key` (#1303)

--- a/src/viur/core/modules/file.py
+++ b/src/viur/core/modules/file.py
@@ -428,7 +428,18 @@ class FileNodeSkel(TreeSkel):
     rootNode = BooleanBone(
         descr="Is RootNode",
         defaultValue=False,
+        readOnly=True,
+        visible=False,
     )
+
+    public = BooleanBone(
+        descr="Is public?",
+        defaultValue=False,
+        readOnly=True,
+        visible=False,
+    )
+
+    viurCurrentSeoKeys = None
 
 
 class File(Tree):
@@ -858,6 +869,9 @@ class File(Tree):
 
             if not self.canAdd("leaf", rootNode):
                 raise errors.Forbidden()
+
+            if rootNode and public != bool(rootNode.get("public")):
+                raise errors.Forbidden("Cannot upload a public file into private repository or vice versa")
 
             maxSize = None  # The user has some file/add permissions, don't restrict fileSize
 

--- a/src/viur/core/render/json/default.py
+++ b/src/viur/core/render/json/default.py
@@ -233,6 +233,7 @@ class DefaultRender(AbstractRenderer):
         return json.dumps("OKAY")
 
     def listRootNodes(self, rootNodes, *args, **kwargs):
+        current.request.get().response.headers["Content-Type"] = "application/json"
         return json.dumps(rootNodes, cls=CustomJsonEncoder)
 
     def render(self, action: str, skel: t.Optional[SkeletonInstance] = None, **kwargs):

--- a/src/viur/core/version.py
+++ b/src/viur/core/version.py
@@ -3,7 +3,7 @@
 # This will mark it as a pre-release as well on PyPI.
 # See CONTRIBUTING.md for further information.
 
-__version__ = "3.7.0.rc8"
+__version__ = "3.7.0.rc9"
 
 assert __version__.count(".") >= 2 and "".join(__version__.split(".", 3)[:3]).isdigit(), \
     "Semantic __version__ expected!"


### PR DESCRIPTION
- `Skeleton.read()` now allows to create an entry when not existing (Skeletonish replacement for db.GetOrInsert()`
- `Tree.rootnodeSkel()` with optional ensure-feature
- Deprecation of `Tree.ensureOwnModuleRootNode()`
- `File.FileNodeSkel` now contains a `public`-bone to identify public root nodes
- `File.getUploadURL()` checks against public-setting of the uploaded file and the repository given