### PR TITLE
feat: Implement `TypeVar` for `Skeleton` and make `SkeletonInstance` `Generic`

### DIFF
--- a/src/viur/core/modules/translation.py
+++ b/src/viur/core/modules/translation.py
@@ -10,7 +10,7 @@ from viur.core.decorators import exposed
 from viur.core.bones import *
 from viur.core.i18n import KINDNAME, initializeTranslations, systemTranslations, translate
 from viur.core.prototypes.list import List
-from viur.core.skeleton import Skeleton, ViurTagsSearchAdapter
+from viur.core.skeleton import Skeleton, SkeletonInstance, ViurTagsSearchAdapter
 
 
 class Creator(enum.Enum):
@@ -211,7 +211,7 @@ class Translation(List):
         "admin": "*",
     }
 
-    def addSkel(self):
+    def addSkel(self) -> SkeletonInstance["TranslationSkel"]:
         """
         Returns a custom TranslationSkel where the name is editable.
         The name becomes part of the key.

--- a/src/viur/core/modules/user.py
+++ b/src/viur/core/modules/user.py
@@ -557,7 +557,7 @@ class UserPassword(UserPrimaryAuthentication):
     def canAdd(self) -> bool:
         return self.registrationEnabled
 
-    def addSkel(self):
+    def addSkel(self) -> skeleton.SkeletonInstance["UserSkel"]:
         """
             Prepare the add-Skel for rendering.
             Currently only calls self._user_module.addSkel() and sets skel["status"] depending on
@@ -1350,7 +1350,7 @@ class User(List):
 
         return ret
 
-    def addSkel(self):
+    def addSkel(self) -> skeleton.SkeletonInstance["UserSkel"]:
         skel = super().addSkel().clone()
 
         if self.is_admin(current.user.get()):
@@ -1377,7 +1377,7 @@ class User(List):
         skel.name.readOnly = False  # Don't enforce readonly name in user/add
         return skel
 
-    def editSkel(self, *args, **kwargs):
+    def editSkel(self, *args, **kwargs) -> skeleton.SkeletonInstance["UserSkel"]:
         skel = super().editSkel().clone()
 
         if "password" in skel:

--- a/src/viur/core/skeleton/__init__.py
+++ b/src/viur/core/skeleton/__init__.py
@@ -3,7 +3,7 @@ import warnings
 
 from .adapter import DatabaseAdapter, ViurTagsSearchAdapter
 from .instance import SkeletonInstance
-from .meta import ABSTRACT_SKEL_CLS_SUFFIX, BaseSkeleton, MetaBaseSkel, MetaSkel
+from .meta import ABSTRACT_SKEL_CLS_SUFFIX, BaseSkeleton, MetaBaseSkel, MetaSkel, Skeleton_Cls
 from .relskel import RefSkel, RelSkel
 from .skeleton import SeoKeyBone, Skeleton, _UNDEFINED_KINDNAME
 from .tasks import SkelIterTask, SkeletonMaintenanceTask, update_relations
@@ -55,6 +55,7 @@ __all__ = [
     SkelIterTask,
     SkelList,
     Skeleton,
+    Skeleton_Cls,
     SkeletonInstance,
     SkeletonMaintenanceTask,
     ViurTagsSearchAdapter,

--- a/src/viur/core/skeleton/instance.py
+++ b/src/viur/core/skeleton/instance.py
@@ -8,11 +8,12 @@ import warnings
 from functools import partial
 
 from viur.core import db
+from .meta import Skeleton_Cls
 from .skeleton import Skeleton
 from ..bones.base import BaseBone
 
 
-class SkeletonInstance:
+class SkeletonInstance(t.Generic[Skeleton_Cls]):
     """
         The actual wrapper around a Skeleton-Class. An object of this class is what's actually returned when you
         call a Skeleton-Class. With ViUR3, you don't get an instance of a Skeleton-Class any more - it's always this
@@ -32,7 +33,7 @@ class SkeletonInstance:
 
     def __init__(
         self,
-        skel_cls: t.Type[Skeleton],
+        skel_cls: t.Type[Skeleton_Cls],
         entity: t.Optional[db.Entity | dict] = None,
         *,
         bones: t.Iterable[str] = (),
@@ -104,7 +105,7 @@ class SkeletonInstance:
         self.is_cloned = clone
         self.renderAccessedValues = {}
         self.renderPreparation = None
-        self.skeletonCls = skel_cls
+        self.skeletonCls: t.Type[Skeleton_Cls] = skel_cls
 
     def items(self, yieldBoneValues: bool = False) -> t.Iterable[tuple[str, BaseBone]]:
         if yieldBoneValues:

--- a/src/viur/core/skeleton/instance.py
+++ b/src/viur/core/skeleton/instance.py
@@ -14,10 +14,56 @@ from ..bones.base import BaseBone
 
 
 class SkeletonInstance(t.Generic[Skeleton_Cls]):
-    """
-        The actual wrapper around a Skeleton-Class. An object of this class is what's actually returned when you
-        call a Skeleton-Class. With ViUR3, you don't get an instance of a Skeleton-Class any more - it's always this
-        class. This is much faster as this is a small class.
+    """The actual wrapper around a Skeleton-Class.
+
+    An object of this class is what's actually returned when you call a Skeleton-Class.
+    With ViUR3, you don't get an instance of a Skeleton-Class any more - it's always this
+    class. This is much faster as this is a small class.
+
+    The class is generic over :data:`Skeleton_Cls`, which lets the type checker track which
+    concrete Skeleton subclass a given instance belongs to.  Without the type parameter the
+    class still works exactly as before — the parameter is purely a static-analysis hint.
+
+    **Basic usage**
+
+    Calling a Skeleton class returns a typed ``SkeletonInstance``::
+
+        skel = ProductSkel()          # -> SkeletonInstance[ProductSkel]
+        skel.skeletonCls              # ProductSkel
+        skel["price"]                 # type-safe bone access
+
+    **Typed module method**
+
+    Override ``viewSkel`` / ``editSkel`` etc. in your module with an explicit return type
+    so that callers and IDE auto-complete know which bones are available::
+
+        class ProductModule(List):
+            def editSkel(self) -> SkeletonInstance[ProductSkel]:
+                skel = super().editSkel()
+                skel.price.readOnly = True
+                return skel
+
+    **Generic helper**
+
+    Use :data:`Skeleton_Cls` when writing utilities that must stay agnostic about the
+    concrete skeleton but still preserve the type through the call::
+
+        def set_owner(skel: SkeletonInstance[Skeleton_Cls], owner: str) -> SkeletonInstance[Skeleton_Cls]:
+            skel = skel.clone()
+            skel["owner"] = owner
+            return skel  # type checker keeps SkeletonInstance[ProductSkel] etc.
+
+    **Classmethod signatures** (``t.Self``)
+
+    Inside Skeleton classmethods, ``t.Self`` is preferred over :data:`Skeleton_Cls` because
+    the type checker automatically narrows to the class the method is called on::
+
+        class BaseSkeleton:
+            @classmethod
+            def fromClient(cls, skel: SkeletonInstance[t.Self], data: dict) -> bool: ...
+
+        # Inferred as SkeletonInstance[ProductSkel] when called on ProductSkel
+        ProductSkel.fromClient(skel, request.POST)
     """
     __slots__ = {
         "_cascade_deletion",

--- a/src/viur/core/skeleton/meta.py
+++ b/src/viur/core/skeleton/meta.py
@@ -16,6 +16,37 @@ from ..config import conf
 _UNDEFINED_KINDNAME = object()
 ABSTRACT_SKEL_CLS_SUFFIX = "AbstractSkel"
 
+#: TypeVar for generic skeleton typing.
+#:
+#: Use this to annotate functions and classes that work with a specific, but not yet known, Skeleton subclass.
+#: The type checker then knows which concrete Skeleton is in use and can validate bone access.
+#:
+#: Example — typed helper function::
+#:
+#:     from viur.core.skeleton import Skeleton_Cls, SkeletonInstance
+#:
+#:     def clone_and_set_owner(skel: SkeletonInstance[Skeleton_Cls], owner: str) -> SkeletonInstance[Skeleton_Cls]:
+#:         cloned = skel.clone()
+#:         cloned["owner"] = owner
+#:         return cloned
+#:
+#: Example — typed module override::
+#:
+#:     class ProductModule(List):
+#:         def editSkel(self) -> SkeletonInstance[ProductSkel]:
+#:             skel = super().editSkel()
+#:             skel.price.readOnly = True
+#:             return skel
+#:
+#: When calling a classmethod on a concrete Skeleton, use ``t.Self`` instead so the type checker
+#: automatically narrows to the calling class::
+#:
+#:     class BaseSkeleton:
+#:         @classmethod
+#:         def fromClient(cls, skel: SkeletonInstance[t.Self], data: dict) -> bool: ...
+#:
+#:     # Calling on a concrete class: type checker knows skel is SkeletonInstance[ProductSkel]
+#:     ProductSkel.fromClient(skel, request.POST)
 Skeleton_Cls = t.TypeVar("Skeleton_Cls", bound="BaseSkeleton")
 
 

--- a/src/viur/core/skeleton/meta.py
+++ b/src/viur/core/skeleton/meta.py
@@ -16,38 +16,40 @@ from ..config import conf
 _UNDEFINED_KINDNAME = object()
 ABSTRACT_SKEL_CLS_SUFFIX = "AbstractSkel"
 
-#: TypeVar for generic skeleton typing.
-#:
-#: Use this to annotate functions and classes that work with a specific, but not yet known, Skeleton subclass.
-#: The type checker then knows which concrete Skeleton is in use and can validate bone access.
-#:
-#: Example — typed helper function::
-#:
-#:     from viur.core.skeleton import Skeleton_Cls, SkeletonInstance
-#:
-#:     def clone_and_set_owner(skel: SkeletonInstance[Skeleton_Cls], owner: str) -> SkeletonInstance[Skeleton_Cls]:
-#:         cloned = skel.clone()
-#:         cloned["owner"] = owner
-#:         return cloned
-#:
-#: Example — typed module override::
-#:
-#:     class ProductModule(List):
-#:         def editSkel(self) -> SkeletonInstance[ProductSkel]:
-#:             skel = super().editSkel()
-#:             skel.price.readOnly = True
-#:             return skel
-#:
-#: When calling a classmethod on a concrete Skeleton, use ``t.Self`` instead so the type checker
-#: automatically narrows to the calling class::
-#:
-#:     class BaseSkeleton:
-#:         @classmethod
-#:         def fromClient(cls, skel: SkeletonInstance[t.Self], data: dict) -> bool: ...
-#:
-#:     # Calling on a concrete class: type checker knows skel is SkeletonInstance[ProductSkel]
-#:     ProductSkel.fromClient(skel, request.POST)
 Skeleton_Cls = t.TypeVar("Skeleton_Cls", bound="BaseSkeleton")
+"""TypeVar for generic skeleton typing.
+
+Use this to annotate functions and classes that work with a specific, but not yet known,
+Skeleton subclass. The type checker then knows which concrete Skeleton is in use and can
+validate bone access.
+
+Example — typed helper function::
+
+    from viur.core.skeleton import Skeleton_Cls, SkeletonInstance
+
+    def clone_and_set_owner(skel: SkeletonInstance[Skeleton_Cls], owner: str) -> SkeletonInstance[Skeleton_Cls]:
+        cloned = skel.clone()
+        cloned["owner"] = owner
+        return cloned
+
+Example — typed module override::
+
+    class ProductModule(List):
+        def editSkel(self) -> SkeletonInstance[ProductSkel]:
+            skel = super().editSkel()
+            skel.price.readOnly = True
+            return skel
+
+When calling a classmethod on a concrete Skeleton, use ``t.Self`` instead so the type checker
+automatically narrows to the calling class::
+
+    class BaseSkeleton:
+        @classmethod
+        def fromClient(cls, skel: SkeletonInstance[t.Self], data: dict) -> bool: ...
+
+    # Calling on a concrete class: type checker knows skel is SkeletonInstance[ProductSkel]
+    ProductSkel.fromClient(skel, request.POST)
+"""
 
 
 class MetaBaseSkel(type):

--- a/src/viur/core/skeleton/meta.py
+++ b/src/viur/core/skeleton/meta.py
@@ -16,6 +16,8 @@ from ..config import conf
 _UNDEFINED_KINDNAME = object()
 ABSTRACT_SKEL_CLS_SUFFIX = "AbstractSkel"
 
+Skeleton_Cls = t.TypeVar("Skeleton_Cls", bound="BaseSkeleton")
+
 
 class MetaBaseSkel(type):
     """
@@ -424,7 +426,7 @@ class BaseSkeleton(object, metaclass=MetaBaseSkel):
         return complete
 
     @classmethod
-    def refresh(cls, skel: "SkeletonInstance"):
+    def refresh(cls, skel: "SkeletonInstance[t.Self]"):
         """
             Refresh the bones current content.
 

--- a/src/viur/core/skeleton/skeleton.py
+++ b/src/viur/core/skeleton/skeleton.py
@@ -169,7 +169,7 @@ class Skeleton(BaseSkeleton, metaclass=MetaSkel):
     @classmethod
     def fromClient(
         cls,
-        skel: SkeletonInstance,
+        skel: "SkeletonInstance[t.Self]",
         data: dict[str, list[str] | str],
         *,
         amend: bool = False,

--- a/src/viur/core/skeleton/utils.py
+++ b/src/viur/core/skeleton/utils.py
@@ -51,7 +51,7 @@ class SkelList(list, t.Generic[Skeleton_Cls]):
         "renderPreparation",
     )
 
-    def __init__(self, skel: "SkeletonInstance[Skeleton_Cls]" = None, *items):
+    def __init__(self, skel: t.Optional["SkeletonInstance[Skeleton_Cls]"] = None, *items):
         """
             :param baseSkel: The baseclass for all entries in this list
         """

--- a/src/viur/core/skeleton/utils.py
+++ b/src/viur/core/skeleton/utils.py
@@ -33,14 +33,24 @@ def iterAllSkelClasses() -> t.Iterable["Skeleton"]:
 
 
 class SkelList(list, t.Generic[Skeleton_Cls]):
-    """
-        This class is used to hold multiple skeletons together with other, commonly used information.
+    """A typed list of :class:`SkeletonInstance` objects with query metadata.
 
-        SkelLists are returned by Skel().all()...fetch()-constructs and provide additional information
-        about the data base query, for fetching additional entries.
+    Returned by ``Skel().all()...fetch()`` constructs.  The generic parameter
+    mirrors the one on :class:`SkeletonInstance` so that the element type flows
+    through without manual casts::
 
-        :ivar cursor: Holds the cursor within a query.
-        :vartype cursor: str
+        result: SkelList[ProductSkel] = ProductSkel().all().fetch(10)
+        for skel in result:
+            # skel is SkeletonInstance[ProductSkel]
+            print(skel["price"])
+
+    Without the type parameter the class behaves exactly as before.
+
+    :ivar baseSkel: The base skeleton instance used to construct this list.
+    :ivar getCursor: Callable returning the datastore cursor for pagination.
+    :ivar get_orders: Callable returning the active query ordering.
+    :ivar renderPreparation: Render-preparation callback, set by renderers.
+    :ivar customQueryInfo: Arbitrary extra metadata attached by query helpers.
     """
 
     __slots__ = (

--- a/src/viur/core/skeleton/utils.py
+++ b/src/viur/core/skeleton/utils.py
@@ -1,6 +1,6 @@
 import typing as t
 
-from .meta import MetaBaseSkel
+from .meta import MetaBaseSkel, Skeleton_Cls
 
 if t.TYPE_CHECKING:
     from . import RefSkel, Skeleton, SkeletonInstance
@@ -32,7 +32,7 @@ def iterAllSkelClasses() -> t.Iterable["Skeleton"]:
         yield cls
 
 
-class SkelList(list):
+class SkelList(list, t.Generic[Skeleton_Cls]):
     """
         This class is used to hold multiple skeletons together with other, commonly used information.
 
@@ -51,12 +51,12 @@ class SkelList(list):
         "renderPreparation",
     )
 
-    def __init__(self, skel, *items):
+    def __init__(self, skel: "SkeletonInstance[Skeleton_Cls]" = None, *items):
         """
             :param baseSkel: The baseclass for all entries in this list
         """
         super().__init__()
-        self.baseSkel = skel or {}
+        self.baseSkel: "SkeletonInstance[Skeleton_Cls] | dict" = skel or {}
         self.getCursor = lambda: None
         self.get_orders = lambda: None
         self.renderPreparation = None


### PR DESCRIPTION
## Summary

Make `SkeletonInstance` and `SkelList` generic over the concrete `Skeleton` subclass, so static type checkers and IDEs can track which skeleton is in use through the whole call chain — without any runtime overhead.

## Motivation

Before this change, every method returning or accepting a `SkeletonInstance` was effectively untyped from the perspective of a type checker:

```python
skel = ProductSkel()
skel["price"]        # type: Unknown — no IDE autocomplete, no pyright/mypy validation
skel.skeletonCls     # type: Type[Skeleton] — too broad
```

With this PR the concrete skeleton class flows through:

```python
skel = ProductSkel()          # SkeletonInstance[ProductSkel]
skel.skeletonCls              # Type[ProductSkel]
```

## Changes

### Core — `skeleton/` package

| File | Change |
|------|--------|
| `meta.py` | Add `Skeleton_Cls = TypeVar("Skeleton_Cls", bound="BaseSkeleton")`, exported from the package. Update `BaseSkeleton.refresh` signature to `SkeletonInstance[t.Self]`. |
| `instance.py` | `SkeletonInstance` is now `Generic[Skeleton_Cls]`. `__init__` and `skeletonCls` attribute carry the type parameter. |
| `skeleton.py` | `BaseSkeleton.fromClient` signature updated to `SkeletonInstance[t.Self]`. |
| `utils.py` | `SkelList` is now `Generic[Skeleton_Cls]`. `baseSkel` attribute and `__init__` parameter are typed accordingly. |
| `__init__.py` | `Skeleton_Cls` is exported from `viur.core.skeleton`. |

### Modules — concrete return types

| File | Method | Return type |
|------|--------|-------------|
| `modules/user.py` | `User.addSkel` | `SkeletonInstance[UserSkel]` |
| `modules/user.py` | `User.editSkel` | `SkeletonInstance[UserSkel]` |
| `modules/user.py` | `UserPassword.addSkel` | `SkeletonInstance[UserSkel]` |
| `modules/translation.py` | `Translation.addSkel` | `SkeletonInstance[TranslationSkel]` |

## Usage

**Typed module override** — IDE knows which bones are available:

```python
class ProductModule(List):
    def editSkel(self) -> SkeletonInstance[ProductSkel]:
        skel = super().editSkel()
        skel.price.readOnly = True   # autocomplete + type-safe
        return skel
```

**Generic helper** — type flows through without loss:

```python
from viur.core.skeleton import Skeleton_Cls, SkeletonInstance

def set_owner(skel: SkeletonInstance[Skeleton_Cls], owner: str) -> SkeletonInstance[Skeleton_Cls]:
    skel = skel.clone()
    skel["owner"] = owner
    return skel  # still SkeletonInstance[ProductSkel], not erased to SkeletonInstance[BaseSkeleton]
```

**Typed list** — element type is known after fetch:

```python
result: SkelList[ProductSkel] = ProductSkel().all().fetch(10)
for skel in result:
    print(skel["price"])   # type-safe
```

**`t.Self` in classmethods** — automatically narrows to the calling class:

```python
# Already in BaseSkeleton:
@classmethod
def fromClient(cls, skel: SkeletonInstance[t.Self], data: dict) -> bool: ...

# Type checker infers SkeletonInstance[ProductSkel] here:
ProductSkel.fromClient(skel, request.POST)
```

## Notes

- **No runtime impact** — all changes are purely type annotations; `Generic` base classes add no overhead.
- `Skeleton_Cls` vs `t.Self`: use `Skeleton_Cls` for module methods and generic helpers; use `t.Self` only inside Skeleton classmethods where `cls` already is the concrete type.
- Prototype base classes (`List`, `Tree`, `Singleton`) are intentionally left without a type parameter — making them `Generic[SkeletonT]` is a separate, larger refactor.

---

I've used this in the viur-shop a lot, otherwise it gets very complicated to know which type of Skeleton in meaned
 e.g. here: https://github.com/viur-framework/viur-shop/blob/caa2476c41e9b886f7961cdaa84a441dc3eb2c76/src/viur/shop/types/dc_scope.py#L25-L29

