### PR TITLE
Add setuptools to testing dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ mailjet = [
     "mailjet-rest~=1.3",
 ]
 testing = [
+    "setuptools",
     "coverage",
     "coverage-badge",
 ]


### PR DESCRIPTION
This should fix (hopefully) the failing linter @ python 3.13
```py
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.13.12/x64/bin/coverage-badge", line 3, in <module>
    from coverage_badge.__main__ import main
  File "/opt/hostedtoolcache/Python/3.13.12/x64/lib/python3.13/site-packages/coverage_badge/__main__.py", line 7, in <module>
    import pkg_resources
ModuleNotFoundError: No module named 'pkg_resources'
Error: Process completed with exit code 1.
```
https://github.com/viur-framework/viur-core/actions/runs/21995641690/job/64062265821#step:6:157