### PR TITLE
fix: `add_or_edit` edits entries with empty skeleton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file documents any relevant changes done to ViUR-core since version 3.
 
+## [3.7.12]
+
+- fix: `add_or_edit` edits entries with empty skeleton (#1449)
+
 ## [3.7.11]
 
 - fix: Fixes for `/_translation/dump`

--- a/src/viur/core/prototypes/skelmodule.py
+++ b/src/viur/core/prototypes/skelmodule.py
@@ -214,13 +214,20 @@ class SkelModule(Module):
         This function is intended to be used by importers.
         Only "root"-users are allowed to use it.
         """
-        db_key = db.keyHelper(key, targetKind=self.kindName, adjust_kind=self.kindName)
-        is_add = not bool(db.Get(db_key))
 
+        # Adjust key
+        db_key = db.keyHelper(key, targetKind=self.kindName, adjust_kind=self.kindName)
+
+        # Retrieve and verify existing entry
+        db_entity = db.Get(db_key)
+        is_add = not bool(db_entity)
+
+        # Instanciate relevant skeleton
         if is_add:
             skel = self.addSkel()
         else:
             skel = self.editSkel()
+            skel.dbEntity = db_entity  # assign existing entity
 
         skel["key"] = db_key
 

--- a/src/viur/core/prototypes/tree.py
+++ b/src/viur/core/prototypes/tree.py
@@ -474,13 +474,19 @@ class Tree(SkelModule):
 
         kind_name = self.nodeSkelCls.kindName if skelType == "node" else self.leafSkelCls.kindName
 
+        # Adjust key
         db_key = db.keyHelper(key, targetKind=kind_name, adjust_kind=kind_name)
-        is_add = not bool(db.Get(db_key))
 
+        # Retrieve and verify existing entry
+        db_entity = db.Get(db_key)
+        is_add = not bool(db_entity)
+
+        # Instanciate relevant skeleton
         if is_add:
             skel = self.addSkel(skelType)
         else:
             skel = self.editSkel(skelType)
+            skel.dbEntity = db_entity  # assign existing entity
 
         skel = skel.ensure_is_cloned()
         skel.parententry.required = True

--- a/src/viur/core/version.py
+++ b/src/viur/core/version.py
@@ -3,7 +3,7 @@
 # This will mark it as a pre-release as well on PyPI.
 # See CONTRIBUTING.md for further information.
 
-__version__ = "3.7.11"
+__version__ = "3.7.12"
 
 assert __version__.count(".") >= 2 and "".join(__version__.split(".", 3)[:3]).isdigit(), \
     "Semantic __version__ expected!"


### PR DESCRIPTION
Might corrupt data under special circumstances (in this case: translation-module)