### PR TITLE
fix: `shortkey` computation needs `Key` instance

### DIFF
--- a/src/viur/core/skeleton/skeleton.py
+++ b/src/viur/core/skeleton/skeleton.py
@@ -101,7 +101,7 @@ class Skeleton(BaseSkeleton, metaclass=MetaSkel):
 
     shortkey = RawBone(
         descr="Shortkey",
-        compute=Compute(lambda skel: skel["key"].id_or_name if skel["key"] else None),
+        compute=Compute(lambda skel: skel.dbEntity.key.id_or_name if skel.dbEntity and skel.dbEntity.key else None),
         readOnly=True,
         visible=False,
         searchable=True,


### PR DESCRIPTION
Does not work with renderPreparation.

Fixes #1618