### PR TITLE
feat: Implement endpoints for App Login Flow via session cookie                                                                     

### DIFF
--- a/src/viur/core/modules/user.py
+++ b/src/viur/core/modules/user.py
@@ -7,7 +7,11 @@ import hmac
 import json
 import logging
 import secrets
+import time
+import urllib.parse
 import warnings
+from http.cookies import SimpleCookie
+
 import user_agents
 
 import pyotp
@@ -27,6 +31,7 @@ from viur.core.bones.password import PBKDF2_DEFAULT_ITERATIONS, encode_password
 from viur.core.prototypes.list import List
 from viur.core.ratelimit import RateLimit
 from viur.core.securityheaders import extendCsp
+from viur.core.session import Session
 
 
 @functools.total_ordering
@@ -1731,6 +1736,50 @@ class User(List):
                 raise errors.NotImplemented(f"Action {action!r} not implemented")
 
         return self.render.render(f"trigger/{action}Success", skel)
+
+    @exposed
+    @access("admin", "root", "mausbrand")
+    def get_cookie_for_app(self, redirect_to: str = None):
+        if redirect_to:
+            if "?" not in redirect_to:
+                redirect_to = f"{redirect_to}?"
+            raise errors.Redirect(
+                f"{redirect_to}&cookie={urllib.parse.quote_plus(self._get_cookie_for_app())}&app={conf.instance.project_id}"
+            )
+        current.request.get().response.headers["Content-Type"] = "text/plain"
+        return self._get_cookie_for_app()
+
+    def _get_cookie_for_app(self):
+        cookie_key = utils.string.random(42)
+        db_session = db.Entity(db.Key(Session.kindName, cookie_key))
+        data = db.Entity()
+        data["user"] = current.user.get().dbEntity
+        data["is_app_session"] = True
+        db_session["data"] = db.fix_unindexable_properties(data)
+        db_session["static_security_key"] = utils.string.random(42)
+        db_session["lastseen"] = time.time()
+        db_session["user"] = str(current.user.get()["key"])
+        db_session.exclude_from_indexes = {"data"}
+        db.put(db_session)
+
+        # Provide Set-Cookie header entry with configured properties
+        return f"{Session.cookie_name}={cookie_key};{Session.build_flags()}"
+
+    @exposed
+    def apply_login_cookie(self, cookie: str):
+        """
+        Redirect endpoint to load session from the given cookie.
+        """
+        cookies = SimpleCookie()
+        cookies.load(cookie)
+        if Session.cookie_name in cookies:
+            session_cookie = cookies[Session.cookie_name]
+            current.session.get().reset()
+            current.request.get().request.cookies[session_cookie.key] = session_cookie.value
+            current.session.get().load()
+            raise errors.Redirect("/")
+        else:
+            raise errors.BadRequest
 
     def onEdited(self, skel):
         super().onEdited(skel)

--- a/src/viur/core/modules/user.py
+++ b/src/viur/core/modules/user.py
@@ -1738,8 +1738,55 @@ class User(List):
         return self.render.render(f"trigger/{action}Success", skel)
 
     @exposed
-    @access("admin", "root", "mausbrand")
+    @access("admin", "root")
     def get_cookie_for_app(self, redirect_to: str = None):
+        """
+        Generates a session cookie for the currently logged-in user and hands it to an external
+        client (script, native app, or WebView).
+
+        This endpoint is the entry point of a *App Login Flow*.  A privileged user
+        (admin/root) authenticates normally in the browser and then opens this URL.
+        The backend creates a fresh ViUR session (see :meth:`_get_cookie_for_app`) and
+        delivers the resulting ``Set-Cookie`` string to the caller.
+
+        **Typical usage — local Python client / script:**
+
+        The caller spins up a temporary local HTTP server (e.g. on ``http://localhost:60000``)
+        and passes its address as *redirect_to*::
+
+            /vi/user/get_cookie_for_app?redirect_to=http://localhost:60000
+
+        After the user authenticates in the browser, the backend redirects to::
+
+            http://localhost:60000?cookie=<url-encoded Set-Cookie string>&app=<project_id>
+
+        The local server can then extract only the ``name=value`` part of the cookie string
+        (everything before the first ``;``) and use it for subsequent API calls::
+
+            cookie_str = qs["cookie"][0]              # full Set-Cookie value
+            key, value = cookie_str.split(";", 1)[0].split("=")
+            session.cookies.update({key: value})
+
+        The ``app`` query parameter is set by the server to ``conf.instance.project_id`` and
+        lets the client distinguish between multiple backends / cache credentials per project.
+
+        **Alternative — WebView / browser redirect:**
+
+        When the receiving side is a browser or WebView the full ``Set-Cookie`` string can be
+        forwarded to :meth:`apply_login_cookie` to let the framework activate the session.
+
+        :param redirect_to: Optional callback URL.  When provided the caller is redirected to
+            that URL with two query parameters appended automatically:
+
+            - ``cookie`` – URL-encoded ``Set-Cookie`` string (``name=value;flags…``).
+            - ``app`` – the server's GCP project ID (``conf.instance.project_id``).
+
+            A ``?`` is appended if the URL does not already contain one.
+            When omitted, the raw ``Set-Cookie`` string is returned as ``text/plain``
+            (useful for debugging or direct API calls).
+
+        :raises errors.Redirect: Always raised when *redirect_to* is supplied.
+        """
         if redirect_to:
             if "?" not in redirect_to:
                 redirect_to = f"{redirect_to}?"
@@ -1749,7 +1796,28 @@ class User(List):
         current.request.get().response.headers["Content-Type"] = "text/plain"
         return self._get_cookie_for_app()
 
-    def _get_cookie_for_app(self):
+    def _get_cookie_for_app(self) -> str:
+        """
+        Creates a new, standalone ViUR session for the current user and returns the
+        corresponding ``Set-Cookie`` header value.
+
+        Unlike the regular session created during a normal login, this session is intentionally
+        **not** attached to the current HTTP request.  Instead it is persisted directly in
+        Datastore so that a different HTTP client can pick it up via :meth:`apply_login_cookie`.
+
+        The created session entity mirrors the structure of a regular :class:`Session` entry:
+
+        - ``data["user"]``          – the full user ``dbEntity`` (needed by the session loader).
+        - ``data["is_app_session"]``– flag to distinguish app sessions from regular browser sessions.
+        - ``static_security_key``   – random value, same role as in normal sessions.
+        - ``lastseen``              – current timestamp so the session is not immediately garbage-
+          collected.
+        - ``user``                  – stringified user key for server-side user-based queries.
+
+        :returns: A ``Set-Cookie`` header value in the form
+            ``<cookie_name>=<key>;<flags>`` where ``<flags>`` is produced by
+            :meth:`Session.build_flags` (``Path=/; HttpOnly; SameSite=…; Secure; Max-Age=…``).
+        """
         cookie_key = utils.string.random(42)
         db_session = db.Entity(db.Key(Session.kindName, cookie_key))
         data = db.Entity()
@@ -1769,6 +1837,25 @@ class User(List):
     def apply_login_cookie(self, cookie: str):
         """
         Redirect endpoint to load session from the given cookie.
+
+        This is the second half of the *App Login Flow*.  A native app or WebView that received a
+        ``Set-Cookie`` string from :meth:`get_cookie_for_app` (typically via a redirect URL
+        parameter) calls this endpoint to activate the embedded session for its own HTTP context.
+
+        The flow is:
+
+        1. Parse the raw ``Set-Cookie`` string with :class:`http.cookies.SimpleCookie`.
+        2. Look for the expected session cookie name (:attr:`Session.cookie_name`).
+        3. Reset the caller's current (anonymous) session.
+        4. Inject the cookie value into the current request's cookie jar so that
+           :meth:`Session.load` can find the pre-built Datastore session.
+        5. Redirect to ``/`` – from this point on the caller is fully authenticated.
+
+        :param cookie: A raw ``Set-Cookie`` header value as produced by :meth:`_get_cookie_for_app`,
+            e.g. ``viur_cookie_myproject=<key>;Path=/;HttpOnly;…``.
+        :raises errors.Redirect: On success – redirects to ``/``.
+        :raises errors.BadRequest: When the cookie string does not contain a recognisable session
+            cookie (i.e. :attr:`Session.cookie_name` is absent after parsing).
         """
         cookies = SimpleCookie()
         cookies.load(cookie)

--- a/src/viur/core/modules/user.py
+++ b/src/viur/core/modules/user.py
@@ -1791,7 +1791,9 @@ class User(List):
             if "?" not in redirect_to:
                 redirect_to = f"{redirect_to}?"
             raise errors.Redirect(
-                f"{redirect_to}&cookie={urllib.parse.quote_plus(self._get_cookie_for_app())}&app={conf.instance.project_id}"
+                f"{redirect_to}"
+                f"&cookie={urllib.parse.quote_plus(self._get_cookie_for_app())}"
+                f"&app={conf.instance.project_id}"
             )
         current.request.get().response.headers["Content-Type"] = "text/plain"
         return self._get_cookie_for_app()

--- a/src/viur/core/session.py
+++ b/src/viur/core/session.py
@@ -136,6 +136,28 @@ class Session(db.Entity):
 
     @classmethod
     def build_flags(cls) -> str:
+        """
+        Assembles the attribute part of a ``Set-Cookie`` header for ViUR sessions.
+
+        The method was extracted from :meth:`save` so that the same cookie flags can be reused
+        when constructing out-of-band session cookies (e.g. for the App Login Flow in
+        :meth:`~viur.core.modules.user.User._get_cookie_for_app`).
+
+        Flag behaviour:
+
+        - ``Path=/``        – cookie is valid for the whole application.
+        - ``HttpOnly``      – cookie is not accessible via JavaScript (XSS mitigation).
+        - ``SameSite=…``    – only added when :attr:`same_site` is set **and** we are not running
+          on the dev server (the dev server often operates cross-site, so the flag would break
+          local development).
+        - ``Secure``        – only added on non-dev servers (requires HTTPS).
+        - ``Max-Age=…``     – only added when :attr:`use_session_cookie` is ``False``; omitting it
+          turns the cookie into a browser-session cookie that disappears on close.
+
+        :returns: Semicolon-joined flag string ready to be appended to
+            ``<cookie_name>=<value>;`` in a ``Set-Cookie`` header, e.g.
+            ``Path=/;HttpOnly;SameSite=lax;Secure;Max-Age=86400``.
+        """
         flags = (
             "Path=/",
             "HttpOnly",

--- a/src/viur/core/session.py
+++ b/src/viur/core/session.py
@@ -130,17 +130,20 @@ class Session(db.Entity):
         db.put(dbSession)
 
         # Provide Set-Cookie header entry with configured properties
+        current_request.response.headerlist.append(
+            ("Set-Cookie", f"{self.cookie_name}={self.cookie_key};{self.build_flags()}")
+        )
+
+    @classmethod
+    def build_flags(cls) -> str:
         flags = (
             "Path=/",
             "HttpOnly",
-            f"SameSite={self.same_site}" if self.same_site and not conf.instance.is_dev_server else None,
+            f"SameSite={cls.same_site}" if cls.same_site and not conf.instance.is_dev_server else None,
             "Secure" if not conf.instance.is_dev_server else None,
-            f"Max-Age={int(conf.user.session_life_time.total_seconds())}" if not self.use_session_cookie else None,
+            f"Max-Age={int(conf.user.session_life_time.total_seconds())}" if not cls.use_session_cookie else None,
         )
-
-        current_request.response.headerlist.append(
-            ("Set-Cookie", f"{self.cookie_name}={self.cookie_key};{';'.join([f for f in flags if f])}")
-        )
+        return ";".join(flag for flag in flags if flag)
 
     def __setitem__(self, key: str, item: t.Any):
         """


### PR DESCRIPTION
Adds two new endpoints to the User module that allow privileged users to hand off their authenticated session to an external client (e.g. a local Python script or a native app WebView) without exposing credentials.

**get_cookie_for_app (admin/root):**                                                                            
Creates a standalone Datastore session for the current user and returns the Set-Cookie string. With `redirect_to` the browser is redirected to the callback URL with `cookie` (URL-encoded Set-Cookie value) and `app` (project ID) as query parameters. Without `redirect_to` the raw string is returned as text/plain for debugging.                                                                            
                                                                                                                        
**_get_cookie_for_app:**
Internal helper that writes the Datastore session entity directly (not attached to the current request) and returns the Set-Cookie string using the shared Session.build_flags() helper.
                                                                                                                    
**apply_login_cookie:**
Accepts a Set-Cookie string, resets the caller's anonymous session, injects the cookie value into the current request, and calls Session.load() — redirects to / on success.                                                                         
                                                                                                                    
**Session.build_flags() (session.py):**                                                                                   
Extracted from Session.save() so the cookie flags (Path, HttpOnly, SameSite, Secure, Max-Age) can be reused when building out-of-band sessions without an active HTTP response.       