### PR TITLE
fix: `SignatureDoesNotMatch` for filenames containing `+`

### DIFF
--- a/src/viur/core/modules/file.py
+++ b/src/viur/core/modules/file.py
@@ -11,7 +11,7 @@ import string
 import typing as t
 import warnings
 from collections import namedtuple
-from urllib.parse import quote as urlquote, urlencode
+from urllib.parse import quote as urlquote, unquote as urlunquote, urlencode
 from urllib.request import urlopen
 
 import PIL
@@ -1117,7 +1117,7 @@ class File(Tree):
             raise errors.Gone("The requested blob has expired.")
 
         if not filename:
-            filename = download_filename or urlquote(blob.name.rsplit("/", 1)[-1])
+            filename = urlunquote(download_filename) if download_filename else blob.name.rsplit("/", 1)[-1]
 
         content_disposition = utils.build_content_disposition_header(filename, attachment=download)
 

--- a/src/viur/core/utils/__init__.py
+++ b/src/viur/core/utils/__init__.py
@@ -178,7 +178,10 @@ def build_content_disposition_header(
     if attachment and inline:
         raise ValueError("Only one of 'attachment' or 'inline' may be True.")
 
-    fallback = string.normalize_ascii(filename)
+    # Replace '+' with '%2B' in the ASCII fallback: when this header is embedded
+    # as a query parameter in GCS signed URLs, the signing library leaves '+' unencoded
+    # while GCS form-decodes '+' as space during verification → SignatureDoesNotMatch.
+    fallback = string.normalize_ascii(filename).replace("+", "%2B")
     quoted_utf8 = urllib.parse.quote_from_bytes(filename.encode("utf-8"))
 
     content_disposition = "; ".join(


### PR DESCRIPTION
Two issues when downloading files via GCS signed URLs:

1. `create_download_url` stores `download_filename` URL-encoded in the blob key. `File.download()` passed it as-is to `build_content_disposition_header`, which then double-encoded it → broken `Content-Disposition` in the signed URL. Fix: URL-decode `download_filename` (or fall back to the raw blob name) before building the header.

2. The GCS signing library leaves `+` unencoded in the signed URL query params but correctly encodes it as `%2B` in the signing canonical. During verification GCS form-decodes the URL query string, turning `+` into a space, so the verification canonical differs from the signing canonical. Fix: replace `+` → `%2B` in the ASCII `filename=` fallback inside `build_content_disposition_header` so both sides agree.