### PR TITLE
refactor: Provide and use `_can_access`-function in vi-render

### DIFF
--- a/src/viur/core/render/vi/__init__.py
+++ b/src/viur/core/render/vi/__init__.py
@@ -107,7 +107,7 @@ def _can_access(user_skel: SkeletonInstance) -> bool:
     Internal check for vi-render if a given user is allowed to use this render.
     The function is used in several places for better integration.
     """
-    return bool(user_skel and "admin" in user_skel["access"])
+    return bool(user_skel and user_skel["access"] and any(flag in user_skel["access"] for flag in ("admin", "root")))
 
 
 def canAccess(*args, **kwargs) -> bool:

--- a/src/viur/core/render/vi/__init__.py
+++ b/src/viur/core/render/vi/__init__.py
@@ -95,20 +95,26 @@ def getVersion(*args, **kwargs):
     while len(version) < 4:
         version += (None,)
 
-    if conf.instance.is_dev_server \
-            or ((cuser := current.user.get()) and ("root" in cuser["access"] or "admin" in cuser["access"])):
+    if conf.instance.is_dev_server or _can_access(current.user.get()):
         return json.dumps(version[:4])
 
     # Hide patch level + appendix to non-authorized users
     return json.dumps((version[0], version[1], None, None))
 
 
+def _can_access(user_skel: SkeletonInstance) -> bool:
+    """
+    Internal check for vi-render if a given user is allowed to use this render.
+    The function is used in several places for better integration.
+    """
+    return bool(user_skel and "admin" in user_skel["access"])
+
+
 def canAccess(*args, **kwargs) -> bool:
     """
     General access restrictions for the vi-render.
     """
-
-    if (cuser := current.user.get()) and any(right in cuser["access"] for right in ("root", "admin")):
+    if _can_access(current.user.get()):
         return True
 
     return any(fnmatch.fnmatch(current.request.get().path, pat) for pat in conf.security.admin_allowed_paths)
@@ -136,15 +142,19 @@ def get_config():
     Get public admin-tool specific settings, requires no user to be logged in.
     This is used by new vi-admin.
     """
-    modules = {}
+    current.request.get().response.headers["Content-Type"] = "application/json"
+
+    result = {}
     config = {k.replace("_", "."): v for k, v in conf.admin.items(True)}
 
     if conf.user.google_client_id:
         config["admin.user.google.clientID"] = conf.user.google_client_id
+
     config["admin.language"] = current.language.get() or conf.i18n.default_language
     config["admin.languages"] = conf.i18n.available_languages
-    if (cuser := current.user.get()) and any(right in cuser["access"] for right in ("root", "admin")):
 
+    if _can_access(current.user.get()):
+        modules = {}
         visited_objects = set()
 
         def collect_modules(parent, depth: int = 0) -> None:
@@ -157,6 +167,7 @@ def get_config():
                 module = getattr(parent, key, None)
                 if not isinstance(module, Module):
                     continue
+
                 if module in visited_objects:
                     # Some modules reference other modules as parents, this will
                     # lead to infinite recursion. We can avoid reaching the
@@ -164,23 +175,22 @@ def get_config():
                     if conf.debug.trace:
                         logging.debug(f"Already visited and added {module=}")
                     continue
+
                 visited_objects.add(module)
 
                 if admin_info := module.describe():
                     # map path --> config
                     modules[module.modulePath.removeprefix("/vi/").replace("/", ".")] = admin_info
+
                 # Collect children
                 collect_modules(module, depth=depth + 1)
 
         collect_modules(conf.main_app.vi)
 
-    fields = {
-        "modules": modules,
-        "configuration": config
-    }
+        result["modules"] = modules
 
-    current.request.get().response.headers["Content-Type"] = "application/json"
-    return json.dumps(fields, cls=CustomJsonEncoder)
+    result["configuration"] = config
+    return json.dumps(result, cls=CustomJsonEncoder)
 
 
 def _postProcessAppObj(obj):


### PR DESCRIPTION
The new function is the only "place of truth" who may access content via the vi-render. It is a wanted change, that there is an explicit check for "admin"-access, rather than "root" or "admin".

This PR is an add-on to #1620.