### PR TITLE
feat: Pass `create` param in `Singleton.getContents()` to `Skeleton.read()`

### DIFF
--- a/src/viur/core/bones/base.py
+++ b/src/viur/core/bones/base.py
@@ -1502,7 +1502,6 @@ class BaseBone(object):
 
             if issubclass(skel.skeletonCls, RefSkel):  # we have a ref skel we must load the complete skeleton
                 cloned_skel = skeletonByKind(skel.kindName)()
-                logging.debug(f"read for skel@{id(skel)} // {skel.skeletonCls}@{id(skel.skeletonCls)} // {skel["key"]!r}")
                 if not cloned_skel.read(skel["key"]):
                     raise ValueError(f'{skel["key"]=!r} does no longer exists. Cannot compute a broken relation')
             else:

--- a/src/viur/core/bones/base.py
+++ b/src/viur/core/bones/base.py
@@ -1502,6 +1502,7 @@ class BaseBone(object):
 
             if issubclass(skel.skeletonCls, RefSkel):  # we have a ref skel we must load the complete skeleton
                 cloned_skel = skeletonByKind(skel.kindName)()
+                logging.debug(f"read for skel@{id(skel)} // {skel.skeletonCls}@{id(skel.skeletonCls)} // {skel["key"]!r}")
                 if not cloned_skel.read(skel["key"]):
                     raise ValueError(f'{skel["key"]=!r} does no longer exists. Cannot compute a broken relation')
             else:

--- a/src/viur/core/prototypes/singleton.py
+++ b/src/viur/core/prototypes/singleton.py
@@ -170,16 +170,22 @@ class Singleton(SkelModule):
         self.onEdited(skel)
         return self.render.editSuccess(skel)
 
-    def getContents(self) -> SkeletonInstance | None:
+    def getContents(
+        self,
+        create: bool | dict | t.Callable[[SkeletonInstance], None] = False,
+    ) -> SkeletonInstance | None:
         """
-        Returns the entity of this singleton application as :class:`viur.core.skeleton.Skeleton` object.
+        Return the entity of this singleton application as :class:`SkeletonInstance` object.
 
-        :returns: The content as Skeleton provided by :func:`viewSkel`.
+        :param create: Whether the entity should be created if it does not exist.
+            See :meth:`Skeleton.read` for more details.
+
+        :returns: The read skeleton or `None`.
         """
         skel = self.viewSkel()
         key = db.Key(self.viewSkel().kindName, self.getKey())
 
-        if not skel.read(key):
+        if not skel.read(key, create=create):
             return None
 
         return skel


### PR DESCRIPTION
So you can always get a skeleton regardless if it was saved before or not (and has only default values).