### PR TITLE
fix: Ensure derives are generated in `FileBone` inside a `RecordBone` too

### DIFF
--- a/src/viur/core/bones/base.py
+++ b/src/viur/core/bones/base.py
@@ -1093,13 +1093,13 @@ class BaseBone(object):
         """
         pass  # We do nothing by default
 
-    def postSavedHandler(self, skel: 'viur.core.skeleton.SkeletonInstance', boneName: str, key: str):
+    def postSavedHandler(self, skel: "SkeletonInstance", boneName: str, key: db.Key | None) -> None:
         """
             Can be overridden to perform further actions after the main entity has been written.
 
             :param boneName: Name of this bone
             :param skel: The skeleton this bone belongs to
-            :param key: The (new?) Database Key we've written to
+            :param key: The (new?) Database Key we've written to. In case of a RelSkel the key is None.
         """
         pass
 

--- a/src/viur/core/bones/file.py
+++ b/src/viur/core/bones/file.py
@@ -212,15 +212,12 @@ class FileBone(TreeLeafBone):
         super().postSavedHandler(skel, boneName, key)
         from viur.core.skeleton import RelSkel, Skeleton
 
-        logging.debug(f"{skel}")
-        logging.debug(f"{skel.skeletonCls}")
         if issubclass(skel.skeletonCls, Skeleton):
             prefix = f"{skel.kindName}_{boneName}"
-        elif issubclass(skel.skeletonCls, RelSkel):
+        elif issubclass(skel.skeletonCls, RelSkel):  # RelSkel is just a container and has no kindname
             prefix = f"{skel.skeletonCls.__name__}_{boneName}"
         else:
             raise NotImplementedError(f"Cannot handle {skel.skeletonCls=}")
-        logging.debug(f"{prefix}: {skel.skeletonCls}")
 
         def handleDerives(values):
             if isinstance(values, dict):

--- a/src/viur/core/bones/file.py
+++ b/src/viur/core/bones/file.py
@@ -210,12 +210,23 @@ class FileBone(TreeLeafBone):
         the derived files directly.
         """
         super().postSavedHandler(skel, boneName, key)
+        from viur.core.skeleton import RelSkel, Skeleton
+
+        logging.debug(f"{skel}")
+        logging.debug(f"{skel.skeletonCls}")
+        if issubclass(skel.skeletonCls, Skeleton):
+            prefix = f"{skel.kindName}_{boneName}"
+        elif issubclass(skel.skeletonCls, RelSkel):
+            prefix = f"{skel.skeletonCls.__name__}_{boneName}"
+        else:
+            raise NotImplementedError(f"Cannot handle {skel.skeletonCls=}")
+        logging.debug(f"{prefix}: {skel.skeletonCls}")
 
         def handleDerives(values):
             if isinstance(values, dict):
                 values = [values]
             for val in (values or ()):  # Ensure derives getting build for each file referenced in this relation
-                ensureDerived(val["dest"]["key"], f"{skel.kindName}_{boneName}", self.derive)
+                ensureDerived(val["dest"]["key"], prefix, self.derive)
 
         values = skel[boneName]
         if self.derive and values:

--- a/src/viur/core/bones/record.py
+++ b/src/viur/core/bones/record.py
@@ -112,6 +112,13 @@ class RecordBone(BaseBone):
             for bone_name, bone in using.items():
                 bone.postSavedHandler(using, bone_name, None)
 
+    def refresh(self, skel, boneName) -> None:
+        super().refresh(skel, boneName)
+        for idx, lang, value in self.iter_bone_value(skel, boneName):
+            using = self.using()
+            using.unserialize(value)
+            for bone_name, bone in using.items():
+                bone.refresh(using, bone_name)
 
     def getSearchTags(self, skel: 'viur.core.skeleton.SkeletonInstance', name: str) -> set[str]:
         """

--- a/src/viur/core/bones/record.py
+++ b/src/viur/core/bones/record.py
@@ -1,6 +1,5 @@
 import json
 import typing as t
-import logging
 
 from viur.core.bones.base import BaseBone, ReadFromClientError, ReadFromClientErrorSeverity
 

--- a/src/viur/core/bones/record.py
+++ b/src/viur/core/bones/record.py
@@ -104,19 +104,13 @@ class RecordBone(BaseBone):
             )
         return usingSkel, usingSkel.errors
 
-    def postSavedHandler(self, skel: "SkeletonInstance", boneName: str, key: str) -> None:
+    def postSavedHandler(self, skel, boneName, key) -> None:
         super().postSavedHandler(skel, boneName, key)
-        try:
-            logging.info(f"Record bone {boneName=} | {key=} has been saved")
-            logging.debug(f"Record bone {skel=} has been saved")
-            for idx, lang, value in self.iter_bone_value(skel, boneName):
-                using = self.using()
-                using.unserialize(value)
-                logging.debug(f"{using=}")
-                for bone_name, bone in using.items():
-                    bone.postSavedHandler(using, bone_name, None)
-        except Exception as e:
-            logging.exception(e)
+        for idx, lang, value in self.iter_bone_value(skel, boneName):
+            using = self.using()
+            using.unserialize(value)
+            for bone_name, bone in using.items():
+                bone.postSavedHandler(using, bone_name, None)
 
 
     def getSearchTags(self, skel: 'viur.core.skeleton.SkeletonInstance', name: str) -> set[str]:

--- a/src/viur/core/bones/relational.py
+++ b/src/viur/core/bones/relational.py
@@ -491,7 +491,7 @@ class RelationalBone(BaseBone):
 
         return tuple(parts)
 
-    def postSavedHandler(self, skel: "SkeletonInstance", boneName: str, key: db.Key) -> None:
+    def postSavedHandler(self, skel, boneName, key) -> None:
         """
         Handle relational updates after a skeleton is saved.
 
@@ -502,7 +502,7 @@ class RelationalBone(BaseBone):
         :param boneName: The name of the relational bone.
         :param key: The key of the saved skeleton instance.
         """
-        if key is None:  # RecordBone container has no key
+        if key is None:  # RelSkel container (e.g. RecordBone) has no key, it's covered by it's parent
             return
         if not skel[boneName]:
             values = []

--- a/src/viur/core/bones/relational.py
+++ b/src/viur/core/bones/relational.py
@@ -502,6 +502,8 @@ class RelationalBone(BaseBone):
         :param boneName: The name of the relational bone.
         :param key: The key of the saved skeleton instance.
         """
+        if key is None:  # RecordBone container has no key
+            return
         if not skel[boneName]:
             values = []
         elif self.multiple and self.languages:

--- a/src/viur/core/tasks.py
+++ b/src/viur/core/tasks.py
@@ -791,9 +791,9 @@ class QueryIter(object, metaclass=MetaQueryIter):
         qry.origKind = qryDict["origKind"]
         qry.queries.distinct = qryDict["distinct"]
         if qry.srcSkel:
-            qryIter = qry.fetch(100)
+            qryIter = qry.fetch(5)
         else:
-            qryIter = qry.run(100)
+            qryIter = qry.run(5)
         for item in qryIter:
             try:
                 cls.handleEntry(item, qryDict["customData"])

--- a/src/viur/core/tasks.py
+++ b/src/viur/core/tasks.py
@@ -791,9 +791,9 @@ class QueryIter(object, metaclass=MetaQueryIter):
         qry.origKind = qryDict["origKind"]
         qry.queries.distinct = qryDict["distinct"]
         if qry.srcSkel:
-            qryIter = qry.fetch(5)
+            qryIter = qry.fetch(100)
         else:
-            qryIter = qry.run(5)
+            qryIter = qry.run(100)
         for item in qryIter:
             try:
                 cls.handleEntry(item, qryDict["customData"])


### PR DESCRIPTION
The `postSavedHandler` of the `FileBone` inside a `RelSkel` (which is used as `UsingSkel` for a `RecordBone`) was never called. Therefore `ensureDerived` was never called for this bone too and derives are never generated.

Fixes #817 