### PR TITLE
fix: add `None` guards to `RecordBone` iteration methods

### DIFF
--- a/src/viur/core/bones/record.py
+++ b/src/viur/core/bones/record.py
@@ -121,6 +121,9 @@ class RecordBone(BaseBone):
                 drop_relations_higher.clear()
                 break
 
+            if value is None:
+                continue
+
             for sub_bone_name, bone in value.items():
                 path = ".".join(name for name in (boneName, lang, f"{idx or 0:02}", sub_bone_name) if name)
                 if utils.string.is_prefix(bone.type, "relational"):
@@ -142,6 +145,9 @@ class RecordBone(BaseBone):
         super().postDeletedHandler(skel, boneName, key)
 
         for idx, lang, value in self.iter_bone_value(skel, boneName):
+            if value is None:
+                continue
+
             for sub_bone_name, bone in value.items():
                 path = ".".join(part for part in (boneName, lang, f"{idx or 0:02}", sub_bone_name) if part)
                 bone.postDeletedHandler(value, path, key)
@@ -235,6 +241,8 @@ class RecordBone(BaseBone):
 
     def refresh(self, skel, bone_name):
         for _, _, using_skel in self.iter_bone_value(skel, bone_name):
+            if using_skel is None:
+                continue
             for key, bone in using_skel.items():
                 bone.refresh(using_skel, key)
 

--- a/tests/bones/test_record_bone.py
+++ b/tests/bones/test_record_bone.py
@@ -1,0 +1,94 @@
+"""Regression tests for RecordBone None-value handling.
+
+When iter_bone_value yields None entries (e.g. from corrupt or partial data),
+postSavedHandler, postDeletedHandler, and refresh must skip them gracefully
+instead of raising ``AttributeError: 'NoneType' object has no attribute 'items'``.
+
+See: https://github.com/viur-framework/viur-core/pull/1652
+"""
+import pytest
+from unittest.mock import MagicMock
+
+
+BONE_NAME = "myRecord"
+
+
+def _make_bone(multiple=True):
+    from viur.core.bones import StringBone
+    from viur.core.bones.record import RecordBone
+    from viur.core.skeleton.relskel import RelSkel
+
+    class _Rel(RelSkel):
+        name = StringBone(descr="Name")
+
+    return RecordBone(using=_Rel, format="$(name)", multiple=multiple)
+
+
+class TestRecordBoneNoneGuard:
+    """RecordBone iteration methods must not crash on None values."""
+
+    # -- Only None values (pure regression) ----------------------------------
+
+    def test_postSavedHandler_skips_none(self):
+        """postSavedHandler must not raise when value list contains None."""
+        bone = _make_bone()
+        skel = {BONE_NAME: [None]}
+        bone.postSavedHandler(skel, BONE_NAME, MagicMock())
+
+    def test_postDeletedHandler_skips_none(self):
+        """postDeletedHandler must not raise when value list contains None."""
+        bone = _make_bone()
+        skel = {BONE_NAME: [None]}
+        bone.postDeletedHandler(skel, BONE_NAME, MagicMock())
+
+    def test_refresh_skips_none(self):
+        """refresh must not raise when value list contains None."""
+        bone = _make_bone()
+        skel = {BONE_NAME: [None]}
+        bone.refresh(skel, BONE_NAME)
+
+    # -- None mixed with valid values ----------------------------------------
+
+    def test_postSavedHandler_skips_none_among_valid(self):
+        """None values are skipped while valid SkeletonInstances are processed."""
+        bone = _make_bone()
+        valid = bone.using()
+        valid.unserialize({"name": "test"})
+        skel = {BONE_NAME: [None, valid, None]}
+        bone.postSavedHandler(skel, BONE_NAME, MagicMock())
+
+    def test_postDeletedHandler_skips_none_among_valid(self):
+        """None values are skipped while valid SkeletonInstances are processed."""
+        bone = _make_bone()
+        valid = bone.using()
+        valid.unserialize({"name": "test"})
+        skel = {BONE_NAME: [None, valid, None]}
+        bone.postDeletedHandler(skel, BONE_NAME, MagicMock())
+
+    def test_refresh_skips_none_among_valid(self):
+        """None values are skipped while valid SkeletonInstances are processed."""
+        bone = _make_bone()
+        valid = bone.using()
+        valid.unserialize({"name": "test"})
+        skel = {BONE_NAME: [None, valid, None]}
+        bone.refresh(skel, BONE_NAME)
+
+    # -- Multiple None values ------------------------------------------------
+
+    def test_postSavedHandler_all_none(self):
+        """An entirely None-filled list must not crash."""
+        bone = _make_bone()
+        skel = {BONE_NAME: [None, None, None]}
+        bone.postSavedHandler(skel, BONE_NAME, MagicMock())
+
+    def test_postDeletedHandler_all_none(self):
+        """An entirely None-filled list must not crash."""
+        bone = _make_bone()
+        skel = {BONE_NAME: [None, None, None]}
+        bone.postDeletedHandler(skel, BONE_NAME, MagicMock())
+
+    def test_refresh_all_none(self):
+        """An entirely None-filled list must not crash."""
+        bone = _make_bone()
+        skel = {BONE_NAME: [None, None, None]}
+        bone.refresh(skel, BONE_NAME)


### PR DESCRIPTION
`postSavedHandler`, `postDeletedHandler` and `refresh` iterate `iter_bone_value()` without checking for `None` values. This crashes with `AttributeError: 'NoneType' object has no attribute 'items'` when a value inside the iteration is `None`.

The `None` guards are consistent with the existing pattern already used in `getSearchTags` and `getReferencedBlobs` which check `if value is None: continue`.

### Changes

- Added `if value is None: continue` to `postSavedHandler`, `postDeletedHandler` and `refresh`

Found during conformance testing with pairwise bone parameter combinations in [viur-testing-dbinterface](https://gitlab.mausbrand.app/mausbrand/mausbrand-bibliotheken/viur-testing-dbinterface/-/tree/feat/bone-combination-generator).