### PR TITLE
fix: `FileBone.refresh()` should fix `serving_url`

### DIFF
--- a/src/viur/core/bones/relational.py
+++ b/src/viur/core/bones/relational.py
@@ -1027,11 +1027,8 @@ class RelationalBone(BaseBone):
         if not skel[name] or self.updateLevel == RelationalUpdateLevel.OnValueAssignment:
             return
 
-        for idx, lang, value in self.iter_bone_value(skel, name):
-            if value is None:
-                continue
-
-            if value["dest"]:
+        for _, _, value in self.iter_bone_value(skel, name):
+            if value and value["dest"]:
                 try:
                     target_skel = value["dest"].read()
                 except ValueError:


### PR DESCRIPTION
This is part of the "public-Files"-feature introduced with viur-core 3.7. In case of a RelationalBone configured as public, and an assigned image that is public but has no serving_url, the referenced entry should be refreshed as well.