### PR TITLE
fix: Reject invalid `dest_key` types early in `RelationalBone.singleValueFromClient`

### DIFF
--- a/src/viur/core/bones/relational.py
+++ b/src/viur/core/bones/relational.py
@@ -645,7 +645,7 @@ class RelationalBone(BaseBone):
             dest_key = value
             value = {}
 
-        if not isinstance(dest_key, (str, int, db.Key)):
+        if not isinstance(dest_key, db.KeyType):
             errors.append(ReadFromClientError(ReadFromClientErrorSeverity.Invalid))
             return self.getEmptyValue(), errors
 

--- a/src/viur/core/bones/relational.py
+++ b/src/viur/core/bones/relational.py
@@ -645,6 +645,10 @@ class RelationalBone(BaseBone):
             dest_key = value
             value = {}
 
+        if not isinstance(dest_key, (str, int, db.Key)):
+            errors.append(ReadFromClientError(ReadFromClientErrorSeverity.Invalid))
+            return self.getEmptyValue(), errors
+
         if self.using:
             rel = self.using()
             if not rel.fromClient(value):


### PR DESCRIPTION
Passing a list (or other unsupported type) as a key caused `key_helper` to raise `NotImplementedError` deep in the call stack. Guard against this at the entry point so malformed client data produces a proper validation error instead of a 500.

---

This issue is caused by invalid payload serialization by the vi-admin (refers to this issue https://github.com/viur-framework/vi-admin/issues/27), where the `key` is sent twice (which results into a `list`).

So it's a edge-case, but maybe still helpful.

```py
Unsupported key type <class 'list'>
Traceback (most recent call last):
  File "/layers/google.python.pip/pip/lib/python3.14/site-packages/viur/core/request.py", line 372, in _process
    self._route(path)
    ~~~~~~~~~~~^^^^^^
  File "/layers/google.python.pip/pip/lib/python3.14/site-packages/viur/core/request.py", line 657, in _route
    res = caller(*self.args, **kwargs)
  File "/layers/google.python.pip/pip/lib/python3.14/site-packages/viur/core/module.py", line 245, in __call__
    return self._func(self._instance, *args, **kwargs)
           ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/layers/google.python.pip/pip/lib/python3.14/site-packages/viur/core/prototypes/list.py", line 239, in edit
    or not skel.fromClient(kwargs, amend=True)  # failure on reading into the bones
           ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^
  File "/layers/google.python.pip/pip/lib/python3.14/site-packages/viur/core/skeleton/skeleton.py", line 200, in fromClient
    complete = bool(data) and super().fromClient(skel, data, amend=amend, ignore=ignore)
                              ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/layers/google.python.pip/pip/lib/python3.14/site-packages/viur/core/skeleton/meta.py", line 375, in fromClient
    if errors := bone.fromClient(skel, key, data):
                 ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/layers/google.python.pip/pip/lib/python3.14/site-packages/viur/core/bones/base.py", line 776, in fromClient
    parsedVal, parseErrors = self.singleValueFromClient(singleValue, skel, name, data)
                             ~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/layers/google.python.pip/pip/lib/python3.14/site-packages/viur/core/bones/relational.py", line 658, in singleValueFromClient
    if ret := self.createRelSkelFromKey(dest_key, None):  # ...therefore we need to first give None...
              ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^
  File "/layers/google.python.pip/pip/lib/python3.14/site-packages/viur/core/bones/relational.py", line 1107, in createRelSkelFromKey
    if rel_skel := self.relskels_from_keys([(key, rel)]):
                   ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^
  File "/layers/google.python.pip/pip/lib/python3.14/site-packages/viur/core/bones/relational.py", line 1125, in relskels_from_keys
    if not all(db_objs := db.get([db.key_helper(value[0], self.kind, adjust_kind=True) for value in key_rel_list])):
                                  ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/layers/google.python.pip/pip/lib/python3.14/site-packages/viur/core/db/utils.py", line 115, in key_helper
    raise NotImplementedError(f"Unsupported key type {type(in_key)}")
NotImplementedError: Unsupported key type <class 'list'>
```