### PR TITLE
feat: `conf.db_query_max_limit` and `conf.db_query_default_limit`

### DIFF
--- a/src/viur/core/config.py
+++ b/src/viur/core/config.py
@@ -849,8 +849,11 @@ class Conf(ConfigType):
     ]
     """Backward compatibility flags; Remove to enforce new style."""
 
-    db_engine: str = "viur.datastore"
-    """Database engine module"""
+    db_query_max_limit: int = 100
+    """Sets the maximum query limit."""
+
+    db_query_default_limit: int = 30
+    """Sets the default query limit for all queries."""
 
     db_memcache_client: Client | None = None
     """If set, ViUR cache data for the db.get in the Memcache for faster access."""
@@ -1030,7 +1033,6 @@ class Conf(ConfigType):
         "viur.cacheEnvironmentKey": "cache_environment_key",
         "viur.contentSecurityPolicy": "content_security_policy",
         "viur.bone.boolean.str2true": "bone_boolean_str2true",
-        "viur.db.engine": "db_engine",
         "viur.errorHandler": "error_handler",
         "viur.static.embedSvg.path": "static_embed_svg_path",
         "viur.file.hmacKey": "file_hmac_key",

--- a/src/viur/core/db/types.py
+++ b/src/viur/core/db/types.py
@@ -7,7 +7,8 @@ import datetime
 import enum
 import typing as t
 from contextvars import ContextVar
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from ..config import conf
 
 from google.cloud.datastore import Entity as Datastore_entity, Key as Datastore_key
 
@@ -167,7 +168,7 @@ class QueryDefinition:
     distinct: t.Optional[list[str]] = None
     """If set, a list of fields that we should return distinct values of"""
 
-    limit: int = 30
+    limit: int = field(init=False)
     """The maximum amount of entities that should be returned"""
 
     startCursor: t.Optional[str] = None
@@ -178,3 +179,6 @@ class QueryDefinition:
 
     currentCursor: t.Optional[str] = None
     """Will be set after this query has been run, pointing after the last entity returned"""
+
+    def __post_init__(self):
+        self.limit = conf.db_query_default_limit

--- a/src/viur/core/scripts/viur_migrate.py
+++ b/src/viur/core/scripts/viur_migrate.py
@@ -108,7 +108,6 @@ for old_key, new_attr in {
     "viur.bone.boolean.str2true": "bone_boolean_str2true",
     "viur.cacheEnvironmentKey": "cache_environment_key",
     "viur.compatibility": "compatibility",
-    "viur.db.engine": "db_engine",
     "viur.debug.skeleton.fromClient": "debug.skeleton.fromClient",
     "viur.debug.trace": "debug.trace",
     "viur.debug.traceExceptions": "debug.trace_exceptions",


### PR DESCRIPTION
Allows to configure defaults and maximum for query limits.

Removes `db_engine` as this config switch becomes obsolete in viur-core 3.8.