### PR TITLE
fix: a `not caseSensitive` bone should lock the lower value

### DIFF
--- a/src/viur/core/bones/base.py
+++ b/src/viur/core/bones/base.py
@@ -389,7 +389,7 @@ class BaseBone(object):
             assignment.
         """
         if not self.isClonedInstance and getSystemInitialized() and key != "isClonedInstance" and not key.startswith(
-            "_"):
+                "_"):
             raise AttributeError("You cannot modify this Skeleton. Grab a copy using .clone() first")
         super().__setattr__(key, value)
 
@@ -1273,8 +1273,7 @@ class BaseBone(object):
         compute_fn_parameters = inspect.signature(self.compute.fn).parameters
         compute_fn_args = {}
         if "skel" in compute_fn_parameters:
-            from viur.core.skeleton import skeletonByKind, \
-                RefSkel  # noqa: E402 # import works only here because circular imports
+            from viur.core.skeleton import skeletonByKind, RefSkel  # noqa: E402 # import works only here because circular imports
 
             if issubclass(skel.skeletonCls, RefSkel):  # we have a ref skel we must load the complete skeleton
                 cloned_skel = skeletonByKind(skel.kindName)()

--- a/src/viur/core/bones/base.py
+++ b/src/viur/core/bones/base.py
@@ -1045,7 +1045,6 @@ class BaseBone(object):
                 return f"K-{keyHash(value)}"
             raise NotImplementedError(f"Type {type(value)} can't be safely used in an uniquePropertyIndex")
 
-        logging.debug(f"_hashValueForUniquePropertyIndex: {value=}")
         if not value and not self.unique.lockEmpty:
             return []  # We are zero/empty string and these should not be locked
         if not self.multiple:

--- a/src/viur/core/bones/base.py
+++ b/src/viur/core/bones/base.py
@@ -1045,6 +1045,7 @@ class BaseBone(object):
                 return f"K-{keyHash(value)}"
             raise NotImplementedError(f"Type {type(value)} can't be safely used in an uniquePropertyIndex")
 
+        logging.debug(f"_hashValueForUniquePropertyIndex: {value=}")
         if not value and not self.unique.lockEmpty:
             return []  # We are zero/empty string and these should not be locked
         if not self.multiple:

--- a/src/viur/core/bones/string.py
+++ b/src/viur/core/bones/string.py
@@ -351,10 +351,12 @@ class StringBone(BaseBone):
             # Not yet implemented as it's unclear if we should keep each language distinct or not
             raise NotImplementedError()
 
-        if not self.caseSensitive and (val := skel[name]) is not None:
+        if not self.caseSensitive and (value := skel[name]) is not None:
             if self.multiple:
-                val = [v.lower() for v in val]
-            return self._hashValueForUniquePropertyIndex(val.lower())
+                value = [v.lower() for v in value]
+            else:
+                value = value.lower()
+            return self._hashValueForUniquePropertyIndex(value)
 
         return super().getUniquePropertyIndexValues(skel, name)
 

--- a/src/viur/core/bones/string.py
+++ b/src/viur/core/bones/string.py
@@ -351,6 +351,9 @@ class StringBone(BaseBone):
             # Not yet implemented as it's unclear if we should keep each language distinct or not
             raise NotImplementedError()
 
+        if not self.caseSensitive and (val := skel[name]) is not None:
+            return self._hashValueForUniquePropertyIndex(val.lower())
+
         return super().getUniquePropertyIndexValues(skel, name)
 
     def refresh(self, skel: "SkeletonInstance", bone_name: str) -> None:

--- a/src/viur/core/bones/string.py
+++ b/src/viur/core/bones/string.py
@@ -352,6 +352,8 @@ class StringBone(BaseBone):
             raise NotImplementedError()
 
         if not self.caseSensitive and (val := skel[name]) is not None:
+            if self.multiple:
+                val = [v.lower() for v in val]
             return self._hashValueForUniquePropertyIndex(val.lower())
 
         return super().getUniquePropertyIndexValues(skel, name)


### PR DESCRIPTION
The idea of _caseINSensitive_ bones is that the upper/lower case does not matter and `"Test"`, `"test"`, and `"TEST"` are equivalent.

If you now have a unique contstraint `UniqueLockMethod.SameValue`, it is still possible to create the three entries.

---

Alternatively, we could of course also introduce `UniqueLockMethod.EqualValue`, which controls this even more precisely.