### PR TITLE
fix: Call `Tree.canAdd` with `SkeletonInstance` in `Tree.clone`

### DIFF
--- a/src/viur/core/prototypes/tree.py
+++ b/src/viur/core/prototypes/tree.py
@@ -1,15 +1,16 @@
-import time
 import logging
+import time
 import typing as t
+
 from deprecated.sphinx import deprecated
-from viur.core import errors, db, current
-from viur.core.decorators import *
-from viur.core.bones import KeyBone, SortIndexBone, BooleanBone
+
+from viur.core import current, db, errors
+from viur.core.bones import BooleanBone, KeyBone, SortIndexBone
 from viur.core.cache import flushCache
+from viur.core.decorators import *
 from viur.core.skeleton import Skeleton, SkeletonInstance
 from viur.core.tasks import CallDeferred
 from .skelmodule import SkelModule
-
 
 SkelType = t.Literal["node", "leaf"]
 
@@ -729,12 +730,13 @@ class Tree(SkelModule):
     @force_ssl
     @skey(allow_empty=True)
     def clone(
-        self, 
-        skelType: SkelType, 
-        key: db.Key | str | int, *, 
+        self,
+        skelType: SkelType,
+        key: db.Key | str | int,
+        *,
         bounce: bool = False,
         parententry: t.Optional[db.Key | str | int] = None,
-        **kwargs
+        **kwargs,
     ):
         """
         Clone an existing entry, and render the entry, eventually with error notes on incorrect data.
@@ -746,6 +748,8 @@ class Tree(SkelModule):
 
         :param skelType: Defines the type of the entry that should be cloned and may either be "node" or "leaf".
         :param key: URL-safe key of the item to be edited.
+        :param bounce: Return the skeleton after applying client data and validtion without writing.
+        :param parententry: URL-safe key of the destination parent node.
 
         :returns: The cloned object of the entry, eventually with error hints.
 


### PR DESCRIPTION
Must be a `SkeletonInstance`, not a string-encoded key.

Fixes #1602