### PR TITLE
fix: Make translations usable

### DIFF
--- a/src/viur/core/bones/string.py
+++ b/src/viur/core/bones/string.py
@@ -28,6 +28,7 @@ class StringBone(BaseBone):
         max_length: int | None = 254,
         min_length: int | None = None,
         natural_sorting: bool | t.Callable = False,
+        escape_html: bool = True,
         **kwargs
     ):
         """
@@ -42,6 +43,8 @@ class StringBone(BaseBone):
             `True` enables sorting according to DIN 5007 Variant 2.
             With passing a `callable`, a custom transformer method can be set
             that creates the value for the index property.
+        :param escape_html: Replace some characters in the string with HTML-safe sequences with
+            using :meth:`utils.string.escape` for safe use in HTML.
         :param kwargs: Inherited arguments from the BaseBone.
         """
         # fixme: Remove in viur-core >= 4
@@ -67,6 +70,7 @@ class StringBone(BaseBone):
         elif not natural_sorting:
             self.natural_sorting = None
         # else: keep self.natural_sorting as is
+        self.escape_html = escape_html
 
     def type_coerce_single_value(self, value: t.Any) -> str:
         """Convert a value to a string (if not already)
@@ -167,9 +171,12 @@ class StringBone(BaseBone):
         Returns None and the escaped value if the value would be valid for
         this bone, otherwise the empty value and an error-message.
         """
-
         if not (err := self.isInvalid(str(value))):
-            return utils.string.escape(value, self.max_length), None
+            if self.escape_html:
+                return utils.string.escape(value, self.max_length), None
+            elif self.max_length:
+                return value[:self.max_length], None
+            return value, None
 
         return self.getEmptyValue(), [ReadFromClientError(ReadFromClientErrorSeverity.Invalid, err)]
 

--- a/src/viur/core/modules/translation.py
+++ b/src/viur/core/modules/translation.py
@@ -31,6 +31,7 @@ class TranslationSkel(Skeleton):
         ),
         searchable=True,
         required=True,
+        min_length=1,
         unique=UniqueValue(UniqueLockMethod.SameValue, False,
                            "This translation key exist already"),
     )

--- a/src/viur/core/modules/translation.py
+++ b/src/viur/core/modules/translation.py
@@ -9,7 +9,7 @@ from viur.core.decorators import exposed
 from viur.core.bones import *
 from viur.core.i18n import KINDNAME, initializeTranslations, systemTranslations, translate
 from viur.core.prototypes.list import List
-from viur.core.skeleton import Skeleton, SkeletonInstance
+from viur.core.skeleton import Skeleton, SkeletonInstance, ViurTagsSearchAdapter
 
 
 class Creator(enum.Enum):
@@ -20,12 +20,17 @@ class Creator(enum.Enum):
 class TranslationSkel(Skeleton):
     kindName = KINDNAME
 
+    database_adapters = [
+        ViurTagsSearchAdapter(max_length=256),
+    ]
+
     tr_key = StringBone(
         descr=translate(
             "core.translationskel.tr_key.descr",
             "Translation key",
         ),
         searchable=True,
+        required=True,
         unique=UniqueValue(UniqueLockMethod.SameValue, False,
                            "This translation key exist already"),
     )
@@ -37,6 +42,8 @@ class TranslationSkel(Skeleton):
         ),
         searchable=True,
         languages=conf.i18n.available_dialects,
+        escape_html=False,
+        max_length=1024,
         params={
             "tooltip": translate(
                 "core.translationskel.translations.tooltip",

--- a/src/viur/core/modules/translation.py
+++ b/src/viur/core/modules/translation.py
@@ -81,6 +81,7 @@ class TranslationSkel(Skeleton):
     )
 
     default_text = StringBone(
+        escape_html=False,
         descr=translate(
             "core.translationskel.default_text.descr",
             "Fallback value",

--- a/src/viur/core/modules/translation.py
+++ b/src/viur/core/modules/translation.py
@@ -24,12 +24,22 @@ class TranslationSkel(Skeleton):
         ViurTagsSearchAdapter(max_length=256),
     ]
 
+    name = StringBone(
+        descr="Name",
+        visible=False,
+        compute=Compute(
+            fn=lambda skel: str(skel["tr_key"]),
+            interval=ComputeInterval(ComputeMethod.OnWrite),
+        ),
+    )
+
     tr_key = StringBone(
         descr=translate(
             "core.translationskel.tr_key.descr",
             "Translation key",
         ),
         searchable=True,
+        escape_html=False,
         required=True,
         min_length=1,
         unique=UniqueValue(UniqueLockMethod.SameValue, False,


### PR DESCRIPTION
* `tr_key` must be required, otherwise this makes no sense for mappings
* longer `translations` should be supported too
* `tr_key`, `translations` and `default_text` should not be HTML escaped, sometimes they contains links, or words that should be highlighted with e.g. `<strong/>`
* `tr_key`s are often longer than 50 char, but they should still be searchable
* Use custom `name` implementation, instead of the `key`. (E.g. used for tabs in admin)