### PR TITLE
fix: expand refKeys wildcard patterns to actual bone names

### DIFF
--- a/src/viur/core/bones/relational.py
+++ b/src/viur/core/bones/relational.py
@@ -544,7 +544,12 @@ class RelationalBone(BaseBone):
             entity["viur_delayed_update_tag"] = now
             entity["viur_relational_updateLevel"] = self.updateLevel.value
             entity["viur_relational_consistency"] = self.consistency.value
-            entity["viur_foreign_keys"] = list(self.refKeys)
+            # Store expanded bone names, not raw refKeys patterns.
+            # refKeys may contain fnmatch wildcards (e.g. "delivery_time_*" matching
+            # "delivery_time_min", "delivery_time_max", "delivery_time_range").
+            # update_relations filters viur-relations via Datastore IN-query with the
+            # literal changed bone name — wildcard patterns would never match there.
+            entity["viur_foreign_keys"] = list(self._ref_keys)
             entity["viurTags"] = skel.dbEntity.get("viurTags") if skel.dbEntity else None
 
             db.put(entity)
@@ -1066,8 +1071,12 @@ class RelationalBone(BaseBone):
                 # Reset the dbEntity for a clean rewrite
                 value["dest"].dbEntity = None
 
-                # Copy over the refKey values
-                for key in self.refKeys:
+                # Copy over the refKey values using expanded bone names (_ref_keys),
+                # not raw refKeys patterns. refKeys may contain fnmatch wildcards
+                # (e.g. "delivery_time_*" → "delivery_time_min", "delivery_time_max",
+                # "delivery_time_range"). Iterating raw patterns would attempt
+                # target_skel["delivery_time_*"] which doesn't exist → copies None.
+                for key in self._ref_keys:
                     value["dest"][key] = target_skel[key]
                     # logging.debug(f"Refreshed {key=} to {value["dest"][key]!r} ({str(value["dest"][key])!r})")
 


### PR DESCRIPTION
refKeys supports fnmatch wildcards (e.g. "delivery_time_*" to match "delivery_time_min", "delivery_time_max", "delivery_time_range"). These are correctly expanded into _ref_keys via RefSkel.fromSkel() at init time, but two code paths used the raw self.refKeys patterns instead of _ref_keys:

1. postSavedHandler stored the raw patterns as viur_foreign_keys in viur-relations Datastore entities. update_relations filters these via an IN-query with the literal changed bone name — wildcard patterns would never match, so the relational cache of referencing entities was never refreshed after a dest entity changed.

2. refresh() iterated self.refKeys and called target_skel["delivery_time_*"], which doesn't exist as a bone name, copying None into the cache. This made RebuildSearchIndex/Refresh tasks ineffective for any bone covered by a wildcard refKey.

Fix: use self._ref_keys (the already-expanded set of actual bone names) in both locations.