### PR TITLE
fix: `singleValueUnserialize` is now working more stable

### DIFF
--- a/src/viur/core/bones/numeric.py
+++ b/src/viur/core/bones/numeric.py
@@ -83,12 +83,9 @@ class NumericBone(BaseBone):
     def singleValueUnserialize(self, val):
         if val is not None:
             try:
-                if self.precision:
-                    return round(float(val), self.precision)
-
-                return int(val)
-            except ValueError:
-                return self.getDefaultValue()
+                return self._convert_to_numeric(val)
+            except (ValueError, TypeError):
+                return self.getDefaultValue(None)  # FIXME: callable needs the skeleton instance
 
         return val
 
@@ -220,10 +217,12 @@ class NumericBone(BaseBone):
         """Convert a value to an int or float considering the precision.
 
         If the value is not convertable an exception will be raised."""
+        if isinstance(value, db.Entity | dict) and "val" in value:
+            value = value["val"]  # was a StringBone before
         if isinstance(value, str):
             value = value.replace(",", ".", 1)
         if self.precision:
-            return float(value)
+            return round(float(value), self.precision)
         else:
             # First convert to float then to int to support "42.5" (str)
             return int(float(value))

--- a/tests/bones/test_numeric_bone.py
+++ b/tests/bones/test_numeric_bone.py
@@ -13,15 +13,23 @@ class TestNumericBone(unittest.TestCase):
 
     def test_isEmpty_default_bone(self):
         from viur.core.bones import NumericBone
-        self._run_tests(NumericBone())
+        self._run_tests(bone:=NumericBone())
+        self.assertTrue(bone.isEmpty(SMALL_FLOAT), msg=vars(bone))
 
     def test_isEmpty_emptyNone(self):
         from viur.core.bones import NumericBone
-        self._run_tests(NumericBone(getEmptyValueFunc=lambda: None))
+        self._run_tests(bone:=NumericBone(getEmptyValueFunc=lambda: None))
+        self.assertFalse(bone.isEmpty(SMALL_FLOAT), msg=vars(bone))
 
     def test_isEmpty_precision(self):
         from viur.core.bones import NumericBone
-        self._run_tests(NumericBone(precision=2))
+        self._run_tests(bone := NumericBone(precision=2))
+        self.assertTrue(bone.isEmpty(SMALL_FLOAT), msg=vars(bone))
+
+    def test_isEmpty_high_precision(self):
+        from viur.core.bones import NumericBone
+        self._run_tests(bone := NumericBone(precision=8))
+        self.assertFalse(bone.isEmpty(SMALL_FLOAT), msg=vars(bone))
 
     def test_isEmpty_precision_emptyNone(self):
         from viur.core.bones import NumericBone
@@ -35,9 +43,6 @@ class TestNumericBone(unittest.TestCase):
         self.assertFalse(bone.isEmpty(123.456))
         self.assertFalse(bone.isEmpty(LARGE_INT))
         self.assertFalse(bone.isEmpty(LARGE_FLOAT))
-        if bone.precision != 0:
-            self.assertFalse(bone.isEmpty(SMALL_FLOAT), msg=vars(bone))
-
         self.assertTrue(bone.isEmpty(""))
         self.assertTrue(bone.isEmpty(None))
         self.assertTrue(bone.isEmpty([]))
@@ -55,6 +60,7 @@ class TestNumericBone(unittest.TestCase):
         self.assertEqual(42.6, bone._convert_to_numeric(42.6))
         self.assertEqual(42.6, bone._convert_to_numeric("42.6"))
         self.assertEqual(42.6, bone._convert_to_numeric("42,6"))
+        self.assertEqual(42.6, bone._convert_to_numeric({"val": "42,6", "idx": "42,6"}))
         self.assertIsInstance(bone._convert_to_numeric(42), float)
         with self.assertRaises(TypeError):
             bone._convert_to_numeric(None)
@@ -70,6 +76,8 @@ class TestNumericBone(unittest.TestCase):
         self.assertEqual(42, bone._convert_to_numeric(42.0))
         self.assertEqual(42, bone._convert_to_numeric("42.6"))
         self.assertEqual(42, bone._convert_to_numeric("42,6"))
+        self.assertEqual(42, bone._convert_to_numeric("42,6"))
+        self.assertEqual(42, bone._convert_to_numeric({"val": "42", "idx": "42"}))
         with self.assertRaises(ValueError):
             bone._convert_to_numeric("123.456,5")
         self.assertIsInstance(bone._convert_to_numeric(42), int)

--- a/tests/bones/test_numeric_bone.py
+++ b/tests/bones/test_numeric_bone.py
@@ -68,6 +68,11 @@ class TestNumericBone(unittest.TestCase):
             bone._convert_to_numeric("xyz")
         with self.assertRaises(ValueError):
             bone._convert_to_numeric("1.2.3")
+        # rounding
+        self.assertEqual(42.12, bone._convert_to_numeric(42.1234))
+        self.assertEqual(42.0, bone._convert_to_numeric(42.00001))
+        self.assertEqual(42.07, bone._convert_to_numeric(42.066))
+        self.assertEqual(42.06, bone._convert_to_numeric(42.064))
 
         bone = NumericBone(precision=0)
         self.assertEqual(42, bone._convert_to_numeric(42))
@@ -76,7 +81,7 @@ class TestNumericBone(unittest.TestCase):
         self.assertEqual(42, bone._convert_to_numeric(42.0))
         self.assertEqual(42, bone._convert_to_numeric("42.6"))
         self.assertEqual(42, bone._convert_to_numeric("42,6"))
-        self.assertEqual(42, bone._convert_to_numeric("42,6"))
+        self.assertEqual(42, bone._convert_to_numeric({"val": "42,6", "idx": "42,6"}))
         self.assertEqual(42, bone._convert_to_numeric({"val": "42", "idx": "42"}))
         with self.assertRaises(ValueError):
             bone._convert_to_numeric("123.456,5")

--- a/tests/bones/test_numeric_bone.py
+++ b/tests/bones/test_numeric_bone.py
@@ -13,12 +13,12 @@ class TestNumericBone(unittest.TestCase):
 
     def test_isEmpty_default_bone(self):
         from viur.core.bones import NumericBone
-        self._run_tests(bone:=NumericBone())
+        self._run_tests(bone := NumericBone())
         self.assertTrue(bone.isEmpty(SMALL_FLOAT), msg=vars(bone))
 
     def test_isEmpty_emptyNone(self):
         from viur.core.bones import NumericBone
-        self._run_tests(bone:=NumericBone(getEmptyValueFunc=lambda: None))
+        self._run_tests(bone := NumericBone(getEmptyValueFunc=lambda: None))
         self.assertFalse(bone.isEmpty(SMALL_FLOAT), msg=vars(bone))
 
     def test_isEmpty_precision(self):


### PR DESCRIPTION
PR #1425 introduced a `singleValueUnserialize` implementation that has no robustness against any other formats.

We still have old StringBone values in the database (`val={'val': '0.5', 'idx': '0.5'}`). This was never noticed, as there was never an error before. Now the value can neither be loaded nor ignored, nor does the `getDefaultValue` in except work without parameters. So no rebuild search index can be made with `refresh()` if the value is not loaded in the first place.