### PR TITLE
fix: `bounce` check order in `clone`

### DIFF
--- a/src/viur/core/prototypes/list.py
+++ b/src/viur/core/prototypes/list.py
@@ -393,8 +393,8 @@ class List(SkelModule):
         if (
             not kwargs  # no data supplied
             or not current.request.get().isPostRequest  # failure if not using POST-method
-            or not skel.fromClient(kwargs)  # failure on reading into the bones
             or utils.parse.bool(kwargs.get("bounce"))  # review before changing
+            or not skel.fromClient(kwargs)  # failure on reading into the bones
         ):
             return self.render.edit(skel, action="clone")
 


### PR DESCRIPTION
If we frist check the `fromClient` and the the `bounce` we send all all erorrs back to the client.