### PR TITLE
fix: list: Distinguish between 401 and 403

### DIFF
--- a/src/viur/core/prototypes/list.py
+++ b/src/viur/core/prototypes/list.py
@@ -200,7 +200,10 @@ class List(SkelModule):
 
         # The general access control is made via self.listFilter()
         if not (query := self.listFilter(skel.all().mergeExternalFilter(kwargs))):
-            raise errors.Unauthorized()
+            if current.user.get():
+                raise errors.Forbidden()
+            else:
+                raise errors.Unauthorized()
 
         self._apply_default_order(query)
         return self.render.list(query.fetch())

--- a/src/viur/core/prototypes/tree.py
+++ b/src/viur/core/prototypes/tree.py
@@ -340,7 +340,10 @@ class Tree(SkelModule):
 
         # The general access control is made via self.listFilter()
         if not (query := self.listFilter(self.viewSkel(skelType).all().mergeExternalFilter(kwargs))):
-            raise errors.Unauthorized()
+            if current.user.get():
+                raise errors.Forbidden()
+            else:
+                raise errors.Unauthorized()
 
         self._apply_default_order(query)
         return self.render.list(query.fetch())


### PR DESCRIPTION
Currently, any listFilter that returns None raises error 401, althought a user is authorized. This fix raises error 403 forbidden when an authenticated user is not allowed to proceed.

Belongs to #29 