### PR TITLE
fix: Hotfix for decorator `@skey` introduced by #1394

### DIFF
--- a/src/viur/core/decorators.py
+++ b/src/viur/core/decorators.py
@@ -227,11 +227,11 @@ def skey(
 
     def decorator(func):
         meth = Method.ensure(func)
-        meth.skey = skey_config["name"]
+        meth.skey = skey_config
         meth.guards.append(validate)
 
         # extend additional access descr, must be a list to be JSON-serializable
-        meth.additional_descr["access"] = skey_config["name"]
+        meth.additional_descr["skey"] = skey_config["name"]
 
         return meth
 

--- a/src/viur/core/module.py
+++ b/src/viur/core/module.py
@@ -215,8 +215,8 @@ class Method:
         args = tuple(parsed_args + varargs)
 
         # always take "skey"-parameter name, when configured, as parsed_kwargs
-        if self.skey and self.skey in kwargs:
-            parsed_kwargs[self.skey] = kwargs.pop(self.skey)
+        if self.skey and self.skey["name"] in kwargs:
+            parsed_kwargs[self.skey["name"]] = kwargs.pop(self.skey["name"])
 
         # When varkwargs are accepted, merge parsed_kwargs and kwargs, otherwise just use parsed_kwargs
         if varkwargs := varkwargs and bool(kwargs):


### PR DESCRIPTION
- `Method.skey` must hold the entire skey_config, as it is used within `Method.__call__`
- `Method.additional_descr` should be set to "skey"-name and not "access" (copy&paste bug)

---
Originated from error:
```
[2025-02-19 11:34:06,036] /.../viur/core/request.py:375 [ERROR] ViUR has caught an unhandled exception!
[2025-02-19 11:34:06,037] /.../viur/core/request.py:376 [ERROR] string indices must be integers, not 'str'
Traceback (most recent call last):
  File "~/viur-core/src/viur/core/request.py", line 350, in _process
    self._route(path)
  File "~/viur-core/src/viur/core/request.py", line 632, in _route
    res = caller(*self.args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/viur-core/src/viur/core/module.py", line 199, in __call__
    if self.skey and param_name == self.skey["forward_payload"]:
                                   ~~~~~~~~~^^^^^^^^^^^^^^^^^^^
TypeError: string indices must be integers, not 'str'
```