### PR TITLE
Update README Copyright Year from 2024 to 2025 README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ See our [contribution guidelines](CONTRIBUTING.md) for details.
 
 ## License
 
-Copyright © 2024 by Mausbrand Informationssysteme GmbH.<br>
+Copyright © 2025 by Mausbrand Informationssysteme GmbH.<br>
 Mausbrand and ViUR are registered trademarks of Mausbrand Informationssysteme GmbH.
 
 Licensed under the MIT license. See LICENSE for more information.


### PR DESCRIPTION
**Summary**
This pull request updates the copyright notice in the README.md file to reflect the new year, 2025. This ensures that all project documentation remains up to date and legally accurate.

**Motivation & Background**
The copyright statement in the documentation serves as an important legal declaration of ownership and protection for the intellectual property contained within this repository. As we have now transitioned into the year 2025, it is necessary to update this statement to maintain correctness and compliance with best practices. Keeping legal notices current demonstrates diligence and professionalism, preventing potential ambiguities regarding the rights and protection period of this project.

**Changes Introduced**
Modified the year in the copyright statement from 2024 to 2025 in README.md. No other content has been altered to preserve the integrity of the document. Impact & Risks
This change is purely administrative and does not impact the functionality, performance, or stability of the project. No dependencies, source code, or configurations have been modified.

**Testing & Verification**
As this is a documentation update, no functional testing is required. However, a manual review has been conducted to confirm that the change is correctly applied.

**Next Steps**
Merge this pull request to ensure the repository remains aligned with the current year. Optionally, check for other instances of the year 2024 in legal or documentation files that may require similar updates.

While this update is minor, it reflects the project's commitment to maintaining accuracy in all aspects, including documentation.