### PR TITLE
fix: `utils.__getattr__` doesn't return callables

### DIFF
--- a/src/viur/core/utils/__init__.py
+++ b/src/viur/core/utils/__init__.py
@@ -207,9 +207,6 @@ def __getattr__(attr):
         msg = f"Use of `utils.{attr}` is deprecated; Use `{replace[0]}` instead!"
         warnings.warn(msg, DeprecationWarning, stacklevel=3)
         logging.warning(msg, stacklevel=3)
-        res = replace[1]
-        if isinstance(res, t.Callable):
-            res = res()
-        return res
+        return replace[1]
 
     return super(__import__(__name__).__class__).__getattribute__(attr)


### PR DESCRIPTION
Alternative replacement for #1632