### PR TITLE
feat: Provide `add_or_edit` root-only endpoint for importers

### DIFF
--- a/src/viur/core/prototypes/singleton.py
+++ b/src/viur/core/prototypes/singleton.py
@@ -56,6 +56,10 @@ class Singleton(SkelModule):
     ## External exposed functions
 
     @exposed
+    def index(self):
+        return self.view()
+
+    @exposed
     @skey
     def preview(self, *args, **kwargs) -> t.Any:
         """

--- a/src/viur/core/prototypes/skelmodule.py
+++ b/src/viur/core/prototypes/skelmodule.py
@@ -181,7 +181,7 @@ class SkelModule(Module):
         else:
             self.onEdit(skel)
 
-        skel.toDB()
+        skel.write()
 
         if is_add:
             self.onAdded(skel)

--- a/src/viur/core/prototypes/skelmodule.py
+++ b/src/viur/core/prototypes/skelmodule.py
@@ -188,7 +188,6 @@ class SkelModule(Module):
         else:
             self.onEdited(skel)
 
-        print(is_add)
         if is_add:
             return self.render.addSuccess(skel)
 

--- a/src/viur/core/prototypes/skelmodule.py
+++ b/src/viur/core/prototypes/skelmodule.py
@@ -185,10 +185,7 @@ class SkelModule(Module):
 
         if is_add:
             self.onAdded(skel)
-        else:
-            self.onEdited(skel)
-
-        if is_add:
             return self.render.addSuccess(skel)
 
+        self.onEdited(skel)
         return self.render.editSuccess(skel)

--- a/src/viur/core/prototypes/tree.py
+++ b/src/viur/core/prototypes/tree.py
@@ -287,6 +287,20 @@ class Tree(SkelModule):
     ## External exposed functions
 
     @exposed
+    def index(self, skelType: SkelType = "node", parententry: t.Optional[db.Key | int | str] = None, **kwargs):
+        if not parententry:
+            repos = self.getAvailableRootNodes(**kwargs)
+            match len(repos):
+                case 0:
+                    raise errors.Unauthorized()
+                case 1:
+                    parententry = repos[0]["key"]
+                case _:
+                    raise errors.NotAcceptable(f"Missing required parameter {'parententry'!r}")
+
+        return self.list(skelType=skelType, parententry=parententry, **kwargs)
+
+    @exposed
     def listRootNodes(self, *args, **kwargs) -> t.Any:
         """
         Renders a list of all available repositories for the current user using the


### PR DESCRIPTION
This endpoint allows for an `add_or_edit`-action with the ability to provide a key as well. It is restricted to 'root'-users.