### PR TITLE
fix: postSavedHandler should ignore `value == None`

### DIFF
--- a/src/viur/core/bones/relational.py
+++ b/src/viur/core/bones/relational.py
@@ -582,7 +582,7 @@ class RelationalBone(BaseBone):
         # Call postSavedHandler on UsingSkel (RelSkel)
         if self.using:
             for idx, lang, value in self.iter_bone_value(skel, boneName):
-                if not value["rel"]:
+                if not value or not value["rel"]:
                     continue
                 for bone_name, bone in value["rel"].items():
                     bone.postSavedHandler(value["rel"], bone_name, key)


### PR DESCRIPTION
related to #1645 and #1637
```py
 Traceback (most recent call last):
  File "/layers/google.python.pip/pip/lib/python3.14/site-packages/viur/core/tasks.py", line 246, in deferred
    _deferred_tasks[funcPath](*args, **kwargs)
    ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/layers/google.python.pip/pip/lib/python3.14/site-packages/viur/core/tasks.py", line 410, in inner_wrapper
    raise exc
  File "/layers/google.python.pip/pip/lib/python3.14/site-packages/viur/core/tasks.py", line 401, in inner_wrapper
    return func(*args, **kwargs)
  File "/workspace/bones/image_migration.py", line 180, in refresh_skel
    skel.write(update_relations=False)
    ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^
  File "/layers/google.python.pip/pip/lib/python3.14/site-packages/viur/core/skeleton/skeleton.py", line 612, in write
    bone.postSavedHandler(skel, bone_name, key)
    ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
  File "/layers/google.python.pip/pip/lib/python3.14/site-packages/viur/core/bones/file.py", line 248, in postSavedHandler
    super().postSavedHandler(skel, boneName, key)
    ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^
  File "/layers/google.python.pip/pip/lib/python3.14/site-packages/viur/core/bones/relational.py", line 585, in postSavedHandler
    if not value["rel"]:
           ~~~~~^^^^^^^
TypeError: 'NoneType' object is not subscriptable
```