### PR TITLE
refactor+fix: `bounce`-flag and amend-handling

### DIFF
--- a/src/viur/core/prototypes/list.py
+++ b/src/viur/core/prototypes/list.py
@@ -209,7 +209,7 @@ class List(SkelModule):
     @force_ssl
     @exposed
     @skey(allow_empty=True)
-    def edit(self, key: db.Key | int | str, *args, **kwargs) -> t.Any:
+    def edit(self, key: db.Key | int | str, *, bounce: bool = False, **kwargs) -> t.Any:
         """
             Modify an existing entry, and render the entry, eventually with error notes on incorrect data.
             Data is taken by any other arguments in *kwargs*.
@@ -238,7 +238,7 @@ class List(SkelModule):
             not kwargs  # no data supplied
             or not current.request.get().isPostRequest  # failure if not using POST-method
             or not skel.fromClient(kwargs, amend=True)  # failure on reading into the bones
-            or utils.parse.bool(kwargs.get("bounce"))  # review before changing
+            or bounce  # review before changing
         ):
             # render the skeleton in the version it could as far as it could be read.
             return self.render.edit(skel)
@@ -252,7 +252,7 @@ class List(SkelModule):
     @force_ssl
     @exposed
     @skey(allow_empty=True)
-    def add(self, *args, **kwargs) -> t.Any:
+    def add(self, *, bounce: bool = False, **kwargs) -> t.Any:
         """
             Add a new entry, and render the entry, eventually with error notes on incorrect data.
             Data is taken by any other arguments in *kwargs*.
@@ -274,8 +274,8 @@ class List(SkelModule):
         if (
             not kwargs  # no data supplied
             or not current.request.get().isPostRequest  # failure if not using POST-method
-            or not skel.fromClient(kwargs)  # failure on reading into the bones
-            or utils.parse.bool(kwargs.get("bounce"))  # review before adding
+            or not skel.fromClient(kwargs, amend=bounce)  # failure on reading into the bones
+            or bounce  # review before adding
         ):
             # render the skeleton in the version it could as far as it could be read.
             return self.render.add(skel)
@@ -290,7 +290,7 @@ class List(SkelModule):
     @force_post
     @exposed
     @skey
-    def delete(self, key: db.Key | int | str, *args, **kwargs) -> t.Any:
+    def delete(self, key: db.Key | int | str, **kwargs) -> t.Any:
         """
             Delete an entry.
 
@@ -358,7 +358,7 @@ class List(SkelModule):
     @exposed
     @force_ssl
     @skey(allow_empty=True)
-    def clone(self, key: db.Key | str | int, **kwargs):
+    def clone(self, key: db.Key | str | int, *, bounce: bool = False, **kwargs):
         """
         Clone an existing entry, and render the entry, eventually with error notes on incorrect data.
         Data is taken by any other arguments in *kwargs*.
@@ -393,8 +393,8 @@ class List(SkelModule):
         if (
             not kwargs  # no data supplied
             or not current.request.get().isPostRequest  # failure if not using POST-method
-            or not skel.fromClient(kwargs)  # failure on reading into the bones
-            or utils.parse.bool(kwargs.get("bounce"))  # review before changing
+            or not skel.fromClient(kwargs, amend=bounce)  # failure on reading into the bones
+            or bounce  # review before changing
         ):
             return self.render.edit(skel, action="clone")
 

--- a/src/viur/core/prototypes/singleton.py
+++ b/src/viur/core/prototypes/singleton.py
@@ -134,7 +134,7 @@ class Singleton(SkelModule):
     @exposed
     @force_ssl
     @skey(allow_empty=True)
-    def edit(self, *args, **kwargs) -> t.Any:
+    def edit(self, *, bounce: bool = False, **kwargs) -> t.Any:
         """
         Modify the existing entry, and render the entry, eventually with error notes on incorrect data.
 
@@ -161,7 +161,7 @@ class Singleton(SkelModule):
             not kwargs  # no data supplied
             or not current.request.get().isPostRequest  # failure if not using POST-method
             or not skel.fromClient(kwargs, amend=True)  # failure on reading into the bones
-            or utils.parse.bool(kwargs.get("bounce"))  # review before changing
+            or bounce  # review before changing
         ):
             return self.render.edit(skel)
 

--- a/src/viur/core/prototypes/tree.py
+++ b/src/viur/core/prototypes/tree.py
@@ -416,7 +416,8 @@ class Tree(SkelModule):
     @exposed
     @force_ssl
     @skey(allow_empty=True)
-    def add(self, skelType: SkelType, node: db.Key | int | str, *args, **kwargs) -> t.Any:
+    def add(self, skelType: SkelType, node: db.Key | int | str, *, bounce: bool = False, **kwargs) -> t.Any:
+        # FIXME: VIUR4 rename node into key...
         """
         Add a new entry with the given parent *node*, and render the entry, eventually with error notes
         on incorrect data. Data is taken by any other arguments in *kwargs*.
@@ -454,8 +455,8 @@ class Tree(SkelModule):
         if (
             not kwargs  # no data supplied
             or not current.request.get().isPostRequest  # failure if not using POST-method
-            or not skel.fromClient(kwargs)  # failure on reading into the bones
-            or utils.parse.bool(kwargs.get("bounce"))  # review before adding
+            or not skel.fromClient(kwargs, amend=bounce)  # failure on reading into the bones
+            or bounce  # review before adding
         ):
             return self.render.add(skel)
 
@@ -535,7 +536,7 @@ class Tree(SkelModule):
     @exposed
     @force_ssl
     @skey(allow_empty=True)
-    def edit(self, skelType: SkelType, key: db.Key | int | str, *args, **kwargs) -> t.Any:
+    def edit(self, skelType: SkelType, key: db.Key | int | str, *, bounce: bool = False, **kwargs) -> t.Any:
         """
         Modify an existing entry, and render the entry, eventually with error notes on incorrect data.
         Data is taken by any other arguments in *kwargs*.
@@ -568,7 +569,7 @@ class Tree(SkelModule):
             not kwargs  # no data supplied
             or not current.request.get().isPostRequest  # failure if not using POST-method
             or not skel.fromClient(kwargs, amend=True)  # failure on reading into the bones
-            or utils.parse.bool(kwargs.get("bounce"))  # review before adding
+            or bounce  # review before adding
         ):
             return self.render.edit(skel)
 
@@ -582,7 +583,7 @@ class Tree(SkelModule):
     @force_ssl
     @force_post
     @skey
-    def delete(self, skelType: SkelType, key: str, *args, **kwargs) -> t.Any:
+    def delete(self, skelType: SkelType, key: str, **kwargs) -> t.Any:
         """
         Deletes an entry or an directory (including its contents).
 
@@ -727,7 +728,7 @@ class Tree(SkelModule):
     @exposed
     @force_ssl
     @skey(allow_empty=True)
-    def clone(self, skelType: SkelType, key: db.Key | str | int, **kwargs):
+    def clone(self, skelType: SkelType, key: db.Key | str | int, *, bounce: bool = False, **kwargs):
         """
         Clone an existing entry, and render the entry, eventually with error notes on incorrect data.
         Data is taken by any other arguments in *kwargs*.
@@ -780,8 +781,8 @@ class Tree(SkelModule):
         if (
             not kwargs  # no data supplied
             or not current.request.get().isPostRequest  # failure if not using POST-method
-            or not skel.fromClient(kwargs)  # failure on reading into the bones
-            or utils.parse.bool(kwargs.get("bounce"))  # review before changing
+            or not skel.fromClient(kwargs, amend=bounce)  # failure on reading into the bones
+            or bounce  # review before changing
         ):
             return self.render.edit(skel, action="clone")
 

--- a/src/viur/core/skeleton/meta.py
+++ b/src/viur/core/skeleton/meta.py
@@ -411,6 +411,8 @@ class BaseSkeleton(object, metaclass=MetaBaseSkel):
                                 f"""{getattr(cls, "kindName", cls.__name__)}: {".".join(error.fieldPath)}: """
                                 f"""({error.severity}) {error.errorMessage}"""
                             )
+                    else:
+                        errors.clear()
 
                 skel.errors += errors
 


### PR DESCRIPTION
Refactors the `bounce`-flag to the following:

- `bounce` is now a bool parameter to all endpoints
- `BaseSkeleton.fromClient(amend=True)` now only outputs errors for provided fields with wrong data
- The behavior is almost the same then before (100% backward compatible)
- add/edit/clone-endpoints won't accept "throw-away-*args" anymore (never used in the wild)

Relates to https://github.com/viur-framework/vi-admin/issues/49#issuecomment-3156402674, replacement for #1543.