### PR TITLE
fix: `User.onLogin()` shall be called earlier

### DIFF
--- a/src/viur/core/modules/user.py
+++ b/src/viur/core/modules/user.py
@@ -1521,13 +1521,13 @@ class User(List):
         # and copy them over to the new session
         session |= take_over
 
+        self.onLogin(skel)
+
         # Update session, user and request
         session["user"] = skel.dbEntity
 
         current.request.get().response.headers[securitykey.SECURITYKEY_STATIC_HEADER] = session.static_security_key
         current.user.set(self.getCurrentUser())
-
-        self.onLogin(skel)
 
         return self.render.render("login_success", skel, **kwargs)
 


### PR DESCRIPTION
This change would allow the User.onLogin()-hook to update things in the provided UserSkel and take this (probably updated) UserSkel into the session. Otherwise, it might happen that the UserSkel is internally updated, but the old UserSkel remains in the session.

Here's an actual example for such a hook from a customer project (without code that does the `current.session.get()["user"]`-re-assignment and `current.user.set()`-call, which are necessary without this change):

```py
    def onLogin(self, skel):
        # Synchronize user with external system
        if not skel["manualoverride"] and skel["debitor"]:
            ok, _ = conf.main_app.thirdparty.sync_user_skel(skel)
            if ok:
                skel.write(update_relations=False)

                # Is user still active, or meanwhile flagged locked?
                if not self.is_active(skel):
                    session.killSessionByUser(skel["key"])
                    raise errors.Redirect("s/user_locked")

        # Super-Login
        super().onLogin(skel)
```