### PR TITLE
chore: Remove legacy `viur-queued-tasks` code

### DIFF
--- a/src/viur/core/tasks.py
+++ b/src/viur/core/tasks.py
@@ -285,21 +285,6 @@ class TaskHandler(Module):
                 entry["date"] = utils.utcNow()
                 db.Put(entry)
         logging.debug("Periodic tasks complete")
-        for currentTask in db.Query("viur-queued-tasks").iter():  # Look for queued tasks
-            db.Delete(currentTask.key())
-            if currentTask["taskid"] in _callableTasks:
-                task = _callableTasks[currentTask["taskid"]]()
-                tmpDict = {}
-                for k in currentTask.keys():
-                    if k == "taskid":
-                        continue
-                    tmpDict[k] = json.loads(currentTask[k])
-                try:
-                    task.execute(**tmpDict)
-                except Exception as e:
-                    logging.error("Error executing Task")
-                    logging.exception(e)
-        logging.debug("Scheduled tasks complete")
 
     def _validate_request(
         self,


### PR DESCRIPTION
This code was around 12 years old and would already fail on the first statement: `db.Delete(currentTask.key())` (key is no longer a method...)

The counterpart does no longer exist; callableTasks are always executed direclty and decide on their own to call a `DeferredTask` or not.