### PR TITLE
fix: No exception raise on compute attempt on deleted RefSkel

### DIFF
--- a/src/viur/core/bones/base.py
+++ b/src/viur/core/bones/base.py
@@ -1581,11 +1581,14 @@ class BaseBone(object):
                     lang: unserialize_raw_value(ret.get(lang, [] if self.multiple else None))
                     for lang in self.languages
                 }
+
             return unserialize_raw_value(ret)
+
         self._prevent_compute = True
         if errors := self.fromClient(skel, bone_name, {bone_name: ret}):
             raise ValueError(f"Computed value fromClient failed with {errors!r}")
         self._prevent_compute = False
+
         return skel[bone_name]
 
     def structure(self) -> dict:


### PR DESCRIPTION
#1598 introduced a computed "shortkey" into every RelationalBone.
This now fails in several cases when the referenced skeleton behind the relation does no longer exists.

This pull requests is a solution and discussion base.

There are several ways to resolve this problem:

1. This PR would use the old value of the bone and log a warning.
2. A computed Always bone in RefKeys should only be updated when the specific entry is written, but not as part of the RefSkel.
3. It may be on the developer when a computed bone is in the refKeys that all required bones to calculate the bone are available in the RefSkel.
4. Implement a ShortKeyBone

We must discuss this. I personally would prefer solution 3+4.

Personally, I didn't see this problem when introducing the shortkey, but this now means, that any RelationalBone that is rendered will read the referenced skel, which is NOT necessary to compute the shortkey.