### PR TITLE
fix: enforce `int` type for `TextBone.max_length` parameter

### DIFF
--- a/src/viur/core/bones/text.py
+++ b/src/viur/core/bones/text.py
@@ -329,6 +329,10 @@ class TextBone(RawBone):
         if "maxLength" in kwargs:
             warnings.warn("maxLength parameter is deprecated, please use max_length", DeprecationWarning)
             max_length = kwargs.pop("maxLength")
+
+        if not isinstance(max_length, int):
+            raise TypeError(f"max_length must be an int, got {type(max_length).__name__}")
+
         super().__init__(indexed=indexed, **kwargs)
 
         if validHtml == TextBone.__undefinedC__:


### PR DESCRIPTION
`TextBone.__init__()` now raises `TypeError` if `max_length` is not an `int`.

Previously, passing `max_length=None` was silently accepted despite the type hint being `int`, which would then crash in `isInvalid()` when comparing `len(value) > None` (`TypeError: '>' not supported between instances of 'int' and 'NoneType'`).

Since `TextBone` is designed to always have an upper bound (default `200000`) to prevent unbounded memory consumption from external input, disallowing `None` is the correct fix rather than adding a defensive check in `isInvalid()`.

### Changes

- **`__init__`**: Added `isinstance(max_length, int)` check that raises `TypeError` early at bone definition time
- **`isInvalid`**: Reverted the `None`-guard (no longer needed since `max_length` is guaranteed to be `int`)

Found during conformance testing with pairwise bone parameter combinations in [viur-testing-dbinterface](https://gitlab.mausbrand.app/mausbrand/mausbrand-bibliotheken/viur-testing-dbinterface/-/tree/feat/bone-combination-generator).