### PR TITLE
fix+refactor: `_tasks/list` and `SkelList`

### DIFF
--- a/src/viur/core/db/query.py
+++ b/src/viur/core/db/query.py
@@ -665,7 +665,7 @@ class Query(object):
         else:
             return count(queryDefinition=self.queries, up_to=up_to)
 
-    def fetch(self, limit: int = -1) -> "SkelList['SkeletonInstance']":
+    def fetch(self, limit: int = -1) -> "SkelList":
         """
         Run this query and fetch results as :class:`core.skeleton.SkelList`.
 
@@ -691,6 +691,7 @@ class Query(object):
 
         res = SkelList(self.srcSkel)
 
+        # FIXME: Why is this not like in ViUR2?
         for entity in self.run(limit):
             skel_instance = SkeletonInstance(self.srcSkel.skeletonCls, bone_map=self.srcSkel.boneMap)
             skel_instance.dbEntity = entity

--- a/src/viur/core/render/json/default.py
+++ b/src/viur/core/render/json/default.py
@@ -3,7 +3,7 @@ import typing as t
 from enum import Enum
 from viur.core import db, current
 from viur.core.render.abstract import AbstractRenderer
-from viur.core.skeleton import SkeletonInstance, SkelList
+from viur.core.skeleton import SkeletonInstance, RelSkel, SkelList
 from viur.core.i18n import translate
 from viur.core.config import conf
 from datetime import datetime
@@ -101,35 +101,19 @@ class DefaultRender(AbstractRenderer):
         return self.renderEntry(skel, action, params)
 
     def list(self, skellist: SkelList, action: str = "list", params=None, **kwargs):
-
-        # Rendering the structure in lists is flagged as deprecated
-        structure = None
-        cursor = None
-        orders = None
-
-        if skellist:
-            if isinstance(skellist[0], SkeletonInstance):
-                if "json.bone.structure.inlists" in conf.compatibility:
-                    structure = DefaultRender.render_structure(skellist[0].structure())
-
-                cursor = skellist.getCursor()
-                orders = skellist.get_orders()
-
-            skellist = [item.dump() for item in skellist]
-        else:
-            skellist = []
-
-        # VIUR4 ;-)
-        # loc = locals()
-        # res = {k: loc[k] for k in ("action", "cursor", "params", "skellist", "structure", "orders") if loc[k]}
+        if not isinstance(skellist, SkelList):
+            raise ValueError("Function requires a SkelList")
 
         res = {
             "action": action,
-            "cursor": cursor,
+            "cursor": skellist.getCursor() if skellist else None,
             "params": params,
-            "skellist": skellist,
-            "structure": structure,
-            "orders": orders
+            "skellist": [item.dump() for item in skellist],
+            "structure":
+                DefaultRender.render_structure(skellist[0].structure())
+                if skellist and "json.bone.structure.inlists" in conf.compatibility
+                else None,
+            "orders": skellist.get_orders() if skellist else None,
         }
 
         current.request.get().response.headers["Content-Type"] = "application/json"

--- a/src/viur/core/skeleton/instance.py
+++ b/src/viur/core/skeleton/instance.py
@@ -31,6 +31,7 @@ class SkeletonInstance:
     def __init__(
         self,
         skel_cls: t.Type[Skeleton],
+        entity: t.Optional[db.Entity | dict] = None,
         *,
         bones: t.Iterable[str] = (),
         bone_map: t.Optional[t.Dict[str, BaseBone]] = None,
@@ -95,7 +96,7 @@ class SkeletonInstance:
                 v.isClonedInstance = True
 
         self.accessedValues = {}
-        self.dbEntity = None
+        self.dbEntity = entity
         self.errors = []
         self.is_cloned = clone
         self.renderAccessedValues = {}

--- a/src/viur/core/skeleton/utils.py
+++ b/src/viur/core/skeleton/utils.py
@@ -47,13 +47,15 @@ class SkelList(list):
         "renderPreparation",
     )
 
-    def __init__(self, baseSkel=None):
+    def __init__(self, skel, *items):
         """
             :param baseSkel: The baseclass for all entries in this list
         """
         super().__init__()
-        self.baseSkel = baseSkel or {}
+        self.baseSkel = skel or {}
         self.getCursor = lambda: None
         self.get_orders = lambda: None
         self.renderPreparation = None
         self.customQueryInfo = {}
+
+        self.extend(items)

--- a/src/viur/core/tasks.py
+++ b/src/viur/core/tasks.py
@@ -1,7 +1,6 @@
 import abc
 import datetime
 import functools
-import json
 import logging
 import os
 import sys
@@ -320,14 +319,21 @@ class TaskHandler(Module):
         """Lists all user-callable tasks which are callable by this user"""
         global _callableTasks
 
-        from viur.core.skeleton import SkelList
-        tasks = SkelList()
-        tasks.extend([{
-            "key": x.key,
-            "name": str(x.name),
-            "descr": str(x.descr)
-        } for x in _callableTasks.values() if x().canCall()
-        ])
+        from viur.core.skeleton import SkeletonInstance, SkelList, RelSkel
+        from viur.core.bones import BaseBone, StringBone
+
+        class TaskSkel(RelSkel):
+            key = BaseBone()
+            name = StringBone()
+            descr = StringBone()
+
+        tasks = SkelList(TaskSkel, *(
+            SkeletonInstance(TaskSkel, {
+                "key": task.key,
+                "name": str(task.name),
+                "descr": str(task.descr)
+            }) for task in _callableTasks.values() if task().canCall()
+        ))
 
         return self.render.list(tasks)
 


### PR DESCRIPTION
- New `SkelList`-constructor
- Use `SkelList` correctly in _tasks/list
- Disallow use of non-skellist-values in render (this broke!)