### PR TITLE
fix: Remove overwriting `action` from `@deprecated` decorator

### DIFF
--- a/src/viur/core/__init__.py
+++ b/src/viur/core/__init__.py
@@ -70,8 +70,9 @@ __all__ = [
 ]
 
 # Show DeprecationWarning from the viur-core
-warnings.filterwarnings("always", category=DeprecationWarning, module=r"viur\.core.*")
-
+warnings.filterwarnings("once", category=DeprecationWarning)
+warnings.filterwarnings("ignore", category=DeprecationWarning, module=r"viur\.datastore.*",
+                        message="'clonedBoneMap' was renamed into 'bone_map'")
 
 def setDefaultLanguage(lang: str):
     """

--- a/src/viur/core/skeleton.py
+++ b/src/viur/core/skeleton.py
@@ -465,7 +465,6 @@ class BaseSkeleton(object, metaclass=MetaBaseSkel):
     @deprecated(
         version="3.7.0",
         reason="Function renamed. Use subskel function as alternative implementation.",
-        action="always"
     )
     def subSkel(cls, *subskel_names, fullClone: bool = False, **kwargs) -> SkeletonInstance:
         return cls.subskel(*subskel_names, clone=fullClone)  # FIXME: REMOVE WITH VIUR4
@@ -1099,7 +1098,6 @@ class Skeleton(BaseSkeleton, metaclass=MetaSkel):
     @deprecated(
         version="3.7.0",
         reason="Use skel.read() instead of skel.fromDB()",
-        action="once"
     )
     def fromDB(cls, skel: SkeletonInstance, key: KeyType) -> bool:
         """
@@ -1166,7 +1164,6 @@ class Skeleton(BaseSkeleton, metaclass=MetaSkel):
     @deprecated(
         version="3.7.0",
         reason="Use skel.write() instead of skel.toDB()",
-        action="once"
     )
     def toDB(cls, skel: SkeletonInstance, update_relations: bool = True, **kwargs) -> db.Key:
         """


### PR DESCRIPTION
The deprecations warnings on third party packages
(which are still in compatibility mode with 3.6) are getting annoying. Therefore I have set up the following warning filter in my project:

```py
    warnings.filterwarnings("ignore", category=DeprecationWarning, module=r"viur\.(shop|toolkit).*",
                            message="'clonedBoneMap' was renamed into 'bone_map'")
    warnings.filterwarnings("ignore", category=DeprecationWarning, module=r"viur\.(shop|toolkit).*",
                            message=r"Call to deprecated class method (subSkel|fromDB|toDB)")
```

Unfortunately it does not work, because the deprecations in the `skeleton` module are explicitly called with an `action `parameter. This in turn means that these warnings are executed in a separate context with exactly this action, all other filter conditions are overwritten or ignored.

I therefore suggest setting the general filter in the `__init__` to `"once"`.

The module filter was wrong at this point anyway. The `module` refers to the module that calls the deprecated method,
not the one that triggers the warning (my fault).

This general filter can easily be customized from a relaxed `"ignore"` to an annoying `"always"` in the project.

Alternatively, the `viur-core` could also use its own `DeprecationWarning` subclass so that these warnings could be filtered even more finely using the class filter.