### PR TITLE
feat: Readd login_failed and is_active

### DIFF
--- a/src/viur/core/modules/user.py
+++ b/src/viur/core/modules/user.py
@@ -336,7 +336,12 @@ class UserPassword(UserPrimaryAuthentication):
 
         if not is_okay:
             self.loginRateLimit.decrementQuota()  # Only failed login attempts will count to the quota
-            return self._user_module.render.login(self.LoginSkel(), action="login")
+            return self._user_module.render.login(
+                self.LoginSkel(),
+                action="login",
+                login_failed=True,
+                is_active=self._user_module.is_active(user_skel)
+            )
 
         # check if iterations are below current security standards, and update if necessary.
         if iterations < PBKDF2_DEFAULT_ITERATIONS:

--- a/src/viur/core/render/html/user.py
+++ b/src/viur/core/render/html/user.py
@@ -29,8 +29,8 @@ class Render(DefaultRender):  # Render user-data to xml
 
     def login(self, skel, tpl: str | None = None, **kwargs):
         tpl = self._choose_template(tpl, "loginTemplate")
-        return self.add(skel, tpl=tpl, loginFailed=kwargs.get("loginFailed", False),
-                        accountStatus=kwargs.get("accountStatus"))
+        return self.add(skel, tpl=tpl, login_failed=kwargs.get("login_failed", False),
+                        is_active=kwargs.get("is_active"))
 
     def loginChoices(self, authMethods, tpl: str | None = None, **kwargs):
         tpl = self._choose_template(tpl, "loginChoicesTemplate")


### PR DESCRIPTION
This PR readds `login_failed` and `is_active` removed by 
https://github.com/viur-framework/viur-core/pull/1292/files#diff-c01d8943e5c82398404f2c14738d9aa91f2332c998e54edc53fb84c9b324ed4aL344-L350