### PR TITLE
fix: `FileBone.postSaveHandler` iterates over `None`

### DIFF
--- a/src/viur/core/bones/file.py
+++ b/src/viur/core/bones/file.py
@@ -214,7 +214,7 @@ class FileBone(TreeLeafBone):
         def handleDerives(values):
             if isinstance(values, dict):
                 values = [values]
-            for val in values:  # Ensure derives getting build for each file referenced in this relation
+            for val in (values or ()):  # Ensure derives getting build for each file referenced in this relation
                 ensureDerived(val["dest"]["key"], f"{skel.kindName}_{boneName}", self.derive)
 
         values = skel[boneName]


### PR DESCRIPTION
An empty multi-lang `FileBone` has `None` values

```py
 Traceback (most recent call last):
  File "/layers/google.python.pip/pip/lib/python3.11/site-packages/viur/toolkit/importer/importable.py", line 616, in _convert_entry
    assert skel.toDB(update_relations=updateRelations)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/layers/google.python.pip/pip/lib/python3.11/site-packages/viur/core/skeleton.py", line 1193, in toDB
    bone.postSavedHandler(skel, bone_name, key)
  File "/layers/google.python.pip/pip/lib/python3.11/site-packages/viur/core/bones/file.py", line 224, in postSavedHandler
    handleDerives(values[lang])
  File "/layers/google.python.pip/pip/lib/python3.11/site-packages/viur/core/bones/file.py", line 217, in handleDerives
    for val in values:  # Ensure derives getting build for each file referenced in this relation
TypeError: 'NoneType' object is not iterable
```