### PR TITLE
fix: Use variable instead of custom name joining for public bucket

### DIFF
--- a/src/viur/core/modules/file.py
+++ b/src/viur/core/modules/file.py
@@ -508,7 +508,7 @@ class File(Tree):
                 return _public_bucket
 
             raise ValueError(
-                f"""The bucket 'public-dot-{_PROJECT_ID}' does not exist! Please create it with ACL access."""
+                f"""The bucket '{PUBLIC_BUCKET_NAME}' does not exist! Please create it with ACL access."""
             )
 
         return _private_bucket


### PR DESCRIPTION
I monkey patched this name for testing and the error was confusing.