### PR TITLE
feat: Inherit RefSkel from the source Skeleton

### DIFF
--- a/src/viur/core/bones/relational.py
+++ b/src/viur/core/bones/relational.py
@@ -309,6 +309,10 @@ class RelationalBone(BaseBone):
             raise NotImplementedError(
                 f"Skeleton {self.skel_cls!r} {self.__class__.__name__} {self.name!r}: Kind {self.kind!r} unknown"
             )
+        logging.debug(f"RelationalBone.setSystemInitialized {self.kind} {self.name} {self._refSkelCache=} {list(self._refSkelCache.__boneMap__.keys())=}")
+        # logging.debug(f"RelationalBone.setSystemInitialized {self.kind} {self.name} {self._refSkelCache=} {list(self._refSkelCache.__boneMap__.keys())=} {self._refSkelCache().structure()=}")
+        # logging.debug(f"RelationalBone.setSystemInitialized {self.kind} {self.name} {self._refSkelCache()=} {list(self._refSkelCache().boneMap.keys())=}")
+        # logging.debug(f"RelationalBone.setSystemInitialized {self.kind} {self.name} {self._refSkelCache=} {list(self._refSkelCache.boneMap)=}")
 
         self._skeletonInstanceClassRef = SkeletonInstance
         self._ref_keys = set(self._refSkelCache.__boneMap__.keys())
@@ -1268,6 +1272,7 @@ class RelationalBone(BaseBone):
             return self._hashValueForUniquePropertyIndex([entry["dest"]["key"] for entry in value if entry])
 
     def structure(self) -> dict:
+        print(f"RelationalBone structure: {self.kind=} {self.name=} ")
         return super().structure() | {
             "type": f"{self.type}.{self.kind}",
             "module": self.module,

--- a/src/viur/core/skeleton/instance.py
+++ b/src/viur/core/skeleton/instance.py
@@ -214,6 +214,8 @@ class SkeletonInstance:
         }:
             return partial(getattr(self.skeletonCls, item), self)
 
+        print(f"Accessing {item} from {self.skeletonCls}")
+
         # Load a @property from the Skeleton class
         try:
             # Use try/except to save an if check
@@ -329,6 +331,7 @@ class SkeletonInstance:
         self.renderAccessedValues = {}
 
     def structure(self) -> dict:
+        print(f"SkeletonInstance structure: {self.skeletonCls=} {list(self.keys())=}")
         return {
             key: bone.structure() | {"sortindex": i}
             for i, (key, bone) in enumerate(self.items())

--- a/src/viur/core/skeleton/meta.py
+++ b/src/viur/core/skeleton/meta.py
@@ -77,9 +77,20 @@ class MetaBaseSkel(type):
         """
         Recursively constructs a dict of bones from
         """
+        print(f"{cls.__name__} generated")
         map = {}
 
+        # from .relskel import  RefSkel, RelSkel
+        # from .skeleton import  Skeleton
+        ignore_base = getattr(cls, "_ignore_base", None)
+
+        print(f"{cls=} {cls.__bases__=} {ignore_base=}")
         for base in cls.__bases__:
+
+            # if issubclass(base, RefSkel) and issubclass(base,Skeleton):
+            #     continue
+            if base is ignore_base:
+                continue
             if "__viurBaseSkeletonMarker__" in dir(base):
                 map |= MetaBaseSkel.generate_bonemap(base)
 
@@ -456,4 +467,5 @@ class BaseSkeleton(object, metaclass=MetaBaseSkel):
 
     def __new__(cls, *args, **kwargs) -> "SkeletonInstance":
         from .instance import SkeletonInstance
+        print(f"BaseSkeleton.NEW {cls=} {args} {kwargs} {list(cls.__boneMap__.keys())=}")
         return SkeletonInstance(cls, *args, **kwargs)

--- a/src/viur/core/skeleton/meta.py
+++ b/src/viur/core/skeleton/meta.py
@@ -5,12 +5,13 @@ import os
 import string
 import sys
 import typing as t
-from deprecated.sphinx import deprecated
-from .adapter import ViurTagsSearchAdapter
-from ..bones.base import BaseBone, ReadFromClientErrorSeverity, getSystemInitialized
-from .. import db, utils
-from ..config import conf
 
+from deprecated.sphinx import deprecated
+
+from .adapter import ViurTagsSearchAdapter
+from .. import db, utils
+from ..bones.base import BaseBone, ReadFromClientErrorSeverity, getSystemInitialized
+from ..config import conf
 
 _UNDEFINED_KINDNAME = object()
 ABSTRACT_SKEL_CLS_SUFFIX = "AbstractSkel"
@@ -109,6 +110,10 @@ class MetaSkel(MetaBaseSkel):
 
     def __init__(cls, name, bases, dct, **kwargs):
         super().__init__(name, bases, dct, **kwargs)
+        from .relskel import RefSkel
+
+        if issubclass(cls, RefSkel):
+            return
 
         relNewFileName = inspect.getfile(cls) \
             .replace(str(conf.instance.project_base_path), "") \
@@ -124,9 +129,9 @@ class MetaSkel(MetaBaseSkel):
 
         # Automatic determination of the kindName, if the class is not part of viur.core.
         if (
-                cls.kindName is _UNDEFINED_KINDNAME
-                and not relNewFileName.strip(os.path.sep).startswith("viur")
-                and "viur_doc_build" not in dir(sys)  # do not check during documentation build
+            cls.kindName is _UNDEFINED_KINDNAME
+            and not relNewFileName.strip(os.path.sep).startswith("viur")
+            and "viur_doc_build" not in dir(sys)  # do not check during documentation build
         ):
             if cls.__name__.endswith("Skel"):
                 cls.kindName = cls.__name__.lower()[:-4]
@@ -157,8 +162,8 @@ class MetaSkel(MetaBaseSkel):
 
         # Ensure that all skeletons are defined in folders listed in conf.skeleton_search_path
         if (
-                not any([relNewFileName.startswith(path) for path in conf.skeleton_search_path])
-                and "viur_doc_build" not in dir(sys)  # do not check during documentation build
+            not any([relNewFileName.startswith(path) for path in conf.skeleton_search_path])
+            and "viur_doc_build" not in dir(sys)  # do not check during documentation build
         ):
             raise NotImplementedError(
                 f"""{relNewFileName} must be defined in a folder listed in {conf.skeleton_search_path}""")

--- a/src/viur/core/skeleton/relskel.py
+++ b/src/viur/core/skeleton/relskel.py
@@ -1,11 +1,11 @@
 from __future__ import annotations  # noqa: required for pre-defined annotations
 
-import typing as t
 import fnmatch
+import typing as t
 
-from .. import db, utils
 from .meta import BaseSkeleton
 from .utils import skeletonByKind
+from .. import db, utils
 
 
 class RelSkel(BaseSkeleton):
@@ -58,8 +58,8 @@ class RefSkel(RelSkel):
             :param args: List of bone names we'll adapt
             :return: A new instance of RefSkel
         """
-        newClass = type("RefSkelFor" + kindName, (RefSkel,), {})
         fromSkel = skeletonByKind(kindName)
+        newClass = type("RefSkelFor" + kindName, (RefSkel, fromSkel), {})
         newClass.kindName = kindName
         bone_map = {}
         for arg in args:

--- a/src/viur/core/skeleton/relskel.py
+++ b/src/viur/core/skeleton/relskel.py
@@ -61,10 +61,13 @@ class RefSkel(RelSkel):
         fromSkel = skeletonByKind(kindName)
         newClass = type("RefSkelFor" + kindName, (RefSkel, fromSkel), {})
         newClass.kindName = kindName
+        newClass._ignore_base = fromSkel
         bone_map = {}
         for arg in args:
             bone_map |= {k: fromSkel.__boneMap__[k] for k in fnmatch.filter(fromSkel.__boneMap__.keys(), arg)}
         newClass.__boneMap__ = bone_map
+        print(f"RefSkelFor{kindName}: {bone_map.keys()}")
+        print(f"RefSkelFor{kindName}: {newClass.__boneMap__.keys()}")
         return newClass
 
     def read(

--- a/src/viur/core/skeleton/skeleton.py
+++ b/src/viur/core/skeleton/skeleton.py
@@ -101,7 +101,7 @@ class Skeleton(BaseSkeleton, metaclass=MetaSkel):
 
     shortkey = RawBone(
         descr="Shortkey",
-        compute=Compute(lambda skel: skel["key"].id_or_name if skel["key"] else None),
+        compute=Compute(lambda skel: 'skel["key"].id_or_name' if skel["key"] else None),
         readOnly=True,
         visible=False,
         searchable=True,


### PR DESCRIPTION
This make `@property`s working properly and allows type checks.

Currently checks like this this https://github.com/viur-framework/viur-shop/blob/2a55ef1aa2fdb00d6a6af3985cfe151c5d6aedb6/src/viur/shop/types/dc_scope.py#L243-L257
would be more easy.

----

This fixes https://github.com/viur-framework/viur-core/issues/1622

**Warning:** It seems to work, but at the moment, I don't want to rule out any ViUR surprises.