### PR TITLE
fix: skip `cached_property` in `Module._update_methods`

### DIFF
--- a/src/viur/core/module.py
+++ b/src/viur/core/module.py
@@ -1,5 +1,6 @@
 import copy
 import enum
+import functools
 import inspect
 import types
 import typing as t
@@ -539,7 +540,7 @@ class Module:
         for key in dir(self):
             if key[0] == "_":
                 continue
-            if isinstance(getattr(self.__class__, key, None), property):
+            if isinstance(getattr(self.__class__, key, None), (property, functools.cached_property)):
                 continue
 
             prop = getattr(self, key)


### PR DESCRIPTION
This speeds up the boot, since the `cached_property` isn't calculated during the boot, but lazily when it's needed.

And if you return a callable exposed via the cached_property you are just crazy :see_no_evil: 