### PR TITLE
fix: `utils.get_base_url()` using urllib.parse

### DIFF
--- a/src/viur/core/utils/__init__.py
+++ b/src/viur/core/utils/__init__.py
@@ -106,19 +106,21 @@ def normalizeKey(key: t.Union[None, db.Key]) -> t.Union[None, db.Key]:
 def get_base_url() -> str:
     """
     Retrieve current request's base URL with protocol.
+    The function enforces use of https-protocol on non-localhost hostnames.
 
     :returns: Returns the hostname, including the currently used protocol, e.g: https://www.example.com
     :rtype: str
     """
-    url = current.request.get().request.url  # retrireve URL by request
-    url = url[:url.find("/", url.find("://") + 5)]  # cut out base-url
+    base = urllib.parse.urlparse(current.request.get().request.url).netloc  # retrieve URL of request
 
     # Always enforce https!
-    if not any(url.startswith(f"http://{i}") for i in ("localhost", "127.0.0.1")):
-        url = "https://" + url[7:]
+    if any(base.startswith(i) for i in ("localhost", "127.0.0.1", "[::1]", "0.0.0.0")):
+        base = f"http://{base}"
+    else:
+        base = f"https://{base}"
 
     # Replace non-SSL-ready-"appspot.com"-URLs with their SSL-ready counterpart
-    return url.replace(f".{conf.instance.project_id}.", f"-dot-{conf.instance.project_id}.")
+    return base.replace(f".{conf.instance.project_id}.", f"-dot-{conf.instance.project_id}.")
 
 
 def ensure_iterable(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,5 @@
 from datetime import timedelta as td
+from unittest import mock
 
 from abstract import ViURTestCase
 
@@ -86,3 +87,70 @@ class TestUtils(ViURTestCase):
         self.assertEqual(td(seconds=60), utils.parse.timedelta("60"))
         self.assertEqual(td(seconds=60), utils.parse.timedelta("60.0"))
         self.assertNotEqual(td(seconds=0), utils.parse.timedelta(60.0))
+
+
+def _make_request(url: str):
+    """Return a mock mimicking current.request.get() with .request.url set."""
+    req = mock.Mock()
+    req.request.url = url
+    ctx_var = mock.Mock()
+    ctx_var.get.return_value = req
+    return ctx_var
+
+
+class TestGetBaseUrl(ViURTestCase):
+
+    def _call(self, url: str, project_id: str = "myproject") -> str:
+        from viur.core import utils
+        from viur.core import current
+        from viur.core.config import conf
+
+        with mock.patch.object(current, "request", _make_request(url)), \
+             mock.patch.object(conf.instance, "project_id", project_id):
+            return utils.get_base_url()
+
+    # --- localhost variants → http ---
+
+    def test_localhost_plain(self):
+        self.assertEqual(self._call("http://localhost:8080/foo"), "http://localhost:8080")
+
+    def test_localhost_no_port(self):
+        self.assertEqual(self._call("http://localhost/"), "http://localhost")
+
+    def test_127_0_0_1(self):
+        self.assertEqual(self._call("http://127.0.0.1:8080/bar"), "http://127.0.0.1:8080")
+
+    def test_ipv4_all_interfaces(self):
+        self.assertEqual(self._call("http://0.0.0.0:8080/"), "http://0.0.0.0:8080")
+
+    def test_ipv6_loopback(self):
+        self.assertEqual(self._call("http://[::1]:8080/"), "http://[::1]:8080")
+
+    # --- non-localhost → https ---
+
+    def test_plain_domain(self):
+        self.assertEqual(self._call("http://www.example.com/path"), "https://www.example.com")
+
+    def test_already_https(self):
+        self.assertEqual(self._call("https://www.example.com/path"), "https://www.example.com")
+
+    def test_subdomain(self):
+        self.assertEqual(self._call("https://api.example.com/v1/endpoint"), "https://api.example.com")
+
+    # --- appspot.com dot-replacement ---
+
+    def test_appspot_dot_replaced(self):
+        # .myproject. in hostname → -dot-myproject.
+        result = self._call(
+            "https://default.myproject.appspot.com/",
+            project_id="myproject",
+        )
+        self.assertEqual(result, "https://default-dot-myproject.appspot.com")
+
+    def test_appspot_no_replacement_without_project_id_match(self):
+        # project_id does not appear in the host → no replacement
+        result = self._call(
+            "https://www.example.com/",
+            project_id="myproject",
+        )
+        self.assertEqual(result, "https://www.example.com")


### PR DESCRIPTION
Stop working with indexes and slices. This is a more robust approach. Also fixes the issue that "https:///www.mausbrand.de" was returned.