### PR TITLE
fix: Improve error reporting for unknown `RelationalBone` kinds

### DIFF
--- a/src/viur/core/bones/relational.py
+++ b/src/viur/core/bones/relational.py
@@ -301,7 +301,14 @@ class RelationalBone(BaseBone):
         """
         super().setSystemInitialized()
         from viur.core.skeleton import RefSkel, SkeletonInstance
-        self._refSkelCache = RefSkel.fromSkel(self.kind, *self.refKeys)
+
+        try:
+            self._refSkelCache = RefSkel.fromSkel(self.kind, *self.refKeys)
+        except AssertionError:
+            raise NotImplementedError(
+                f"Skeleton {self.skel_cls!r} {self.__class__.__name__} {self.name!r}: Kind {self.kind!s} unknown"
+            )
+
         self._skeletonInstanceClassRef = SkeletonInstance
         self._ref_keys = set(self._refSkelCache.__boneMap__.keys())
 

--- a/src/viur/core/bones/relational.py
+++ b/src/viur/core/bones/relational.py
@@ -306,7 +306,7 @@ class RelationalBone(BaseBone):
             self._refSkelCache = RefSkel.fromSkel(self.kind, *self.refKeys)
         except AssertionError:
             raise NotImplementedError(
-                f"Skeleton {self.skel_cls!r} {self.__class__.__name__} {self.name!r}: Kind {self.kind!s} unknown"
+                f"Skeleton {self.skel_cls!r} {self.__class__.__name__} {self.name!r}: Kind {self.kind!r} unknown"
             )
 
         self._skeletonInstanceClassRef = SkeletonInstance


### PR DESCRIPTION
Changes the error reporting
```
  File "~/project/viur-core/src/viur/core/__init__.py", line 266, in setup
    setSystemInitialized()
  File "~/project/viur-core/src/viur/core/bones/base.py", line 44, in setSystemInitialized
    skelCls.setSystemInitialized()
  File "~/project/viur-core/src/viur/core/skeleton.py", line 553, in setSystemInitialized
    bone.setSystemInitialized()
  File "~/project/viur-core/src/viur/core/bones/relational.py", line 304, in setSystemInitialized
    self._refSkelCache = RefSkel.fromSkel(self.kind, *self.refKeys)
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/project/viur-core/src/viur/core/skeleton.py", line 1770, in fromSkel
    fromSkel = skeletonByKind(kindName)
               ^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/project/viur-core/src/viur/core/skeleton.py", line 1835, in skeletonByKind
    assert kindName in MetaBaseSkel._skelCache, f"Unknown skeleton {kindName=}"
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: Unknown skeleton kindName='shop_shipping_config'
```
into
```
  File "~/project/viur-core/src/viur/core/__init__.py", line 266, in setup
    setSystemInitialized()
  File "~/project/viur-core/src/viur/core/bones/base.py", line 44, in setSystemInitialized
    skelCls.setSystemInitialized()
  File "~/project/viur-core/src/viur/core/skeleton.py", line 553, in setSystemInitialized
    bone.setSystemInitialized()
  File "~/project/viur-core/src/viur/core/bones/relational.py", line 308, in setSystemInitialized
    raise NotImplementedError(
NotImplementedError: Skeleton <class 'skeletons.variant.VariantSkel'> RelationalBone 'shop_shipping_config': Kind 'shop_shipping_config' unknown
```