### PR TITLE
fix: Check in `updateRelations` if `request_data` exist

### DIFF
--- a/src/viur/core/skeleton.py
+++ b/src/viur/core/skeleton.py
@@ -1931,7 +1931,8 @@ def updateRelations(destKey: db.Key, minChangeTime: int, changedBone: t.Optional
             defer again.
     """
     logging.debug(f"Starting updateRelations for {destKey=}; {minChangeTime=}, {changedBone=}, {cursor=}")
-    current.request_data.get()["__update_relations_bone"] = changedBone
+    if request_data := current.request_data.get():
+        request_data["__update_relations_bone"] = changedBone
     updateListQuery = (
         db.Query("viur-relations")
         .filter("dest.__key__ =", destKey)


### PR DESCRIPTION
Fix for #1428.
If a startupTask trigger a updateRelation there is not `current.request_data`