### PR TITLE
fix: Make `skeleton.listKnownSkeletons` always sorted

### DIFF
--- a/src/viur/core/skeleton.py
+++ b/src/viur/core/skeleton.py
@@ -1853,7 +1853,7 @@ def listKnownSkeletons() -> list[str]:
     """
         :return: A list of all known kindnames (all kindnames for which a skeleton is defined)
     """
-    return list(MetaBaseSkel._skelCache.keys())[:]
+    return sorted(MetaBaseSkel._skelCache.keys())
 
 
 def iterAllSkelClasses() -> t.Iterable[Skeleton]:


### PR DESCRIPTION
This function is used rarely, and it makes sense to always obtain a sorted list of skeletons. As the function now also returns a list, it can be directly returned as sorted.

This affects, for example, callable tasks which provide a kind selector, like RebuildSearchIndex.