### PR TITLE
fix: Regression from `canView()` refactoring

### DIFF
--- a/src/viur/core/prototypes/list.py
+++ b/src/viur/core/prototypes/list.py
@@ -432,7 +432,7 @@ class List(SkelModule):
 
         query = self.listFilter(query)  # Access control
 
-        if query is None or not query.getEntry():
+        if query is None or (key and not query.getEntry()):
             return False
 
         return True

--- a/src/viur/core/prototypes/tree.py
+++ b/src/viur/core/prototypes/tree.py
@@ -735,7 +735,7 @@ class Tree(SkelModule):
 
         query = self.listFilter(query)  # Access control
 
-        if query is None or not query.getEntry():
+        if query is None or (key and not query.getEntry()):
             return False
 
         return True


### PR DESCRIPTION
Either the query must be valid, and in case a key is provided, the entry must be readable.