### PR TITLE
fix: Use new vi-admin code-feature with syntax highlighting

### DIFF
--- a/src/viur/core/modules/script.py
+++ b/src/viur/core/modules/script.py
@@ -68,6 +68,7 @@ class ScriptLeafSkel(BaseScriptAbstractSkel):
 
     script = RawBone(
         descr="Code",
+        type_suffix="code.python",
         indexed=False,
     )
 


### PR DESCRIPTION
<img width="1002" height="757" alt="image" src="https://github.com/user-attachments/assets/4ebf6edf-b314-4fd1-8817-e27865d1d189" />
