### PR TITLE
fix: `processRemovedRelations` failes if the source entity has other relations set

### DIFF
--- a/src/viur/core/skeleton.py
+++ b/src/viur/core/skeleton.py
@@ -1868,7 +1868,7 @@ def iterAllSkelClasses() -> t.Iterable[Skeleton]:
 ### Tasks ###
 
 @CallDeferred
-def processRemovedRelations(removedKey, cursor=None):
+def processRemovedRelations(removedKey: db.Key, cursor=None):
     updateListQuery = (
         db.Query("viur-relations")
         .filter("dest.__key__ =", removedKey)
@@ -1889,6 +1889,7 @@ def processRemovedRelations(removedKey, cursor=None):
             for key, bone in skel.items():
                 if isinstance(bone, RelationalBone):
                     if relational_value := skel[key]:
+                        # TODO: LanguageWrapper is not considered here (<RelationalBone(languages=[...])>)
                         if isinstance(relational_value, dict):
                             if relational_value["dest"]["key"] == removedKey:
                                 skel[key] = None

--- a/src/viur/core/skeleton.py
+++ b/src/viur/core/skeleton.py
@@ -1889,9 +1889,10 @@ def processRemovedRelations(removedKey, cursor=None):
             for key, bone in skel.items():
                 if isinstance(bone, RelationalBone):
                     if relational_value := skel[key]:
-                        if isinstance(relational_value, dict) and relational_value["dest"]["key"] == removedKey:
-                            skel[key] = None
-                            found = True
+                        if isinstance(relational_value, dict):
+                            if relational_value["dest"]["key"] == removedKey:
+                                skel[key] = None
+                                found = True
 
                         elif isinstance(relational_value, list):
                             skel[key] = [entry for entry in relational_value if entry["dest"]["key"] != removedKey]


### PR DESCRIPTION
If a relation with the key `key1` has been deleted. In the skeleton might be other `RelationalBone`s which have a `key2`. These obviously do not match. However, this then leads to the `else` being reached and you get the following error:

> In <viur.datastore.Key source_kind/key123, parent=None>, no handling for relational_value={'dest': <SkeletonInstance of RefSkelForfile with {'key': <viur.datastore.Key file/key2, parent=None>,...}> 
