### PR TITLE
fix: `BooleanBone.refresh()` doesn't respect language

### DIFF
--- a/src/viur/core/bones/boolean.py
+++ b/src/viur/core/bones/boolean.py
@@ -68,7 +68,10 @@ class BooleanBone(BaseBone):
 
             :param name: The property-name this bone has in its Skeleton (not the description!)
         """
-        if not isinstance(skel[boneName], bool):
+        if self.languages:
+            for lang in self.languages:
+                skel[boneName][lang] = utils.parse.bool(skel[boneName][lang], conf.bone_boolean_str2true)
+        else:
             skel[boneName] = utils.parse.bool(skel[boneName], conf.bone_boolean_str2true)
 
     def setBoneValue(
@@ -114,7 +117,7 @@ class BooleanBone(BaseBone):
             values.
             The serialized value should be suitable for storage in the database.
         """
-        return utils.parse.bool(value)
+        return utils.parse.bool(value, conf.bone_boolean_str2true)
 
     def buildDBFilter(
         self,

--- a/src/viur/core/bones/boolean.py
+++ b/src/viur/core/bones/boolean.py
@@ -60,7 +60,7 @@ class BooleanBone(BaseBone):
             return True
         return not bool(value)
 
-    def refresh(self, skel: 'viur.core.skeleton.SkeletonInstance', boneName: str) -> None:
+    def refresh(self, skel: 'viur.core.skeleton.SkeletonInstance', name: str) -> None:
         """
             Inverse of serialize. Evaluates whats
             read from the datastore and populates
@@ -70,9 +70,10 @@ class BooleanBone(BaseBone):
         """
         if self.languages:
             for lang in self.languages:
-                skel[boneName][lang] = utils.parse.bool(skel[boneName][name], conf.bone_boolean_str2true) if lang in skel[name] else self.getDefaultValue(skel)
+                skel[name][lang] = utils.parse.bool(skel[name][lang], conf.bone_boolean_str2true) \
+                    if lang in skel[name] else self.getDefaultValue(skel)
         else:
-            skel[boneName] = utils.parse.bool(skel[boneName], conf.bone_boolean_str2true)
+            skel[name] = utils.parse.bool(skel[name], conf.bone_boolean_str2true)
 
     def setBoneValue(
         self,

--- a/src/viur/core/bones/boolean.py
+++ b/src/viur/core/bones/boolean.py
@@ -70,7 +70,7 @@ class BooleanBone(BaseBone):
         """
         if self.languages:
             for lang in self.languages:
-                skel[boneName][lang] = utils.parse.bool(skel[boneName][lang], conf.bone_boolean_str2true)
+                skel[boneName][lang] = utils.parse.bool(skel[boneName][name], conf.bone_boolean_str2true) if lang in skel[name] else self.getDefaultValue(skel)
         else:
             skel[boneName] = utils.parse.bool(skel[boneName], conf.bone_boolean_str2true)
 

--- a/src/viur/core/skeleton.py
+++ b/src/viur/core/skeleton.py
@@ -1258,9 +1258,8 @@ class Skeleton(BaseSkeleton, metaclass=MetaSkel):
                     # Serialize bone into entity
                     try:
                         bone.serialize(skel, bone_name, True)
-                    except Exception:
-                        logging.error(f"Failed to serialize {bone_name} {bone} {skel.accessedValues[bone_name]}")
-                        raise
+                    except Exception as e:
+                        logging.exception(e)
 
                 # Obtain referenced blobs
                 blob_list.update(bone.getReferencedBlobs(skel, bone_name))

--- a/src/viur/core/skeleton.py
+++ b/src/viur/core/skeleton.py
@@ -1251,15 +1251,13 @@ class Skeleton(BaseSkeleton, metaclass=MetaSkel):
 
                 if not (bone_name in skel.accessedValues or bone.compute) and bone_name not in skel.dbEntity:
                     _ = skel[bone_name]  # Ensure the datastore is filled with the default value
+
                 if (
                     bone_name in skel.accessedValues or bone.compute  # We can have a computed value on store
                     or bone_name not in skel.dbEntity  # It has not been written and is not in the database
                 ):
                     # Serialize bone into entity
-                    try:
-                        bone.serialize(skel, bone_name, True)
-                    except Exception as e:
-                        logging.exception(e)
+                    bone.serialize(skel, bone_name, True)
 
                 # Obtain referenced blobs
                 blob_list.update(bone.getReferencedBlobs(skel, bone_name))


### PR DESCRIPTION
- Fixed `BooleanBone.refresh()` to respect a language setting
- Improved `BooleanBone.singleValueFromClient()` to use conf-values for booleans
- ~Fixed `Skeleton.write()` to not raise a catched Exception when it occurs (in this case, came from the resolved bug: Value of type bool is not iterable)~