### PR TITLE
fix: Not execute `_route` on preflight requests

### DIFF
--- a/src/viur/core/request.py
+++ b/src/viur/core/request.py
@@ -364,8 +364,10 @@ class Router:
 
             if conf.request_preprocessor:
                 path = conf.request_preprocessor(path)
-
-            self._route(path)
+            if self.method != "options":
+                # Route actual request only when the methode is not options,
+                # because the preflight not set the cookies so  a normal request can be returned with an error
+                self._route(path)
 
         except errors.Redirect as e:
             if conf.debug.trace_exceptions:


### PR DESCRIPTION
When you call a list with the `x-viur-bonelist` header, the browser starts a preflight request. This request is sent without cookies, so if you have an access check in the list filter, the core response is a 401 error, and the browser thinks it cannot send the header.