### PR TITLE
fix: `prototypes.List` shall default to `addSkel` on cloning

### DIFF
--- a/src/viur/core/prototypes/list.py
+++ b/src/viur/core/prototypes/list.py
@@ -89,7 +89,9 @@ class List(SkelModule):
 
         :return: Returns a SkeletonInstance for editing an entry.
         """
-        return self.baseSkel(**kwargs)
+
+        # On clone, by default, behave as this is a skeleton for adding.
+        return self.addSkel(**kwargs)
 
     ## External exposed functions
 


### PR DESCRIPTION
Replacement for #1469.