### PR TITLE
feat: Evaluate `x-viur-bonelist` on default `viewSkel()` (light-version)

### DIFF
--- a/src/viur/core/prototypes/list.py
+++ b/src/viur/core/prototypes/list.py
@@ -37,7 +37,7 @@ class List(SkelModule):
 
             :return: Returns a Skeleton instance for viewing an entry.
         """
-        return self.skel(**kwargs)
+        return self.baseSkel(**kwargs)
 
     def addSkel(self, *args, **kwargs) -> SkeletonInstance:
         """
@@ -55,7 +55,7 @@ class List(SkelModule):
 
             :return: Returns a Skeleton instance for adding an entry.
         """
-        return self.skel(**kwargs)
+        return self.baseSkel(**kwargs)
 
     def editSkel(self, *args, **kwargs) -> SkeletonInstance:
         """
@@ -72,7 +72,7 @@ class List(SkelModule):
 
             :return: Returns a Skeleton instance for editing an entry.
         """
-        return self.skel(**kwargs)
+        return self.baseSkel(**kwargs)
 
     def cloneSkel(self, *args, **kwargs) -> SkeletonInstance:
         """
@@ -89,7 +89,7 @@ class List(SkelModule):
 
         :return: Returns a SkeletonInstance for editing an entry.
         """
-        return self.skel(**kwargs)
+        return self.baseSkel(**kwargs)
 
     ## External exposed functions
 

--- a/src/viur/core/prototypes/singleton.py
+++ b/src/viur/core/prototypes/singleton.py
@@ -38,7 +38,7 @@ class Singleton(SkelModule):
 
         :return: Returns a Skeleton instance for viewing the singleton entry.
         """
-        return self.skel(**kwargs)
+        return self.baseSkel(**kwargs)
 
     def editSkel(self, *args, **kwargs) -> SkeletonInstance:
         """
@@ -51,7 +51,7 @@ class Singleton(SkelModule):
 
         :return: Returns a Skeleton instance for editing the entry.
         """
-        return self.skel(**kwargs)
+        return self.baseSkel(**kwargs)
 
     ## External exposed functions
 

--- a/src/viur/core/prototypes/singleton.py
+++ b/src/viur/core/prototypes/singleton.py
@@ -38,7 +38,7 @@ class Singleton(SkelModule):
 
         :return: Returns a Skeleton instance for viewing the singleton entry.
         """
-        return self.baseSkel(*args, **kwargs)
+        return self.skel(**kwargs)
 
     def editSkel(self, *args, **kwargs) -> SkeletonInstance:
         """
@@ -51,7 +51,7 @@ class Singleton(SkelModule):
 
         :return: Returns a Skeleton instance for editing the entry.
         """
-        return self.baseSkel(*args, **kwargs)
+        return self.skel(**kwargs)
 
     ## External exposed functions
 
@@ -75,7 +75,7 @@ class Singleton(SkelModule):
         if not self.canPreview():
             raise errors.Unauthorized()
 
-        skel = self.viewSkel()
+        skel = self.viewSkel(allow_client_defined=utils.string.is_prefix(self.render.kind, "json"))
         skel.fromClient(kwargs)
 
         return self.render.view(skel)
@@ -119,12 +119,11 @@ class Singleton(SkelModule):
         :raises: :exc:`viur.core.errors.NotFound`, if there is no singleton entry existing, yet.
         :raises: :exc:`viur.core.errors.Unauthorized`, if the current user does not have the required permissions.
         """
-
-        skel = self.viewSkel()
         if not self.canView():
             raise errors.Unauthorized()
 
-        key = db.Key(self.editSkel().kindName, self.getKey())
+        skel = self.viewSkel(allow_client_defined=utils.string.is_prefix(self.render.kind, "json"))
+        key = db.Key(skel.kindName, self.getKey())
 
         if not skel.read(key):
             raise errors.NotFound()
@@ -153,8 +152,8 @@ class Singleton(SkelModule):
         if not self.canEdit():
             raise errors.Unauthorized()
 
-        key = db.Key(self.editSkel().kindName, self.getKey())
         skel = self.editSkel()
+        key = db.Key(skel.kindName, self.getKey())
         if not skel.read(key):  # Its not there yet; we need to set the key again
             skel["key"] = key
 

--- a/src/viur/core/prototypes/singleton.py
+++ b/src/viur/core/prototypes/singleton.py
@@ -25,7 +25,7 @@ class Singleton(SkelModule):
 
         :returns: Current context DB-key
         """
-        return f"{self.editSkel().kindName}-modulekey"
+        return f"{self._resolveSkelCls().kindName}-modulekey"
 
     def viewSkel(self, *args, **kwargs) -> SkeletonInstance:
         """

--- a/src/viur/core/prototypes/skelmodule.py
+++ b/src/viur/core/prototypes/skelmodule.py
@@ -149,8 +149,7 @@ class SkelModule(Module):
             return skel_cls.subskel(bones=bones)
 
         # Otherwise, return full skeleton
-        # return skel_cls()  # FIXME: VIUR4...
-        return self.baseSkel(**kwargs)
+        return skel_cls()
 
     def _apply_default_order(self, query: db.Query):
         """

--- a/src/viur/core/prototypes/skelmodule.py
+++ b/src/viur/core/prototypes/skelmodule.py
@@ -110,7 +110,7 @@ class SkelModule(Module):
 
         By default, baseSkel is used by :func:`~viewSkel`, :func:`~addSkel`, and :func:`~editSkel`.
         """
-        return self._resolveSkelCls(*args, **kwargs)()
+        return self.skel(**kwargs)
 
     def skel(
         self,

--- a/src/viur/core/prototypes/skelmodule.py
+++ b/src/viur/core/prototypes/skelmodule.py
@@ -149,7 +149,8 @@ class SkelModule(Module):
             return skel_cls.subskel(bones=bones)
 
         # Otherwise, return full skeleton
-        return skel_cls()  # FIXME: This is fishy, it should return a baseSkel(), but then some customer project break
+        # return skel_cls()  # FIXME: VIUR4...
+        return self.baseSkel(**kwargs)
 
     def _apply_default_order(self, query: db.Query):
         """


### PR DESCRIPTION
This is a lighter version of #1384, integrating the feature only for `Singleton` and `List`.