### PR TITLE
fix: Make `#` a safe character for redirects

### DIFF
--- a/src/viur/core/request.py
+++ b/src/viur/core/request.py
@@ -369,7 +369,7 @@ class Router:
             url = e.url
             url = unquote(url)  # decode first
             # safe = https://url.spec.whatwg.org/#url-path-segment-string
-            url = quote(url, encoding="utf-8", safe="!$&'()*+,-./:;=?@_~")  # re-encode all in utf-8
+            url = quote(url, encoding="utf-8", safe="!$&'()*+,-./:;=?@_~#")  # re-encode all in utf-8
             if url.startswith(('.', '/')):
                 url = str(urljoin(self.request.url, url))
             self.response.headers['Location'] = url


### PR DESCRIPTION
This change made in #1504 currently means that I can no longer redirect to `#` routes in a Vue app... if I want to redirect to “/#/12345”, it turns the URL into /%23/12345... therefore `#` should become a safe char.