### PR TITLE
feat: Add `vi/routes`-endpoint

### DIFF
--- a/src/viur/core/render/vi/__init__.py
+++ b/src/viur/core/render/vi/__init__.py
@@ -207,17 +207,40 @@ def settings():
     return json.dumps(json.loads(config())["configuration"])
 
 
+@exposed
+def routes():
+    """
+    Endpoint to retrieve an array of all available routes on this ViUR instance.
+    """
+    current.request.get().response.headers["Content-Type"] = "application/json"
+
+    def resolve(o):
+        result = []
+
+        for key, value in o.items():
+            if isinstance(value, dict):
+                for subresult in resolve(value):
+                    result.append(f"{key}/{subresult}")
+            else:
+                result.append(key)
+
+        return result
+
+    return json.dumps(resolve(conf.main_resolver))
+
+
 def _postProcessAppObj(obj):
     obj["canAccess"] = canAccess
     obj["config"] = config
-    obj["getStructure"] = getStructure
     obj["index"] = index
+    obj["routes"] = routes
     obj["setLanguage"] = setLanguage
     obj["skey"] = json_render_skey
     obj["timestamp"] = timestamp
 
     # DEPRECATED:
-    obj["settings"] = settings  # FIXME: Deprecated; vi-admin 4.x backward compatiblity
+    obj["getStructure"] = getStructure
     obj["getVersion"] = getVersion  # FIXME: Deprecated; vi-admin 4.x backward compatiblity
+    obj["settings"] = settings  # FIXME: Deprecated; vi-admin 4.x backward compatiblity
 
     return obj


### PR DESCRIPTION
This endpoint can be used to retrieve a list of all available exposed endpoints in a ViUR system. Its mandatory for debug purposes and additional security check tools, like the viur-crawler project.

The endpoint can only be used by users who may access the vi-renderer.