### PR TITLE
feat: Add `*args` and `**kwars` to callable acess func

### DIFF
--- a/src/viur/core/module.py
+++ b/src/viur/core/module.py
@@ -288,7 +288,7 @@ class Method:
                     # Callable directly tests access
                     if callable(acc):
                         try:
-                            if acc(*args,**kwargs):
+                            if acc(*args, **kwargs):
                                 ok = True
                                 break
                         except TypeError:

--- a/src/viur/core/module.py
+++ b/src/viur/core/module.py
@@ -287,9 +287,14 @@ class Method:
 
                     # Callable directly tests access
                     if callable(acc):
-                        if acc():
-                            ok = True
-                            break
+                        try:
+                            if acc(*args,**kwargs):
+                                ok = True
+                                break
+                        except TypeError:
+                            if acc():
+                                ok = True
+                                break
 
                         continue
 


### PR DESCRIPTION
Can you solve the following problem: If you have a skel in a list that only certain people should have access to.
Like:
```python
def bar(key, *args, **kwargs):
    user = current.user.get()
    if "manager" in user["access"]:
        return key == "example_key"
    return False
 
@access(bar)
def foo(key, param1, parma2):
    ....
```