### PR TITLE
fix: `Skeleton.write()` returns full skeleton

### DIFF
--- a/src/viur/core/skeleton.py
+++ b/src/viur/core/skeleton.py
@@ -1453,7 +1453,7 @@ class Skeleton(BaseSkeleton, metaclass=MetaSkel):
                 blob_lock_obj["is_stale"] = False
                 db.Put(blob_lock_obj)
 
-            return skel.dbEntity.key, skel, change_list, is_add
+            return skel.dbEntity.key, write_skel, change_list, is_add
 
         # Parse provided key, if any, and set it to skel["key"]
         if key:


### PR DESCRIPTION
Fixes two bugs:
1. `Skeleton.write()` returns another skeleton than the one that is passed. Especially when working with subskels, this is an unwanted behavior.
2. Due the previous full skeleton return, the `postSaveHandlers` of `RelationalBones` are ALL executed, also when the bone is not part of the skeleton. This yields in a query that is fired every time on every bone, which slows down the entire process of the write() with nonsense queries.