### PR TITLE
fix: `NumericBone` ignores precision on read & write

### DIFF
--- a/src/viur/core/bones/numeric.py
+++ b/src/viur/core/bones/numeric.py
@@ -80,6 +80,21 @@ class NumericBone(BaseBone):
 
         return super().__setattr__(key, value)
 
+    def singleValueUnserialize(self, val):
+        if val is not None:
+            try:
+                if self.precision:
+                    return float(f"{val:.{self.precision}f}")
+
+                return int(val)
+            except ValueError:
+                return self.getDefaultValue()
+
+        return val
+
+    def singleValueSerialize(self, value, skel: 'SkeletonInstance', name: str, parentIndexed: bool):
+        return self.singleValueUnserialize(value)  # same logic for unserialize here!
+
     def isInvalid(self, value):
         """
         This method checks if a given value is invalid (e.g., NaN) for the NumericBone instance.


### PR DESCRIPTION
This bug came in with the vi-admin 4.8.x which enforces client-side validation, also of the precision.

In case there of this bone definition
```python
    timedrift = NumericBone(
        descr="Zeitkorrektur",
        defaultValue=0,
        indexed=False,
        precision=1
    )
```

And a computed value that was -4.03169999999, the client rejected to submit the mask with
![image](https://github.com/user-attachments/assets/379e4bb1-2fba-4d1e-abfb-98503c087122)

The problem here is, that the client enforces everything right, but the server loads the value -4.03169999999 which is not valid by its own bonedefinition, so -4.0 would be the correct value.

This pull request fixes NumericBone to store and load only values with the correct precision set.
