### PR TITLE
chore: Enforce config strict mode

### DIFF
--- a/src/viur/core/config.py
+++ b/src/viur/core/config.py
@@ -997,5 +997,5 @@ class Conf(ConfigType):
 
 
 conf = Conf(
-    strict_mode=os.getenv("VIUR_CORE_CONFIG_STRICT_MODE", "").lower() == "true",
+    strict_mode=os.getenv("VIUR_CORE_CONFIG_STRICT_MODE", "").lower() != "false",
 )


### PR DESCRIPTION
The new config type has now been established in the core for two versions.  
In order to force all projects that are still running in compatibility mode to change over, I think it is a good opportunity to activate strict mode by default for 3.8. If necessary, it can of course still be explicitly deactivated.