### PR TITLE
refactor: `db.fix_unindexable_properties`

### DIFF
--- a/src/viur/core/db/transport.py
+++ b/src/viur/core/db/transport.py
@@ -44,6 +44,8 @@ def get(keys: t.Union[Key, t.List[Key]]) -> t.Union[t.List[Entity], Entity, None
     :param keys: A datastore key (or a list thereof) to lookup
     :return: The entity (or None if it has not been found), or a list of entities.
     """
+    if conf.debug.trace_queries:
+        logging.info(f"Calling db.get({keys=})")
     _write_to_access_log(keys)
 
     if isinstance(keys, (list, set, tuple)):
@@ -212,6 +214,11 @@ def run_single_filter(query: QueryDefinition, limit: int) -> t.List[Entity]:
     query.currentCursor = qryRes.next_page_token
     if hasInvertedOrderings:
         res.reverse()
+
+    distinctOn = " distinct on %s" % str(query.distinct) if query.distinct else ""
+    logging.debug("Queried %s with filter %s and orders %s%s. Returned %s results" % (
+        query.kind, query.filters, query.orders, distinctOn, len(res)))
+
     return res
 
 

--- a/src/viur/core/db/transport.py
+++ b/src/viur/core/db/transport.py
@@ -44,8 +44,6 @@ def get(keys: t.Union[Key, t.List[Key]]) -> t.Union[t.List[Entity], Entity, None
     :param keys: A datastore key (or a list thereof) to lookup
     :return: The entity (or None if it has not been found), or a list of entities.
     """
-    if conf.debug.trace_queries:
-        logging.info(f"Calling db.get({keys=})")
     _write_to_access_log(keys)
 
     if isinstance(keys, (list, set, tuple)):
@@ -214,11 +212,6 @@ def run_single_filter(query: QueryDefinition, limit: int) -> t.List[Entity]:
     query.currentCursor = qryRes.next_page_token
     if hasInvertedOrderings:
         res.reverse()
-
-    distinctOn = " distinct on %s" % str(query.distinct) if query.distinct else ""
-    logging.debug("Queried %s with filter %s and orders %s%s. Returned %s results" % (
-        query.kind, query.filters, query.orders, distinctOn, len(res)))
-
     return res
 
 

--- a/src/viur/core/db/utils.py
+++ b/src/viur/core/db/utils.py
@@ -1,44 +1,43 @@
 import datetime
-import logging
 import sys
+import typing as t
 
 from deprecated.sphinx import deprecated
-import typing as t
-from .transport import get, put, run_in_transaction, __client__
-from .types import Entity, Key, current_db_access_log
 from google.cloud.datastore.transaction import Transaction
+
 from viur.core import current
+from .transport import __client__, get, put, run_in_transaction
+from .types import Entity, Key, current_db_access_log
 
 
-def fix_unindexable_properties(entry: Entity) -> Entity:
+def fix_unindexable_properties(entry: Entity, *, keep_exclusions: bool = False) -> Entity:
     """
-        Recursively walk the given Entity and add all properties to the list of unindexed properties if they contain
-        a string longer than 1500 bytes (which is maximum size of a string that can be indexed). The datastore would
-        return an error otherwise.
-        https://cloud.google.com/datastore/docs/concepts/limits?hl=en#limits
+    Recursively walk the given Entity and add all properties to the list of unindexed properties if they contain
+    a string longer than 1500 bytes (which is maximum size of a string that can be indexed). The datastore would
+    return an error otherwise.
+    https://cloud.google.com/datastore/docs/concepts/limits?hl=en#limits
+
     :param entry: The entity to fix (inplace)
+    :param keep_exclusions: If true, keep the properties already included in ``exclude_from_indexes``.
+        Otherwise, ignore them and exclude only non-indexable properties.
     :return: The fixed entity
     """
 
     def has_unindexable_property(prop):
-        if isinstance(prop, dict|Entity):
-            return any([has_unindexable_property(x) for x in prop.values()])
+        if isinstance(prop, dict):
+            return any(has_unindexable_property(x) for x in prop.values())
         elif isinstance(prop, list):
-            return any([has_unindexable_property(x) for x in prop])
+            return any(has_unindexable_property(x) for x in prop)
         elif isinstance(prop, (str, bytes)):
             return sys.getsizeof(prop) >= 1500
-            return len(prop) >= 1500
         else:
             return False
 
     unindexable_properties = set()
     for key, value in entry.items():
-        logging.debug(f" fix_unindexable_properties {key=} {value=}")
-        if not (res:=has_unindexable_property(value)):
-            logging.debug(f"  fix_unindexable_properties {key=}  --> {res=}")
+        if not has_unindexable_property(value):
             continue
-        logging.debug(f"  fix_unindexable_properties {key=}  --> {res=}")
-        if isinstance(value, dict|Entity):
+        if isinstance(value, dict):
             inner_entity = Entity()
             inner_entity.update(value)
             entry[key] = fix_unindexable_properties(inner_entity)
@@ -46,8 +45,10 @@ def fix_unindexable_properties(entry: Entity) -> Entity:
                 inner_entity.key = value.key
         else:
             unindexable_properties.add(key)
-    logging.debug(f"fix_unindexable_properties {entry.key=} {unindexable_properties=}")
-    entry.exclude_from_indexes = unindexable_properties
+    if keep_exclusions:
+        entry.exclude_from_indexes.update(unindexable_properties)  # type:ignore
+    else:
+        entry.exclude_from_indexes = unindexable_properties
     return entry
 
 

--- a/src/viur/core/db/utils.py
+++ b/src/viur/core/db/utils.py
@@ -1,4 +1,7 @@
 import datetime
+import logging
+import sys
+
 from deprecated.sphinx import deprecated
 import typing as t
 from .transport import get, put, run_in_transaction, __client__
@@ -18,20 +21,24 @@ def fix_unindexable_properties(entry: Entity) -> Entity:
     """
 
     def has_unindexable_property(prop):
-        if isinstance(prop, dict):
+        if isinstance(prop, dict|Entity):
             return any([has_unindexable_property(x) for x in prop.values()])
         elif isinstance(prop, list):
             return any([has_unindexable_property(x) for x in prop])
         elif isinstance(prop, (str, bytes)):
+            return sys.getsizeof(prop) >= 1500
             return len(prop) >= 1500
         else:
             return False
 
     unindexable_properties = set()
     for key, value in entry.items():
-        if not has_unindexable_property(value):
+        logging.debug(f" fix_unindexable_properties {key=} {value=}")
+        if not (res:=has_unindexable_property(value)):
+            logging.debug(f"  fix_unindexable_properties {key=}  --> {res=}")
             continue
-        if isinstance(value, dict):
+        logging.debug(f"  fix_unindexable_properties {key=}  --> {res=}")
+        if isinstance(value, dict|Entity):
             inner_entity = Entity()
             inner_entity.update(value)
             entry[key] = fix_unindexable_properties(inner_entity)
@@ -39,6 +46,7 @@ def fix_unindexable_properties(entry: Entity) -> Entity:
                 inner_entity.key = value.key
         else:
             unindexable_properties.add(key)
+    logging.debug(f"fix_unindexable_properties {entry.key=} {unindexable_properties=}")
     entry.exclude_from_indexes = unindexable_properties
     return entry
 

--- a/src/viur/core/db/utils.py
+++ b/src/viur/core/db/utils.py
@@ -10,7 +10,7 @@ from .transport import __client__, get, put, run_in_transaction
 from .types import Entity, Key, current_db_access_log
 
 
-def fix_unindexable_properties(entry: Entity, *, keep_exclusions: bool = False) -> Entity:
+def fix_unindexable_properties(entry: Entity, *, keep_exclusions: bool = True) -> Entity:
     """
     Recursively walk the given Entity and add all properties to the list of unindexed properties if they contain
     a string longer than 1500 bytes (which is maximum size of a string that can be indexed). The datastore would


### PR DESCRIPTION
### 1. The length of a non-ASCII-only string says nothing about its size

Example: 
```py
import sys, string

x = (string.hexdigits * 100)[:1500]
print(len(x), sys.getsizeof(x))
# 1500 1521

y = ((string.hexdigits + "äöüèô\u2013") * 100)[:1500]
print(len(y), sys.getsizeof(y))
# 1500 3030
```
Same length, different size (bytes).
See https://python-fiddle.com/saved/a9d60757-a1e4-47a3-9a6d-d93dc781b396

That's why we should use `sys.getsizeof` here.

### 2. Replace vs. update

Why are the properties replaced and not just supplemented? It may have been a conscious decision to exclude properties, but if they are less than 1500 bytes, this method re-indexes the property. I find that strange. I have therefore added the parameter `keep_exclusions`. 
We can **discuss** here whether it should be `True` by default — I would prefer this!