### PR TITLE
  fix: Email methods has been renamed

### DIFF
--- a/src/viur/core/__init__.py
+++ b/src/viur/core/__init__.py
@@ -254,7 +254,7 @@ def setup(modules:  ModuleType | object, render:  ModuleType | object = None, de
             and (not conf.instance.is_dev_server or conf.debug.dev_server_cloud_logging)):
         from viur.core import email
         try:
-            email.send_emailToAdmins(
+            email.send_email_to_admins(
                 "Debug mode enabled",
                 "ViUR just started a new Instance with call tracing enabled! This might log sensitive information!"
             )

--- a/src/viur/core/__init__.py
+++ b/src/viur/core/__init__.py
@@ -254,7 +254,7 @@ def setup(modules:  ModuleType | object, render:  ModuleType | object = None, de
             and (not conf.instance.is_dev_server or conf.debug.dev_server_cloud_logging)):
         from viur.core import email
         try:
-            email.sendEMailToAdmins(
+            email.send_emailToAdmins(
                 "Debug mode enabled",
                 "ViUR just started a new Instance with call tracing enabled! This might log sensitive information!"
             )

--- a/src/viur/core/config.py
+++ b/src/viur/core/config.py
@@ -558,7 +558,7 @@ class Email(ConfigType):
     """If set, this sender will be used, regardless of what the templates advertise as sender"""
 
     admin_recipients: str | list[str] | t.Callable[[], str | list[str]] = None
-    """Sets recipients for mails send with :meth:`email.send_emailToAdmins`.
+    """Sets recipients for mails send with :meth:`email.send_email_to_admins`.
     If not set, all root users will be used."""
 
     _mapping = {

--- a/src/viur/core/config.py
+++ b/src/viur/core/config.py
@@ -545,7 +545,7 @@ class Email(ConfigType):
 
     recipient_override: str | list[str] | t.Callable[[], str | list[str]] | t.Literal[False] = None
     """If set, all outgoing emails will be sent to this address
-    (overriding the 'dests'-parameter in email.sendEmail)
+    (overriding the 'dests'-parameter in :meth:`core.email.send_email`)
     """
 
     sender_default: str = f"viur@{_project_id}.appspotmail.com"
@@ -558,7 +558,8 @@ class Email(ConfigType):
     """If set, this sender will be used, regardless of what the templates advertise as sender"""
 
     admin_recipients: str | list[str] | t.Callable[[], str | list[str]] = None
-    """Sets recipients for mails send with email.sendEMailToAdmins. If not set, all root users will be used."""
+    """Sets recipients for mails send with :meth:`email.send_emailToAdmins`.
+    If not set, all root users will be used."""
 
     _mapping = {
         "logRetention": "log_retention",

--- a/src/viur/core/config.py
+++ b/src/viur/core/config.py
@@ -535,7 +535,7 @@ class Email(ConfigType):
 
     transport_class: "EmailTransport" = None
     """EmailTransport instance that actually delivers the email using the service provider
-    of choice. See email.py for more details
+    of choice. See :module:`core.email` for more details
     """
 
     send_from_local_development_server: bool = False
@@ -558,7 +558,7 @@ class Email(ConfigType):
     """If set, this sender will be used, regardless of what the templates advertise as sender"""
 
     admin_recipients: str | list[str] | t.Callable[[], str | list[str]] = None
-    """Sets recipients for mails send with :meth:`email.send_email_to_admins`.
+    """Sets recipients for mails send with :meth:`core.email.send_email_to_admins`.
     If not set, all root users will be used."""
 
     _mapping = {

--- a/src/viur/core/email.py
+++ b/src/viur/core/email.py
@@ -622,7 +622,7 @@ class EmailTransportBrevo(EmailTransport):
                     logging.info(f"Already send an email for {limit = }.")
                     break
 
-                sendEMailToAdmins(
+                send_email_to_admins(
                     f"SendInBlue email budget {credits} ({idx}. warning)",
                     f"The SendInBlue email budget reached {credits} credits "
                     f"for {data['email']}. Please increase soon.",

--- a/src/viur/core/modules/user.py
+++ b/src/viur/core/modules/user.py
@@ -1620,7 +1620,7 @@ def createNewUserIfNotExists():
             msg = f"ViUR created a new admin-user for you!\nUsername: {uname}\nPassword: {pw}"
 
             logging.warning(msg)
-            email.send_emailToAdmins("New ViUR password", msg)
+            email.send_email_to_admins("New ViUR password", msg)
 
 
 # DEPRECATED ATTRIBUTES HANDLING

--- a/src/viur/core/modules/user.py
+++ b/src/viur/core/modules/user.py
@@ -1620,7 +1620,7 @@ def createNewUserIfNotExists():
             msg = f"ViUR created a new admin-user for you!\nUsername: {uname}\nPassword: {pw}"
 
             logging.warning(msg)
-            email.sendEMailToAdmins("New ViUR password", msg)
+            email.send_emailToAdmins("New ViUR password", msg)
 
 
 # DEPRECATED ATTRIBUTES HANDLING

--- a/src/viur/core/scripts/viur_migrate.py
+++ b/src/viur/core/scripts/viur_migrate.py
@@ -42,8 +42,8 @@ lookup = {
     "toDB": "write",
     "fromDB": "read",
     re.compile(r"\bsubSkel\b"): "subskel",
-    "sendEMail": "send_email",
     "sendEMailToAdmins": "send_email_to_admins",
+    "sendEMail": "send_email",
 
     # WARNING: THESE MUST BE KEPT AT THE END, THE ORDER MATTERS!!!!
     "projectID": "conf.instance.project_id",

--- a/src/viur/core/scripts/viur_migrate.py
+++ b/src/viur/core/scripts/viur_migrate.py
@@ -42,6 +42,8 @@ lookup = {
     "toDB": "write",
     "fromDB": "read",
     re.compile(r"\bsubSkel\b"): "subskel",
+    "sendEMail": "send_email",
+    "sendEMailToAdmins": "send_email_to_admins",
 
     # WARNING: THESE MUST BE KEPT AT THE END, THE ORDER MATTERS!!!!
     "projectID": "conf.instance.project_id",

--- a/src/viur/core/tasks.py
+++ b/src/viur/core/tasks.py
@@ -190,7 +190,7 @@ class TaskHandler(Module):
         retryCount = req.headers.get("X-Appengine-Taskretrycount", None)
         if retryCount and int(retryCount) == self.retryCountWarningThreshold:
             from viur.core import email
-            email.sendEMailToAdmins(
+            email.send_emailToAdmins(
                 "Deferred task retry counter exceeded warning threshold",
                 f"""Task {req.headers.get("X-Appengine-Taskname", "")} is retried for the {retryCount}th time."""
             )

--- a/src/viur/core/tasks.py
+++ b/src/viur/core/tasks.py
@@ -190,7 +190,7 @@ class TaskHandler(Module):
         retryCount = req.headers.get("X-Appengine-Taskretrycount", None)
         if retryCount and int(retryCount) == self.retryCountWarningThreshold:
             from viur.core import email
-            email.send_emailToAdmins(
+            email.send_email_to_admins(
                 "Deferred task retry counter exceeded warning threshold",
                 f"""Task {req.headers.get("X-Appengine-Taskname", "")} is retried for the {retryCount}th time."""
             )


### PR DESCRIPTION


* Add name mapping in viur-migrate
* Rename calls in core itself
