### PR TITLE
fix: Raise error 400 on broken UTF-8 URL request

### DIFF
--- a/src/viur/core/request.py
+++ b/src/viur/core/request.py
@@ -287,7 +287,11 @@ class Router:
                 self.response.write(statusDescr)
                 return
 
-        path = self.request.path
+        try:
+            path = self.request.path
+        except UnicodeDecodeError:  # webob can fail with UnicodeDecodeError on broken/invalid URLs
+            self.response.status = "400 Bad Request"  # let's send the client onto a health cure in Bad Request ...
+            return
 
         # Add CSP headers early (if any)
         if conf.security.content_security_policy and conf.security.content_security_policy["_headerCache"]:


### PR DESCRIPTION
This issue happens when calling e.g. `/ch/dk/224006/agxlfmhzay0yLXZpdXJyEgsSCmRrX2FydGlrZWwYuuDA/140/160%8A%82%20Eckversion`
raises
```
[2025-12-10 12:56:35 +0100] [126746] [ERROR] Error handling request /ch/dk/224006/agxlfmhzay0yLXZpdXJyEgsSCmRrX2FydGlrZWwYuuDA/140/160%8A%82%20Eckversion
Traceback (most recent call last):
  File "~/myproject/.venv/lib/python3.13/site-packages/gunicorn/workers/gthread.py", line 281, in handle
    keepalive = self.handle_request(req, conn)
  File "~/myproject/.venv/lib/python3.13/site-packages/gunicorn/workers/gthread.py", line 333, in handle_request
    respiter = self.wsgi(environ, resp.start_response)
  File "~/myproject/.venv/lib/python3.13/site-packages/google/appengine/runtime/middlewares.py", line 82, in <lambda>
    lambda app: lambda wsgi_env, start_resp: f(app, wsgi_env, start_resp),
                                             ~^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/myproject/.venv/lib/python3.13/site-packages/google/appengine/runtime/middlewares.py", line 306, in InitLegacyRequestOsEnvironMiddleware
    return app(wsgi_env, start_response)
  File "~/myproject/.venv/lib/python3.13/site-packages/google/appengine/runtime/middlewares.py", line 82, in <lambda>
    lambda app: lambda wsgi_env, start_resp: f(app, wsgi_env, start_resp),
                                             ~^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/myproject/.venv/lib/python3.13/site-packages/google/appengine/runtime/middlewares.py", line 362, in RunInNewContextMiddleware
    return ctx.run(app, wsgi_env, start_response)
           ~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/myproject/.venv/lib/python3.13/site-packages/google/appengine/runtime/middlewares.py", line 82, in <lambda>
    lambda app: lambda wsgi_env, start_resp: f(app, wsgi_env, start_resp),
                                             ~^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/myproject/.venv/lib/python3.13/site-packages/google/appengine/runtime/middlewares.py", line 222, in SetContextFromHeadersMiddleware
    return app(wsgi_env, start_response)
  File "~/myproject/.venv/lib/python3.13/site-packages/google/appengine/runtime/middlewares.py", line 82, in <lambda>
    lambda app: lambda wsgi_env, start_resp: f(app, wsgi_env, start_resp),
                                             ~^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/myproject/.venv/lib/python3.13/site-packages/google/appengine/runtime/middlewares.py", line 339, in CallbackMiddleware
    return app(wsgi_env, start_response)
  File "~/myproject/.venv/lib/python3.13/site-packages/google/appengine/runtime/middlewares.py", line 82, in <lambda>
    lambda app: lambda wsgi_env, start_resp: f(app, wsgi_env, start_resp),
                                             ~^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/myproject/.venv/lib/python3.13/site-packages/google/appengine/runtime/middlewares.py", line 108, in UseRequestSecurityTicketForApiMiddleware
    return app(wsgi_env, start_response)
  File "~/myproject/.venv/lib/python3.13/site-packages/google/appengine/runtime/middlewares.py", line 82, in <lambda>
    lambda app: lambda wsgi_env, start_resp: f(app, wsgi_env, start_resp),
                                             ~^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/myproject/.venv/lib/python3.13/site-packages/google/appengine/runtime/middlewares.py", line 133, in WaitForResponseMiddleware
    return list(app(wsgi_env, start_response))
                ~~~^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/myproject/.venv/lib/python3.13/site-packages/google/appengine/runtime/middlewares.py", line 82, in <lambda>
    lambda app: lambda wsgi_env, start_resp: f(app, wsgi_env, start_resp),
                                             ~^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/myproject/.venv/lib/python3.13/site-packages/google/appengine/runtime/middlewares.py", line 215, in WsgiEnvSettingMiddleware
    return app(wsgi_env, start_response)
  File "~/myproject/.venv/lib/python3.13/site-packages/google/appengine/runtime/middlewares.py", line 82, in <lambda>
    lambda app: lambda wsgi_env, start_resp: f(app, wsgi_env, start_resp),
                                             ~^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/myproject/.venv/lib/python3.13/site-packages/google/appengine/runtime/middlewares.py", line 264, in LegacyWsgiEnvSettingMiddleware
    return app(wsgi_env, start_response)
  File "~/myproject/.venv/lib/python3.13/site-packages/google/appengine/runtime/middlewares.py", line 82, in <lambda>
    lambda app: lambda wsgi_env, start_resp: f(app, wsgi_env, start_resp),
                                             ~^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/myproject/.venv/lib/python3.13/site-packages/google/appengine/runtime/middlewares.py", line 245, in LegacyWsgiRemoveXAppenginePrefixMiddleware
    return app(wsgi_env, start_response)
  File "~/myproject/.venv/lib/python3.13/site-packages/google/appengine/runtime/middlewares.py", line 82, in <lambda>
    lambda app: lambda wsgi_env, start_resp: f(app, wsgi_env, start_resp),
                                             ~^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/myproject/.venv/lib/python3.13/site-packages/google/appengine/runtime/middlewares.py", line 332, in LegacyCopyWsgiEnvToOsEnvMiddleware
    return app(wsgi_env, start_response)
  File "~/myproject/.venv/lib/python3.13/site-packages/google/appengine/runtime/middlewares.py", line 82, in <lambda>
    lambda app: lambda wsgi_env, start_resp: f(app, wsgi_env, start_resp),
                                             ~^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/myproject/.venv/lib/python3.13/site-packages/google/appengine/runtime/middlewares.py", line 140, in ErrorLoggingMiddleware
    return app(wsgi_env, start_response)
  File "~/myproject/.venv/lib/python3.13/site-packages/google/appengine/runtime/middlewares.py", line 82, in <lambda>
    lambda app: lambda wsgi_env, start_resp: f(app, wsgi_env, start_resp),
                                             ~^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/myproject/.venv/lib/python3.13/site-packages/google/appengine/runtime/middlewares.py", line 378, in BackgroundAndShutdownMiddleware
    return app(wsgi_env, start_response)
  File "~/myproject/.venv/lib/python3.13/site-packages/google/appengine/runtime/middlewares.py", line 82, in <lambda>
    lambda app: lambda wsgi_env, start_resp: f(app, wsgi_env, start_resp),
                                             ~^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/myproject/.venv/lib/python3.13/site-packages/google/appengine/runtime/middlewares.py", line 405, in SetNamespaceFromHeader
    return app(wsgi_env, start_response)
  File "~/myproject/.venv/lib/python3.13/site-packages/viur/core/__init__.py", line 352, in app
    return request.Router(environ).response(environ, start_response)
           ~~~~~~~~~~~~~~^^^^^^^^^
  File "~/myproject/.venv/lib/python3.13/site-packages/viur/core/request.py", line 158, in __init__
    self._process()
    ~~~~~~~~~~~~~^^
  File "~/myproject/.venv/lib/python3.13/site-packages/viur/core/request.py", line 290, in _process
    path = self.request.path
           ^^^^^^^^^^^^^^^^^
  File "~/myproject/.venv/lib/python3.13/site-packages/webob/request.py", line 477, in path
    bpath = bytes_(self.path_info, self.url_encoding)
                   ^^^^^^^^^^^^^^
  File "~/myproject/.venv/lib/python3.13/site-packages/webob/descriptors.py", line 70, in fget
    return req.encget(key, encattr=encattr)
           ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
  File "~/myproject/.venv/lib/python3.13/site-packages/webob/request.py", line 166, in encget
    return bytes_(val, 'latin-1').decode(encoding)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x8a in position 66: invalid start byte
```