### PR TITLE
fix: `UserPassword.pwrecover` should strip the recovery_key

### DIFF
--- a/src/viur/core/modules/user.py
+++ b/src/viur/core/modules/user.py
@@ -444,7 +444,9 @@ class UserPassword(UserPrimaryAuthentication):
 
         # in step 3
         skel = self.LostPasswordStep3Skel()
-        skel["recovery_key"] = recovery_key  # resend the recovery key again, in case the fromClient() fails.
+
+        # reset the recovery key again, in case the fromClient() fails.
+        skel["recovery_key"] = str(recovery_key).strip()
 
         # check for any input; Render input-form again when incomplete.
         if (

--- a/src/viur/core/securitykey.py
+++ b/src/viur/core/securitykey.py
@@ -37,7 +37,8 @@ def create(
         session_bound: bool = True,
         key_length: int = 13,
         indexed: bool = True,
-        **custom_data) -> str:
+        **custom_data,
+) -> str:
     """
         Creates a new one-time CSRF-security-key.
 
@@ -47,6 +48,7 @@ def create(
         :param duration: Make this CSRF-token valid for a fixed timeframe.
         :param session_bound: Bind this CSRF-token to the current session.
         :param indexed: Indexes all values stored with the security-key (default), set False to not index.
+        :param key_length: Allows to modify the length of the generated randomized key
         :param custom_data: Any other data is stored with the CSRF-token, for later re-use.
 
         :returns: The new one-time key, which is a randomized string.
@@ -56,6 +58,7 @@ def create(
 
     if not duration:
         duration = conf.user.session_life_time if session_bound else SECURITYKEY_DURATION
+
     key = utils.string.random(key_length)
 
     entity = db.Entity(db.Key(SECURITYKEY_KINDNAME, key))


### PR DESCRIPTION
When the user receives the e-mail, leading and trailing whitspace might be copied, depending on the e-mail client and used HTML tags. This avoids such misuse.