### PR TITLE
fix: Update user's data in session on `user/edit`

### DIFF
--- a/src/viur/core/modules/user.py
+++ b/src/viur/core/modules/user.py
@@ -1579,7 +1579,8 @@ class User(List):
         # In case the user is set to inactive, kill all sessions
         if self.is_active(skel) is False:
             session.killSessionByUser(skel["key"])
-        # Update all Sessions
+
+        # Update user setting in all sessions
         for session_obj in db.Query("user").filter("user =", skel["key"]).iter():
             session_obj["data"]["user"] = skel.dbEntity
 

--- a/src/viur/core/modules/user.py
+++ b/src/viur/core/modules/user.py
@@ -1579,8 +1579,8 @@ class User(List):
         # In case the user is set to inactive, kill all sessions
         if self.is_active(skel) is False:
             session.killSessionByUser(skel["key"])
-        #Update all Sessions
-        for session_obj in db.Query("user").filter("user =",skel["key"]).iter():
+        # Update all Sessions
+        for session_obj in db.Query("user").filter("user =", skel["key"]).iter():
             session_obj["data"]["user"] = skel.dbEntity
 
 

--- a/src/viur/core/modules/user.py
+++ b/src/viur/core/modules/user.py
@@ -1579,6 +1579,10 @@ class User(List):
         # In case the user is set to inactive, kill all sessions
         if self.is_active(skel) is False:
             session.killSessionByUser(skel["key"])
+        #Update all Sessions
+        for session_obj in db.Query("user").filter("user =",skel["key"]).iter():
+            session_obj["data"]["user"] = skel.dbEntity
+
 
     def onDeleted(self, skel):
         super().onDeleted(skel)


### PR DESCRIPTION
This PR fixes the following problem. When you edit a user, the user's session is not edited. This means, for example, that if you revoke a right from a user, the user retains this right until the session expires. Or if you add one, it only becomes usable when you log out and log in again.