### PR TITLE
fix: hmac_verify returns False for non-ASCII signatures instead of raising TypeError

### DIFF
--- a/src/viur/core/modules/file.py
+++ b/src/viur/core/modules/file.py
@@ -580,7 +580,10 @@ class File(Tree):
 
     @classmethod
     def hmac_verify(cls, data: t.Any, signature: str) -> bool:
-        return hmac.compare_digest(cls.hmac_sign(data.encode("ASCII")), signature)
+        try:
+            return hmac.compare_digest(cls.hmac_sign(data.encode("ASCII")), signature)
+        except (TypeError, UnicodeEncodeError):
+            return False
 
     @classmethod
     def create_internal_serving_url(


### PR DESCRIPTION
### Error
```py
comparing strings with non-ASCII characters is not supported
Traceback (most recent call last):
  File "/layers/google.python.pip/pip/lib/python3.12/site-packages/viur/core/request.py", line 356, in _process
    self._route(path)
  File "/layers/google.python.pip/pip/lib/python3.12/site-packages/viur/core/request.py", line 641, in _route
    res = caller(*self.args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/layers/google.python.pip/pip/lib/python3.12/site-packages/viur/core/module.py", line 238, in __call__
    return self._func(self._instance, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/layers/google.python.pip/pip/lib/python3.12/site-packages/viur/core/modules/file.py", line 1007, in download
    if not self.hmac_verify(blobKey, sig):
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/layers/google.python.pip/pip/lib/python3.12/site-packages/viur/core/modules/file.py", line 545, in hmac_verify
    return hmac.compare_digest(File.hmac_sign(data.encode("ASCII")), signature)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: comparing strings with non-ASCII characters is not supported
```