### PR TITLE
fix: `BaseBone.clone_value` should just copy

### DIFF
--- a/src/viur/core/bones/base.py
+++ b/src/viur/core/bones/base.py
@@ -1368,14 +1368,7 @@ class BaseBone(object):
         """Clone / Set the value for this bone depending on :attr:`clone_behavior`"""
         match self.clone_behavior.strategy:
             case CloneStrategy.COPY_VALUE:
-                try:
-                    skel.accessedValues[bone_name] = copy.deepcopy(src_skel.accessedValues[bone_name])
-                except KeyError:
-                    pass  # bone_name is not in accessedValues, cannot clone it
-                try:
-                    skel.renderAccessedValues[bone_name] = copy.deepcopy(src_skel.renderAccessedValues[bone_name])
-                except KeyError:
-                    pass  # bone_name is not in renderAccessedValues, cannot clone it
+                skel[bone_name] = copy.deepcopy(src_skel[bone_name])
             case CloneStrategy.SET_NULL:
                 skel.accessedValues[bone_name] = None
             case CloneStrategy.SET_DEFAULT:


### PR DESCRIPTION
I just found out that the List.clone-prototype function does not copy values correctly.
It was strange, but this simply fixed it, I think it has to do with the intermixing of accessedValues, renderAccessedValues and dbEntity.

This mess must be entirely cleaned up.