### PR TITLE
fix: `DatabaseAdapter` and `HistoryAdapter`

### DIFF
--- a/src/viur/core/bones/base.py
+++ b/src/viur/core/bones/base.py
@@ -916,7 +916,7 @@ class BaseBone(object):
             elif self.multiple:
                 res = []
 
-                assert newVal is None or isinstance(newVal, (list, tuple)), \
+                assert newVal is None or isinstance(newVal, (list, tuple, set)), \
                     f"Cannot handle {repr(newVal)} here. Expecting list or tuple."
 
                 for singleValue in (newVal or ()):

--- a/src/viur/core/modules/history.py
+++ b/src/viur/core/modules/history.py
@@ -276,14 +276,14 @@ class HistoryAdapter(DatabaseAdapter):
         # add excludes to diff excludes
         self.diff_excludes = set(excludes)
 
-    def prewrite(self, skel, is_add, change_list=()):
-        if not is_add:  # edit
+    def prewrite(self, skel, *, is_add, change_list, update_relations, **kwargs):
+        if not is_add and update_relations:  # edit
             old_skel = skel.clone()
             old_skel.read(skel["key"])
             self.trigger("edit", old_skel, skel, change_list)
 
-    def write(self, skel, is_add, change_list=()):
-        if is_add:  # add
+    def write(self, skel, *, is_add, update_relations, **kwargs):
+        if is_add and update_relations:  # add
             self.trigger("add", None, skel)
 
     def delete(self, skel):
@@ -311,7 +311,7 @@ class HistoryAdapter(DatabaseAdapter):
             return None
 
         # FIXME: Turn change_list into set, in entire Core...
-        if change_list and not set(change_list).difference(self.diff_excludes):
+        if not (change_list := set(change_list).difference(self.diff_excludes)):
             logging.info("change_list is empty, nothing to write")
             return None
 

--- a/src/viur/core/skeleton/adapter.py
+++ b/src/viur/core/skeleton/adapter.py
@@ -18,7 +18,14 @@ class DatabaseAdapter:
     providesCustomQueries: bool = False
     """Indicate that we can run more types of queries than originally supported by datastore"""
 
-    def prewrite(self, skel: "SkeletonInstance", is_add: bool, change_list: t.Iterable[str] = ()):
+    def prewrite(
+        self,
+        skel: "SkeletonInstance",
+        *,
+        is_add: bool,
+        change_list: t.Iterable[str] = (),
+        update_relations: bool = False,
+    ):
         """
         Hook being called on a add, edit or delete operation before the skeleton-specific action is performed.
 
@@ -31,7 +38,14 @@ class DatabaseAdapter:
         """
         pass
 
-    def write(self, skel: "SkeletonInstance", is_add: bool, change_list: t.Iterable[str] = ()):
+    def write(
+        self,
+        skel: "SkeletonInstance",
+        *,
+        is_add: bool,
+        change_list: t.Iterable[str] = (),
+        update_relations: bool = False,
+    ):
         """
         Hook being called on a write operations after the skeleton is written.
 
@@ -106,7 +120,7 @@ class ViurTagsSearchAdapter(DatabaseAdapter):
 
         return res
 
-    def prewrite(self, skel: "SkeletonInstance", *args, **kwargs):
+    def prewrite(self, skel: "SkeletonInstance", **kwargs):
         """
         Collect searchTags from skeleton and build viurTags
         """

--- a/src/viur/core/skeleton/skeleton.py
+++ b/src/viur/core/skeleton/skeleton.py
@@ -515,7 +515,7 @@ class Skeleton(BaseSkeleton, metaclass=MetaSkel):
 
             # Allow the database adapter to apply last minute changes to the object
             for adapter in skel.database_adapters:
-                adapter.prewrite(skel, is_add, change_list)
+                adapter.prewrite(skel, is_add=is_add, change_list=change_list, update_relations=update_relations)
 
             # ViUR2 import compatibility - remove properties containing. if we have a dict with the same name
             def fixDotNames(entity):
@@ -604,7 +604,7 @@ class Skeleton(BaseSkeleton, metaclass=MetaSkel):
 
         # Trigger the database adapter of the changes made to the entry
         for adapter in skel.database_adapters:
-            adapter.write(skel, is_add, change_list)
+            adapter.write(skel, is_add=is_add, change_list=change_list, update_relations=update_relations)
 
         return skel
 


### PR DESCRIPTION
- `DatabaseAdapter` now accepts the `update_relations`-flag to determine for the
- `HistoryAdapter` if entries shall be written or not during a refresh or update_relations, which currently is the case. Anyway, this solution maybe does not satisfy all cases, which could only be determined using a special "write_history"-flag provided to `skel.write()`...

This PR is breaking, because custom DatabaseAdapters must accept the `update_relations`-flag or `**kwargs`.