### PR TITLE
doc: Fix `SyntaxWarning: invalid escape sequence '\*'`

### DIFF
--- a/src/viur/core/skeleton.py
+++ b/src/viur/core/skeleton.py
@@ -1760,7 +1760,7 @@ class RefSkel(RelSkel):
     @classmethod
     def fromSkel(cls, kindName: str, *args: list[str]) -> t.Type[RefSkel]:
         """
-            Creates a relSkel from a skeleton-class using only the bones explicitly named in args.
+            Creates a ``RefSkel`` from a skeleton-class using only the bones explicitly named in ``args``.
 
             :param args: List of bone names we'll adapt
             :return: A new instance of RefSkel

--- a/src/viur/core/skeleton.py
+++ b/src/viur/core/skeleton.py
@@ -1760,8 +1760,7 @@ class RefSkel(RelSkel):
     @classmethod
     def fromSkel(cls, kindName: str, *args: list[str]) -> t.Type[RefSkel]:
         """
-            Creates a relSkel from a skeleton-class using only the bones explicitly named
-            in \*args
+            Creates a relSkel from a skeleton-class using only the bones explicitly named in args.
 
             :param args: List of bone names we'll adapt
             :return: A new instance of RefSkel


### PR DESCRIPTION
The previous docstring caused InvalidEscapeSequence warnings with Python 3.12