### PR TITLE
fix: Hotfix for `Skeleton.write()` with wrong dbEntity

### DIFF
--- a/src/viur/core/skeleton.py
+++ b/src/viur/core/skeleton.py
@@ -1249,7 +1249,9 @@ class Skeleton(BaseSkeleton, metaclass=MetaSkel):
             # Merge values and assemble unique properties
             # Move accessed Values from srcSkel over to skel
             skel.accessedValues = write_skel.accessedValues
-            skel["key"] = db_key  # Ensure key stays set
+
+            write_skel["key"] = skel["key"] = db_key  # Ensure key stays set
+            write_skel.dbEntity = skel.dbEntity  # update write_skel's dbEntity
 
             for bone_name, bone in skel.items():
                 if bone_name == "key":  # Explicitly skip key on top-level - this had been set above
@@ -1301,7 +1303,7 @@ class Skeleton(BaseSkeleton, metaclass=MetaSkel):
                                 # TODO: Use a custom exception class which is catchable with an try/except
                                 raise ValueError(
                                     f"The unique value {skel[bone_name]!r} of bone {bone_name!r} "
-                                    f"has been recently claimed!")
+                                    f"has been recently claimed (by {new_lock_key=}).")
                         else:
                             # This value is locked for the first time, create a new lock-object
                             lock_obj = db.Entity(new_lock_key)


### PR DESCRIPTION
`Skeleton.write()` returns a skeleton with an empty dbEntity on is_add. This PR fixes the write_skel being updated to the loaded db_key and dbEntity. This PR is a follow-up on #1421 and a general bugfix on #1264.