### PR TITLE
fix+refactor: `(Raw|String|Text)Bone\.getSearchTags`

### DIFF
--- a/src/viur/core/bones/raw.py
+++ b/src/viur/core/bones/raw.py
@@ -1,4 +1,7 @@
+import re
 from viur.core.bones.base import BaseBone, ReadFromClientError, ReadFromClientErrorSeverity
+
+SEARCH_TAGS = re.compile(r"\w+")
 
 
 class RawBone(BaseBone):
@@ -18,3 +21,15 @@ class RawBone(BaseBone):
         if err:
             return self.getEmptyValue(), [ReadFromClientError(ReadFromClientErrorSeverity.Invalid, err)]
         return value, None
+
+    def getSearchTags(self, skel: "SkeletonInstance", name: str) -> set[str]:
+        result = set()
+
+        for idx, lang, value in self.iter_bone_value(skel, name):
+            if not value:
+                continue
+
+            for tag in re.finditer(SEARCH_TAGS, value):
+                result.add(tag.group())
+
+        return result

--- a/src/viur/core/bones/string.py
+++ b/src/viur/core/bones/string.py
@@ -7,7 +7,8 @@ import warnings
 from numbers import Number
 
 from viur.core import current, db, utils
-from viur.core.bones.base import BaseBone, ReadFromClientError, ReadFromClientErrorSeverity
+from .base import ReadFromClientError, ReadFromClientErrorSeverity
+from .raw import RawBone
 
 if t.TYPE_CHECKING:
     from ..skeleton import SkeletonInstance
@@ -15,7 +16,7 @@ if t.TYPE_CHECKING:
 DB_TYPE_INDEXED: t.TypeAlias = dict[t.Literal["val", "idx", "sort_idx"], str]
 
 
-class StringBone(BaseBone):
+class StringBone(RawBone):
     """
     The "StringBone" represents a data field that contains text values.
     """
@@ -283,24 +284,6 @@ class StringBone(BaseBone):
             "Ä": "Ae",
             "ẞ": "SS",
         }))
-
-    def getSearchTags(self, skel: "SkeletonInstance", name: str) -> set[str]:
-        """
-        Returns a set of lowercased words that represent searchable tags for the given bone.
-
-        :param skel: The skeleton instance being searched.
-        :param name: The name of the bone to generate tags for.
-
-        :return: A set of lowercased words representing searchable tags.
-        """
-        result = set()
-        for idx, lang, value in self.iter_bone_value(skel, name):
-            if value is None:
-                continue
-            for line in str(value).splitlines():  # TODO: Can a StringBone be multiline?
-                for word in line.split(" "):
-                    result.add(word.lower())
-        return result
 
     def getUniquePropertyIndexValues(self, skel: "SkeletonInstance", name: str) -> list[str]:
         """

--- a/src/viur/core/bones/text.py
+++ b/src/viur/core/bones/text.py
@@ -8,7 +8,8 @@ import typing as t
 import warnings
 from html.parser import HTMLParser
 from viur.core import db, conf
-from viur.core.bones.base import BaseBone, ReadFromClientError, ReadFromClientErrorSeverity
+from .base import ReadFromClientError, ReadFromClientErrorSeverity
+from .raw import RawBone
 
 
 class HtmlBoneConfiguration(t.TypedDict):
@@ -286,7 +287,7 @@ class HtmlSerializer(HTMLParser):
         return self.result
 
 
-class TextBone(BaseBone):
+class TextBone(RawBone):
     """
     A bone for storing and validating HTML or plain text content. Can be configured to allow
     only specific HTML tags and attributes, and enforce a maximum length. Supports the use of
@@ -436,27 +437,6 @@ class TextBone(BaseBone):
                 skel[boneName] = {k: self.singleValueFromClient(v, skel, boneName, None)[0] for k, v in val.items()}
             elif not self.languages and isinstance(val, str):
                 skel[boneName] = self.singleValueFromClient(val, skel, boneName, None)[0]
-
-    def getSearchTags(self, skel: 'viur.core.skeleton.SkeletonInstance', name: str) -> set[str]:
-        """
-        Extracts search tags from the text content of a TextBone.
-
-        This method iterates over the values of the TextBone in the given skeleton, and for each non-empty value,
-        it tokenizes the text by lines and words. Then, it adds the lowercase version of each word to a set of
-        search tags, which is returned at the end.
-
-        :param skel: A SkeletonInstance containing the TextBone.
-        :param name: The name of the TextBone in the skeleton.
-        :return: A set of unique search tags (lowercase words) extracted from the text content of the TextBone.
-        """
-        result = set()
-        for idx, lang, value in self.iter_bone_value(skel, name):
-            if value is None:
-                continue
-            for line in str(value).splitlines():
-                for word in line.split(" "):
-                    result.add(word.lower())
-        return result
 
     def getUniquePropertyIndexValues(self, valuesCache: dict, name: str) -> list[str]:
         """


### PR DESCRIPTION
Implements getSearchTags() for `RawBone` as well, and lets `TextBone` and `StringBone` inherit from `RawBone` to avoid redundant code. Tag matching implemented via regex now.