### PR TITLE
fix: `Tree._clone_recursive` internal call

### DIFF
--- a/src/viur/core/prototypes/tree.py
+++ b/src/viur/core/prototypes/tree.py
@@ -1111,7 +1111,7 @@ class Tree(SkelModule):
         logging.debug(f"_clone_recursive {count=}")
 
         if cursor := q.getCursor():
-            self._clone_recursive(skel_type, src_key, target_key, target_repo, skel_type, cursor)
+            self._clone_recursive(skel_type, src_key, target_key, target_repo, cursor)
 
     def onCloned(self, skelType: SkelType, skel: SkeletonInstance, src_skel: SkeletonInstance):
         """


### PR DESCRIPTION
The internal recall of `Tree._clone_recursive` raises `TypeError: Tree._clone_recursive() takes from 5 to 6 positional arguments but 7 were given` because it is called with skel_type twice.