### PR TITLE
cicd: upgrade Read the Docs build image to `ubuntu-24.04`

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,7 +7,7 @@ version: 2
 
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-20.04
+  os: ubuntu-24.04
   tools:
     python: "3.13"
 


### PR DESCRIPTION
See https://about.readthedocs.com/blog/2026/03/ubuntu-20-04-deprecated/