### PR TITLE
fix: `BaseBone._get_distinct_hash`

### DIFF
--- a/src/viur/core/bones/base.py
+++ b/src/viur/core/bones/base.py
@@ -819,15 +819,16 @@ class BaseBone(object):
         """
         return value
 
-    def _get_destinct_hash(self, value) -> t.Any:
+    def _get_destinct_hash(self, skel: 'SkeletonInstance', name: str) -> t.Any:
         """
         Returns a distinct hash value for this bone.
         The returned value must be hashable.
         """
-        if not isinstance(value, str) and isinstance(value, Iterable):
-            return tuple(self._get_single_destinct_hash(item) for item in value)
+        values = []
+        for _, _, value in self.iter_bone_value(skel, name):
+            values.append(self._get_single_destinct_hash(value))
 
-        return value
+        return tuple(values)
 
     def _validate_multiple_contraints(
         self,
@@ -845,7 +846,7 @@ class BaseBone(object):
         :return: A list of ReadFromClientError objects for each constraint violation.
         """
         res = []
-        value = self._get_destinct_hash(skel[name])
+        value = self._get_destinct_hash(skel, name)
 
         if constraints.min and len(value) < constraints.min:
             res.append(

--- a/src/viur/core/bones/record.py
+++ b/src/viur/core/bones/record.py
@@ -88,7 +88,7 @@ class RecordBone(BaseBone):
         return value.serialize(parentIndexed=False)
 
     def _get_single_destinct_hash(self, value):
-        return tuple(bone._get_destinct_hash(value[name]) for name, bone in self.using.__boneMap__.items())
+        return tuple(bone._get_destinct_hash(value, name) for name, bone in self.using.__boneMap__.items())
 
     def parseSubfieldsFromClient(self) -> bool:
         """

--- a/src/viur/core/bones/relational.py
+++ b/src/viur/core/bones/relational.py
@@ -484,7 +484,7 @@ class RelationalBone(BaseBone):
 
         if self.using:
             for name, bone in self.using.__boneMap__.items():
-                parts.append(bone._get_destinct_hash(value["rel"][name]))
+                parts.append(bone._get_destinct_hash(value["rel"], name))
 
         return tuple(parts)
 


### PR DESCRIPTION
The feature introduced by #1228 didn't work under all circumstances. This version should be much more robust. It changes signatures, but it won't be a problem due current lack of feature use.

In this case, a RecordBone containing a RelationalBone failed with
```
File ".venv/lib/python3.13/site-packages/viur/core/bones/relational.py", line 483, in _get_single_destinct_hash
    parts = [value["dest"]["key"]]
             ~~~~~^^^^^^^^
TypeError: string indices must be integers, not 'str'
```