### PR TITLE
fix: `skel.read()` with `create`-mode totally broken

### DIFF
--- a/src/viur/core/bones/base.py
+++ b/src/viur/core/bones/base.py
@@ -957,6 +957,7 @@ class BaseBone(object):
         """
         if not self.compute:
             return None
+
         match self.compute.interval.method:
             case ComputeMethod.OnWrite:
                 skel.accessedValues[name] = self._compute(skel, name)

--- a/src/viur/core/skeleton/skeleton.py
+++ b/src/viur/core/skeleton/skeleton.py
@@ -291,13 +291,14 @@ class Skeleton(BaseSkeleton, metaclass=MetaSkel):
         elif create in (False, None):
             return None
         elif isinstance(create, dict):
-            if create and not skel.fromClient(create, amend=True):
+            if create and not skel.fromClient(create, amend=True, ignore=()):
                 raise ReadFromClientException(skel.errors)
         elif callable(create):
             create(skel)
         elif create is not True:
             raise ValueError("'create' must either be dict, a callable or True.")
 
+        skel["key"] = db_key
         return skel.write()
 
     @classmethod


### PR DESCRIPTION
1. `skel.read()` did never use the provided key when in create-mode, there was always a random key used, which entirely fails this feature.
2. Providing a create-dict did only set non-readonly-bones, which is NOT the wanted behavior here.