### PR TITLE
fix: `RecordBone` and prefix substitution

### DIFF
--- a/src/viur/core/bones/base.py
+++ b/src/viur/core/bones/base.py
@@ -559,6 +559,7 @@ class BaseBone(object):
         :return: A dictionary containing the collected raw client data.
         """
         fieldSubmitted = False
+
         if languages:
             res = {}
             for lang in languages:
@@ -584,7 +585,7 @@ class BaseBone(object):
                             if not key.startswith(prefix):
                                 continue
                             fieldSubmitted = True
-                            partKey = key.replace(prefix, "")
+                            partKey = key[len(prefix):]
                             firstKey, remainingKey = partKey.split(".", maxsplit=1)
                             try:
                                 firstKey = int(firstKey)
@@ -602,7 +603,7 @@ class BaseBone(object):
                             if not key.startswith(prefix):
                                 continue
                             fieldSubmitted = True
-                            partKey = key.replace(prefix, "")
+                            partKey = key[len(prefix):]
                             tmpDict[partKey] = value
                         res[lang] = tmpDict
             return res, fieldSubmitted
@@ -631,7 +632,7 @@ class BaseBone(object):
                         if not key.startswith(prefix):
                             continue
                         fieldSubmitted = True
-                        partKey = key.replace(prefix, "")
+                        partKey = key[len(prefix):]
                         try:
                             firstKey, remainingKey = partKey.split(".", maxsplit=1)
                             firstKey = int(firstKey)
@@ -649,7 +650,7 @@ class BaseBone(object):
                         if not key.startswith(prefix):
                             continue
                         fieldSubmitted = True
-                        subKey = key.replace(prefix, "")
+                        subKey = key[len(prefix):]
                         res[subKey] = value
                     return res, fieldSubmitted
 
@@ -1167,8 +1168,9 @@ class BaseBone(object):
         if query.queries and (orderby := params.get("orderby")) and utils.string.is_prefix(orderby, name):
             if self.languages:
                 lang = None
-                if orderby.startswith(f"{name}."):
-                    lng = orderby.replace(f"{name}.", "")
+                prefix = f"{name}."
+                if orderby.startswith(prefix):
+                    lng = orderby[len(prefix):]
                     if lng in self.languages:
                         lang = lng
 

--- a/src/viur/core/bones/record.py
+++ b/src/viur/core/bones/record.py
@@ -83,8 +83,7 @@ class RecordBone(BaseBone):
         if not value:
             return value
 
-        ret = value.serialize(parentIndexed=False)
-        return ret
+        return value.serialize(parentIndexed=False)
 
     def _get_single_destinct_hash(self, value):
         return tuple(bone._get_destinct_hash(value[name]) for name, bone in self.using.__boneMap__.items())

--- a/src/viur/core/bones/record.py
+++ b/src/viur/core/bones/record.py
@@ -64,7 +64,7 @@ class RecordBone(BaseBone):
         if isinstance(value, list) and value:
             value = value[0]
 
-        assert isinstance(value, dict), f"Read something from the datastore thats not a dict: {type(value)}"
+        assert isinstance(value, dict), f"Read {value=} ({type(value)})"
 
         usingSkel = self.using()
         usingSkel.unserialize(value)
@@ -83,7 +83,8 @@ class RecordBone(BaseBone):
         if not value:
             return value
 
-        return value.serialize(parentIndexed=False)
+        ret = value.serialize(parentIndexed=False)
+        return ret
 
     def _get_single_destinct_hash(self, value):
         return tuple(bone._get_destinct_hash(value[name]) for name, bone in self.using.__boneMap__.items())
@@ -97,27 +98,20 @@ class RecordBone(BaseBone):
 
     def singleValueFromClient(self, value, skel, bone_name, client_data):
         usingSkel = self.using()
+
         if not usingSkel.fromClient(value):
             usingSkel.errors.append(
                 ReadFromClientError(ReadFromClientErrorSeverity.Invalid, "Incomplete data")
             )
+
         return usingSkel, usingSkel.errors
 
     def postSavedHandler(self, skel, boneName, key) -> None:
         super().postSavedHandler(skel, boneName, key)
-        for idx, lang, value in self.iter_bone_value(skel, boneName):
-            using = self.using()
-            using.unserialize(value)
-            for bone_name, bone in using.items():
-                bone.postSavedHandler(using, bone_name, None)
 
-    def refresh(self, skel, boneName) -> None:
-        super().refresh(skel, boneName)
-        for idx, lang, value in self.iter_bone_value(skel, boneName):
-            using = self.using()
-            using.unserialize(value)
-            for bone_name, bone in using.items():
-                bone.refresh(using, bone_name)
+        for _, lang, value in self.iter_bone_value(skel, boneName):
+            for bone_name, bone in value.items():
+                bone.postSavedHandler(value, bone_name, None)
 
     def getSearchTags(self, skel: 'viur.core.skeleton.SkeletonInstance', name: str) -> set[str]:
         """
@@ -129,13 +123,14 @@ class RecordBone(BaseBone):
         """
         result = set()
 
-        using_skel_cache = self.using()
-        for idx, lang, value in self.iter_bone_value(skel, name):
+        for _, lang, value in self.iter_bone_value(skel, name):
             if value is None:
                 continue
-            for key, bone in using_skel_cache.items():
+
+            for key, bone in value.items():
                 if not bone.searchable:
                     continue
+
                 for tag in bone.getSearchTags(value, key):
                     result.add(tag)
 
@@ -178,11 +173,11 @@ class RecordBone(BaseBone):
         """
         result = set()
 
-        using_skel_cache = self.using()
-        for idx, lang, value in self.iter_bone_value(skel, name):
+        for _, lang, value in self.iter_bone_value(skel, name):
             if value is None:
                 continue
-            for key, bone in using_skel_cache.items():
+
+            for key, bone in value.items():
                 result |= bone.getReferencedBlobs(value, key)
 
         return result
@@ -198,16 +193,13 @@ class RecordBone(BaseBone):
     def structure(self) -> dict:
         return super().structure() | {
             "format": self.format,
-            "using": self.using().structure()}
+            "using": self.using().structure(),
+        }
 
     def refresh(self, skel, bone_name):
-        using_skel = self.using()
-
-        for idx, lang, value in self.iter_bone_value(skel, bone_name):
+        for _, lang, value in self.iter_bone_value(skel, bone_name):
             if value is None:
                 continue
 
-            using_skel.unserialize(value)
-
-            for key, bone in using_skel.items():
-                bone.refresh(using_skel, key)
+            for key, bone in value.items():
+                bone.refresh(value, key)


### PR DESCRIPTION
- Correctly parses, saves and reads RecordBones in RecordBones, fixes #1426
- Refactored code, removed unnecessary stuff that causes double unserialization
- Fixed `BaseBone.collectRawClientData()` to replace only the real prefix, and no other substrings which might contain the prefix