### PR TITLE
fix: `BooleanBone` doesn't respect `vfunc/isInvalid`

### DIFF
--- a/src/viur/core/bones/boolean.py
+++ b/src/viur/core/bones/boolean.py
@@ -1,7 +1,7 @@
 import typing as t
 
 from viur.core import conf, db, utils
-from viur.core.bones.base import BaseBone
+from viur.core.bones.base import BaseBone, ReadFromClientError, ReadFromClientErrorSeverity
 
 DEFAULT_VALUE_T: t.TypeAlias = bool | None | list[bool] | dict[str, list[bool] | bool]
 
@@ -36,7 +36,12 @@ class BooleanBone(BaseBone):
             raise ValueError("BooleanBone cannot be multiple")
 
     def singleValueFromClient(self, value, skel, bone_name, client_data):
-        return utils.parse.bool(value, conf.bone_boolean_str2true), None
+        value = utils.parse.bool(value, conf.bone_boolean_str2true)
+
+        if err := self.isInvalid(value):
+            return value, [ReadFromClientError(ReadFromClientErrorSeverity.Invalid, err)]
+
+        return value, None
 
     def getEmptyValue(self):
         """

--- a/src/viur/core/version.py
+++ b/src/viur/core/version.py
@@ -3,7 +3,7 @@
 # This will mark it as a pre-release as well on PyPI.
 # See CONTRIBUTING.md for further information.
 
-__version__ = "3.9.0.dev2"
+__version__ = "3.9.0.dev3"
 
 assert __version__.count(".") >= 2 and "".join(__version__.split(".", 3)[:3]).isdigit(), \
     "Semantic __version__ expected!"


### PR DESCRIPTION
This BaseBone feature was generally not implemented for this kind of bone.