### PR TITLE
fix: Hotfix for #1391: missing skeltype-check

### DIFF
--- a/src/viur/core/modules/file.py
+++ b/src/viur/core/modules/file.py
@@ -1284,12 +1284,13 @@ class File(Tree):
         bucket.delete_blob(old_path)
 
     def onAdded(self, skelType: SkelType, skel: SkeletonInstance) -> None:
-        super().onAdded(skelType, skel)
-        if skel["mimetype"].startswith("image/"):
+        if skelType == "leaf" and skel["mimetype"].startswith("image/"):
             if skel["size"] > self.IMAGE_META_MAX_SIZE:
                 logging.warning(f"File size {skel['size']} exceeds limit {self.IMAGE_META_MAX_SIZE=}")
                 return
             self.set_image_meta(skel["key"])
+
+        super().onAdded(skelType, skel)
 
     @CallDeferred
     def set_image_meta(self, key: db.Key) -> None:


### PR DESCRIPTION
Pull request #1391 introduced this bug coming up when creating a FOLDER!
```
[2025-02-19 11:41:33,257] /.../viur/core/request.py:375 [ERROR] ViUR has caught an unhandled exception!
[2025-02-19 11:41:33,257] /.../viur/core/request.py:376 [ERROR] 'NoneType' object has no attribute 'startswith'
Traceback (most recent call last):
  File "~/viur-core/src/viur/core/request.py", line 350, in _process
    self._route(path)
  File "~/viur-core/src/viur/core/request.py", line 632, in _route
    res = caller(*self.args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/viur-core/src/viur/core/module.py", line 236, in __call__
    return self._func(self._instance, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/viur-core/src/viur/core/modules/file.py", line 1214, in add
    return super().add(skelType, node, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/viur-core/src/viur/core/module.py", line 236, in __call__
    return self._func(self._instance, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/viur-core/src/viur/core/prototypes/tree.py", line 458, in add
    self.onAdded(skelType, skel)
  File "~/viur-core/src/viur/core/modules/file.py", line 1288, in onAdded
    if skel["mimetype"].startswith("image/"):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'startswith'
```