### PR TITLE
fix: `RelationalBone._atomic_dump()` raises `KeyError`

### DIFF
--- a/src/viur/core/bones/relational.py
+++ b/src/viur/core/bones/relational.py
@@ -1300,7 +1300,7 @@ class RelationalBone(BaseBone):
         }
 
     def _atomic_dump(self, value: dict[str, "SkeletonInstance"]) -> dict | None:
-        if isinstance(value, dict):
+        if value and isinstance(value, dict):  # can be an empty dict due RelationalConsistency.SetNull
             return {
                 "dest": value["dest"].dump(),
                 "rel": value["rel"].dump() if value["rel"] else None,


### PR DESCRIPTION
This fixes the following KeyError exception sometimes raised when RelationalConsistency.SetNull dropped relations:

```
  File "/layers/google.python.pip/pip/lib/python3.13/site-packages/viur/core/skeleton/instance.py", line 358, in dump
    bone_name: bone.dump(self, bone_name) for bone_name, bone in self.items()
               ~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/layers/google.python.pip/pip/lib/python3.13/site-packages/viur/core/bones/base.py", line 1671, in dump
    ret = [self._atomic_dump(value) for value in bone_value or ()]
           ~~~~~~~~~~~~~~~~~^^^^^^^
  File "/layers/google.python.pip/pip/lib/python3.13/site-packages/viur/core/bones/relational.py", line 1305, in _atomic_dump
    "dest": value["dest"].dump(),
            ~~~~~^^^^^^^^
KeyError: 'dest'
```