### PR TITLE
feat: `utils.get_base_url()` refactors `getHostUrl()`

### DIFF
--- a/src/viur/core/bones/base.py
+++ b/src/viur/core/bones/base.py
@@ -978,7 +978,6 @@ class BaseBone(object):
                 if name not in skel.dbEntity:
                     skel.accessedValues[name] = self._compute(skel, name)
 
-
     def singleValueUnserialize(self, val):
         """
             Unserializes a single value of the bone from the stored database value.

--- a/src/viur/core/render/html/env/viur.py
+++ b/src/viur/core/render/html/env/viur.py
@@ -222,18 +222,14 @@ def getSkel(
 
 
 @jinjaGlobalFunction
-def getHostUrl(render: Render, forceSSL=False, *args, **kwargs):
+def getHostUrl(render: Render, *args, **kwargs) -> str:
     """
     Jinja2 global: Retrieve hostname with protocol.
 
-    :returns: Returns the hostname, including the currently used protocol, e.g: http://www.example.com
+    :returns: Returns the hostname, including the currently used protocol, e.g: https://www.example.com
     :rtype: str
     """
-    url = current.request.get().request.url
-    url = url[:url.find("/", url.find("://") + 5)]
-    if forceSSL and url.startswith("http://"):
-        url = "https://" + url[7:]
-    return url
+    return utils.get_base_url()
 
 
 @jinjaGlobalFunction

--- a/src/viur/core/utils/__init__.py
+++ b/src/viur/core/utils/__init__.py
@@ -103,6 +103,24 @@ def normalizeKey(key: t.Union[None, db.Key]) -> t.Union[None, db.Key]:
     db.normalize_key(key)
 
 
+def get_base_url() -> str:
+    """
+    Retrieve current request's base URL with protocol.
+
+    :returns: Returns the hostname, including the currently used protocol, e.g: https://www.example.com
+    :rtype: str
+    """
+    url = current.request.get().request.url  # retrireve URL by request
+    url = url[:url.find("/", url.find("://") + 5)]  # cut out base-url
+
+    # Always enforce https!
+    if not any(url.startswith(f"http://{i}") for i in ("localhost", "127.0.0.1")):
+        url = "https://" + url[7:]
+
+    # Replace non-SSL-ready-"appspot.com"-URLs with their SSL-ready counterpart
+    return url.replace(f".{conf.instance.project_id}.", f"-dot-{conf.instance.project_id}.")
+
+
 def ensure_iterable(
     obj: t.Any,
     *,


### PR DESCRIPTION
- `utils.get_base_url()` added as new utility function (long-time wanted!)
- Improved behavior for non-SSL-ready appspot.com domains
- `getHostUrl()` refactored, removed obsolete `enforceSSL`-parameter