### PR TITLE
feat: Add QueryOrder and Tests

### DIFF
--- a/src/viur/core/bones/randomslice.py
+++ b/src/viur/core/bones/randomslice.py
@@ -118,7 +118,7 @@ class RandomSliceBone(BaseBone):
                 q = db.QueryDefinition(origKind, {}, [])
                 property, value = applyFilterHook(dbFilter, f"{name} >", rndVal)
                 q.filters[property] = value
-                q.orders = [db.QueryOrder(name, db.SortOrder.Ascending)]
+                q.orders = [db.QueryOrder(name)]
                 queries.append(q)
             dbFilter.queries = queries
             # Map the original filter back in

--- a/src/viur/core/bones/randomslice.py
+++ b/src/viur/core/bones/randomslice.py
@@ -112,13 +112,13 @@ class RandomSliceBone(BaseBone):
                 q = db.QueryDefinition(origKind, {}, [])
                 property, value = applyFilterHook(dbFilter, f"{name} <=", rndVal)
                 q.filters[property] = value
-                q.orders = [(name, db.SortOrder.Descending)]
+                q.orders = [db.QueryOrder(name, db.SortOrder.Descending)]
                 queries.append(q)
                 # Left Side
                 q = db.QueryDefinition(origKind, {}, [])
                 property, value = applyFilterHook(dbFilter, f"{name} >", rndVal)
                 q.filters[property] = value
-                q.orders = [(name, db.SortOrder.Ascending)]
+                q.orders = [db.QueryOrder(name, db.SortOrder.Ascending)]
                 queries.append(q)
             dbFilter.queries = queries
             # Map the original filter back in

--- a/src/viur/core/bones/relational.py
+++ b/src/viur/core/bones/relational.py
@@ -965,7 +965,12 @@ class RelationalBone(BaseBone):
                 raise RuntimeError()
             return f"src.{param}", value
 
-    def orderHook(self, name: str, query: db.Query, orderings):  # FIXME
+    def orderHook(
+        self,
+        name: str,
+        query: db.Query,
+        orderings: list[db.QueryOrder | str] | tuple[db.QueryOrder | str, ...],
+    ) -> list[db.QueryOrder | str] | tuple[db.QueryOrder | str]:
         """
         Hook installed by buildDbFilter that rewrites orderings added to the query to match the layout of the
         viur-relations index and performs sanity checks on the query.
@@ -977,10 +982,8 @@ class RelationalBone(BaseBone):
         :param name: The name of the bone.
         :param query: The datastore query to be modified.
         :param orderings: A list or tuple of orderings to be checked and potentially modified.
-        :type orderings: List[Union[str, db.QueryOrder]] or Tuple[Union[str, db.QueryOrder]]
 
         :return: A list of modified orderings that are compatible with the viur-relations index.
-        :rtype: List[Union[str, db.QueryOrder]]
 
         :raises RuntimeError: If the ordering is invalid, e.g., using properties not in 'refKeys' or 'parentKeys'.
         """

--- a/src/viur/core/bones/relational.py
+++ b/src/viur/core/bones/relational.py
@@ -977,21 +977,25 @@ class RelationalBone(BaseBone):
         :param name: The name of the bone.
         :param query: The datastore query to be modified.
         :param orderings: A list or tuple of orderings to be checked and potentially modified.
-        :type orderings: List[Union[str, Tuple[str, db.SortOrder]]] or Tuple[Union[str, Tuple[str, db.SortOrder]]]
+        :type orderings: List[Union[str, db.QueryOrder]] or Tuple[Union[str, db.QueryOrder]]
 
         :return: A list of modified orderings that are compatible with the viur-relations index.
-        :rtype: List[Union[str, Tuple[str, db.SortOrder]]]
+        :rtype: List[Union[str, db.QueryOrder]]
 
         :raises RuntimeError: If the ordering is invalid, e.g., using properties not in 'refKeys' or 'parentKeys'.
         """
         res = []
-        if not isinstance(orderings, list) and not isinstance(orderings, tuple):
+        if isinstance(orderings, (str, db.QueryOrder)):
             orderings = [orderings]
+        elif not isinstance(orderings, list):
+            orderings = list(orderings)
         for order in orderings:
-            if isinstance(order, tuple):
-                orderKey = order[0]
-            else:
+            if isinstance(order, db.QueryOrder):
+                orderKey = order.name
+            elif isinstance(order, str):
                 orderKey = order
+            else:
+                raise TypeError(f"Invalid ordering {order!r} in orderHook")
             if orderKey.startswith("dest.") or orderKey.startswith("rel.") or orderKey.startswith("src."):
                 # This is already valid for our relational index
                 res.append(order)
@@ -1005,7 +1009,7 @@ class RelationalBone(BaseBone):
                     res.append(order)
                 else:
                     if isinstance(order, tuple):
-                        res.append((f"dest.{k}", order[1]))
+                        res.append(db.QueryOrder(f"dest.{k}", order[1]))
                     else:
                         res.append(f"dest.{k}")
             else:
@@ -1019,7 +1023,7 @@ class RelationalBone(BaseBone):
                             f"Invalid ordering! {orderKey} is not in parentKeys of RelationalBone {name}!")
                         raise RuntimeError()
                     if isinstance(order, tuple):
-                        res.append((f"src.{orderKey}", order[1]))
+                        res.append(db.QueryOrder(f"src.{orderKey}", order[1]))
                     else:
                         res.append(f"src.{orderKey}")
         return res

--- a/src/viur/core/bones/spatial.py
+++ b/src/viur/core/bones/spatial.py
@@ -281,7 +281,7 @@ class SpatialBone(BaseBone):
             q1 = deepcopy(origQuery)
             q1.filters[name + ".coordinates.lat >="] = lat
             q1.filters[name + ".tiles.lat ="] = tileLat
-            q1.orders = [db.QueryOrder(name + ".coordinates.lat", db.SortOrder.Ascending)]
+            q1.orders = [db.QueryOrder(name + ".coordinates.lat")]
             # Lat - Left Side
             q2 = deepcopy(origQuery)
             q2.filters[name + ".coordinates.lat <"] = lat
@@ -291,7 +291,7 @@ class SpatialBone(BaseBone):
             q3 = deepcopy(origQuery)
             q3.filters[name + ".coordinates.lng >="] = lng
             q3.filters[name + ".tiles.lng ="] = tileLng
-            q3.orders = [db.QueryOrder(name + ".coordinates.lng", db.SortOrder.Ascending)]
+            q3.orders = [db.QueryOrder(name + ".coordinates.lng")]
             # Lng - Top
             q4 = deepcopy(origQuery)
             q4.filters[name + ".coordinates.lng <"] = lng

--- a/src/viur/core/bones/spatial.py
+++ b/src/viur/core/bones/spatial.py
@@ -281,22 +281,22 @@ class SpatialBone(BaseBone):
             q1 = deepcopy(origQuery)
             q1.filters[name + ".coordinates.lat >="] = lat
             q1.filters[name + ".tiles.lat ="] = tileLat
-            q1.orders = [(name + ".coordinates.lat", db.SortOrder.Ascending)]
+            q1.orders = [db.QueryOrder(name + ".coordinates.lat", db.SortOrder.Ascending)]
             # Lat - Left Side
             q2 = deepcopy(origQuery)
             q2.filters[name + ".coordinates.lat <"] = lat
             q2.filters[name + ".tiles.lat ="] = tileLat
-            q2.orders = [(name + ".coordinates.lat", db.SortOrder.Descending)]
+            q2.orders = [db.QueryOrder(name + ".coordinates.lat", db.SortOrder.Descending)]
             # Lng - Down
             q3 = deepcopy(origQuery)
             q3.filters[name + ".coordinates.lng >="] = lng
             q3.filters[name + ".tiles.lng ="] = tileLng
-            q3.orders = [(name + ".coordinates.lng", db.SortOrder.Ascending)]
+            q3.orders = [db.QueryOrder(name + ".coordinates.lng", db.SortOrder.Ascending)]
             # Lng - Top
             q4 = deepcopy(origQuery)
             q4.filters[name + ".coordinates.lng <"] = lng
             q4.filters[name + ".tiles.lng ="] = tileLng
-            q4.orders = [(name + ".coordinates.lng", db.SortOrder.Descending)]
+            q4.orders = [db.QueryOrder(name + ".coordinates.lng", db.SortOrder.Descending)]
             dbFilter.queries = [q1, q2, q3, q4]
             dbFilter._customMultiQueryMerge = lambda *args, **kwargs: self.customMultiQueryMerge(name, lat, lng, *args,
                                                                                                  **kwargs)

--- a/src/viur/core/bones/text.py
+++ b/src/viur/core/bones/text.py
@@ -414,7 +414,7 @@ class TextBone(RawBone):
             from viur.core.bones.file import ensureDerived
             for blob_key in blob_keys:
                 file_obj = db.Query("file").filter("dlkey =", blob_key) \
-                    .order(db.QueryOrder("creationdate", db.SortOrder.Ascending)).getEntry()
+                    .order(db.QueryOrder("creationdate")).getEntry()
                 if file_obj:
                     ensureDerived(file_obj.key, f"{skel.kindName}_{name}", derive_dict, skel["key"])
 

--- a/src/viur/core/bones/text.py
+++ b/src/viur/core/bones/text.py
@@ -414,7 +414,7 @@ class TextBone(RawBone):
             from viur.core.bones.file import ensureDerived
             for blob_key in blob_keys:
                 file_obj = db.Query("file").filter("dlkey =", blob_key) \
-                    .order(("creationdate", db.SortOrder.Ascending)).getEntry()
+                    .order(db.QueryOrder("creationdate", db.SortOrder.Ascending)).getEntry()
                 if file_obj:
                     ensureDerived(file_obj.key, f"{skel.kindName}_{name}", derive_dict, skel["key"])
 

--- a/src/viur/core/db/__init__.py
+++ b/src/viur/core/db/__init__.py
@@ -27,6 +27,7 @@ from .types import (
     Key,
     KeyType,
     QueryDefinition,
+    QueryOrder,
     SortOrder,
 )
 from .utils import (
@@ -51,6 +52,7 @@ __all__ = [
     "KEY_SPECIAL_PROPERTY",
     "DATASTORE_BASE_TYPES",
     "SortOrder",
+    "QueryOrder",
     "Entity",
     "QueryDefinition",
     "Key",

--- a/src/viur/core/db/query.py
+++ b/src/viur/core/db/query.py
@@ -13,6 +13,7 @@ from .types import (
     Entity,
     KEY_SPECIAL_PROPERTY,
     QueryDefinition,
+    QueryOrder,
     SortOrder,
     TFilters,
     TOrders,
@@ -282,14 +283,14 @@ class Query(object):
             if op in {"<", "<=", ">", ">="}:
                 if isinstance(self.queries, list):
                     for queryObj in self.queries:
-                        if not queryObj.orders or queryObj.orders[0][0] != field:
-                            queryObj.orders = [(field, SortOrder.Ascending)] + (queryObj.orders or [])
+                        if not queryObj.orders or queryObj.orders[0].name != field:
+                            queryObj.orders = [QueryOrder(field, SortOrder.Ascending)] + (queryObj.orders or [])
                 else:
-                    if not self.queries.orders or self.queries.orders[0][0] != field:
-                        self.queries.orders = [(field, SortOrder.Ascending)] + (self.queries.orders or [])
+                    if not self.queries.orders or self.queries.orders[0].name != field:
+                        self.queries.orders = [QueryOrder(field, SortOrder.Ascending)] + (self.queries.orders or [])
         return self
 
-    def order(self, *orderings: t.Tuple[str, SortOrder]) -> t.Self:
+    def order(self, *orderings: QueryOrder | t.Tuple[str, SortOrder] | str) -> t.Self:
         """
         Specify a query sorting.
 
@@ -301,7 +302,10 @@ class Query(object):
         .. code-block:: python
 
             query = Query("Person")
-            query.order(("bday" db.SortOrder.Ascending), ("age", db.SortOrder.Descending))
+            query.order(
+                db.QueryOrder("bday", db.SortOrder.Ascending),
+                db.QueryOrder("age", db.SortOrder.Descending),
+            )
 
         sorts every Person in order of their birthday, starting with January 1.
         People with the same birthday are sorted by age, oldest to youngest.
@@ -311,7 +315,7 @@ class Query(object):
         from scratch.
 
         If an inequality filter exists in this Query it must be the first property
-        passed to ``order()``. t.Any number of sort orders may be used after the
+        passed to ``order()``. Any number of sort orders may be used after the
         inequality filter property. Without inequality filters, any number of
         filters with different orders may be specified.
 
@@ -328,8 +332,9 @@ class Query(object):
         made to compare property values across types.
 
 
-        :param orderings: The properties to sort by, in sort order.
-            Each argument must be a (name, direction) 2-tuple.
+        :param orderings: The properties to sort by, in sort order. Each argument may be a
+            :class:`QueryOrder`, a ``(name, direction)`` tuple, or a plain ``str`` (implies
+            ``SortOrder.Ascending``).
         :returns: Returns the query itself for chaining.
         """
         if self.queries is None:
@@ -340,12 +345,20 @@ class Query(object):
         orders = []
         for order in orderings:
             if isinstance(order, str):
-                order = (order, SortOrder.Ascending)
-
-            if not (isinstance(order[0], str) and isinstance(order[1], SortOrder)):
+                order = QueryOrder(order, SortOrder.Ascending)
+            elif isinstance(order, QueryOrder):
+                pass
+            elif (
+                isinstance(order, (tuple, list)) and
+                len(order) == 2 and
+                isinstance(order[0], str) and isinstance(order[1], SortOrder)
+            ):
+                order = QueryOrder(order[0], order[1])
+            else:
                 raise TypeError(
-                    f"Invalid ordering {order}, it has to be a tuple. Try: `(\"{order}\", SortOrder.Ascending)`")
-
+                    f"Invalid ordering {order!r}, expected a (str, SortOrder) tuple or QueryOrder."
+                    f' Try: `QueryOrder("{order}", SortOrder.Ascending)`'
+                )
             orders.append(order)
 
         if self._orderHook is not None:
@@ -445,7 +458,7 @@ class Query(object):
                 q = self.queries[0]
         return base64.urlsafe_b64encode(q.currentCursor).decode("ASCII") if q.currentCursor else None
 
-    def get_orders(self) -> t.List[t.Tuple[str, SortOrder]] | None:
+    def get_orders(self) -> t.List[QueryOrder] | None:
         """
         Get the orders from this query.
 
@@ -502,10 +515,10 @@ class Query(object):
         return self._resort_result(res, {}, self.queries[0].orders)
 
     def _resort_result(
-            self,
-            entities: t.List[Entity],
-            filters: t.Dict[str, DATASTORE_BASE_TYPES],
-            orders: t.List[t.Tuple[str, SortOrder]],
+        self,
+        entities: t.List[Entity],
+        filters: t.Dict[str, DATASTORE_BASE_TYPES],
+        orders: t.List[QueryOrder],
     ) -> t.List[Entity]:
         """
         Internal helper that takes a (deduplicated) list of entities that has been fetched from different internal
@@ -550,8 +563,8 @@ class Query(object):
             if "<" in end or ">" in end:
                 ineqFilter = k.split(" ")[0]
                 break
-        if ineqFilter and (not orders or not orders[0][0] == ineqFilter):
-            orders = [(ineqFilter, SortOrder.Ascending)] + (orders or [])
+        if ineqFilter and (not orders or not orders[0].name == ineqFilter):
+            orders = [QueryOrder(ineqFilter, SortOrder.Ascending)] + (orders or [])
 
         for orderField, direction in orders[::-1]:
             if orderField == KEY_SPECIAL_PROPERTY:
@@ -572,10 +585,10 @@ class Query(object):
         """
         resultList = list(resultList)
         if (
-                resultList
-                and resultList[0].key.kind != self.origKind
-                and resultList[0].key.parent
-                and resultList[0].key.parent.kind == self.origKind
+            resultList
+            and resultList[0].key.kind != self.origKind
+            and resultList[0].key.parent
+            and resultList[0].key.parent.kind == self.origKind
         ):
             return list(get(list(dict.fromkeys([x.key.parent for x in resultList]))))
 

--- a/src/viur/core/db/query.py
+++ b/src/viur/core/db/query.py
@@ -284,10 +284,10 @@ class Query(object):
                 if isinstance(self.queries, list):
                     for queryObj in self.queries:
                         if not queryObj.orders or queryObj.orders[0].name != field:
-                            queryObj.orders = [QueryOrder(field, SortOrder.Ascending)] + (queryObj.orders or [])
+                            queryObj.orders = [QueryOrder(field)] + (queryObj.orders or [])
                 else:
                     if not self.queries.orders or self.queries.orders[0].name != field:
-                        self.queries.orders = [QueryOrder(field, SortOrder.Ascending)] + (self.queries.orders or [])
+                        self.queries.orders = [QueryOrder(field)] + (self.queries.orders or [])
         return self
 
     def order(self, *orderings: QueryOrder | t.Tuple[str, SortOrder] | str) -> t.Self:
@@ -303,7 +303,7 @@ class Query(object):
 
             query = Query("Person")
             query.order(
-                db.QueryOrder("bday", db.SortOrder.Ascending),
+                db.QueryOrder("bday"),
                 db.QueryOrder("age", db.SortOrder.Descending),
             )
 
@@ -345,7 +345,7 @@ class Query(object):
         orders = []
         for order in orderings:
             if isinstance(order, str):
-                order = QueryOrder(order, SortOrder.Ascending)
+                order = QueryOrder(order)
             elif isinstance(order, QueryOrder):
                 pass
             elif (
@@ -357,7 +357,7 @@ class Query(object):
             else:
                 raise TypeError(
                     f"Invalid ordering {order!r}, expected a (str, SortOrder) tuple or QueryOrder."
-                    f' Try: `QueryOrder("{order}", SortOrder.Ascending)`'
+                    f' Try: `QueryOrder("{order}")`'
                 )
             orders.append(order)
 
@@ -564,7 +564,7 @@ class Query(object):
                 ineqFilter = k.split(" ")[0]
                 break
         if ineqFilter and (not orders or not orders[0].name == ineqFilter):
-            orders = [QueryOrder(ineqFilter, SortOrder.Ascending)] + (orders or [])
+            orders = [QueryOrder(ineqFilter)] + (orders or [])
 
         for orderField, direction in orders[::-1]:
             if orderField == KEY_SPECIAL_PROPERTY:

--- a/src/viur/core/db/transport.py
+++ b/src/viur/core/db/transport.py
@@ -207,13 +207,11 @@ def run_single_filter(query: QueryDefinition, limit: int, keys_only: bool) -> t.
 
         if query.orders:
             hasInvertedOrderings = any(
-                [
-                    x[1] in [SortOrder.InvertedAscending, SortOrder.InvertedDescending]
-                    for x in query.orders
-                ]
+                x.order in (SortOrder.InvertedAscending, SortOrder.InvertedDescending)
+                for x in query.orders
             )
             qry.order = [
-                x[0] if x[1] in [SortOrder.Ascending, SortOrder.InvertedDescending] else f"-{x[0]}"
+                x.name if x.order in (SortOrder.Ascending, SortOrder.InvertedDescending) else f"-{x.name}"
                 for x in query.orders
             ]
 

--- a/src/viur/core/db/transport.py
+++ b/src/viur/core/db/transport.py
@@ -207,12 +207,12 @@ def run_single_filter(query: QueryDefinition, limit: int, keys_only: bool) -> t.
 
         if query.orders:
             hasInvertedOrderings = any(
-                x.order in (SortOrder.InvertedAscending, SortOrder.InvertedDescending)
-                for x in query.orders
+                order.order in (SortOrder.InvertedAscending, SortOrder.InvertedDescending)
+                for order in query.orders
             )
             qry.order = [
-                x.name if x.order in (SortOrder.Ascending, SortOrder.InvertedDescending) else f"-{x.name}"
-                for x in query.orders
+                order.name if order.order in (SortOrder.Ascending, SortOrder.InvertedDescending) else f"-{order.name}"
+for order in query.orders
             ]
 
         if query.distinct:

--- a/src/viur/core/db/transport.py
+++ b/src/viur/core/db/transport.py
@@ -212,7 +212,7 @@ def run_single_filter(query: QueryDefinition, limit: int, keys_only: bool) -> t.
             )
             qry.order = [
                 order.name if order.order in (SortOrder.Ascending, SortOrder.InvertedDescending) else f"-{order.name}"
-for order in query.orders
+                for order in query.orders
             ]
 
         if query.distinct:

--- a/src/viur/core/db/types.py
+++ b/src/viur/core/db/types.py
@@ -39,7 +39,7 @@ class SortOrder(enum.Enum):
 class QueryOrder(t.NamedTuple):
     """A named tuple describing a single sort order for a datastore query."""
     name: str
-    order: SortOrder
+    order: SortOrder = SortOrder.Ascending
 
 
 class Key(Datastore_key):

--- a/src/viur/core/db/types.py
+++ b/src/viur/core/db/types.py
@@ -36,6 +36,12 @@ class SortOrder(enum.Enum):
     """Fetch A->Z, then flip the results (useful in pagination)"""
 
 
+class QueryOrder(t.NamedTuple):
+    """A named tuple describing a single sort order for a datastore query."""
+    name: str
+    order: SortOrder
+
+
 class Key(Datastore_key):
     """
         The python representation of one datastore key. Unlike the original implementation, we don't store a
@@ -165,7 +171,7 @@ KeyType: t.TypeAlias = Key | str | int
 Alias that describes a key-type.
 """
 
-TOrders: t.TypeAlias = list[tuple[str, SortOrder]]
+TOrders: t.TypeAlias = list[QueryOrder]
 TFilters: t.TypeAlias = dict[str, DATASTORE_BASE_TYPES | list[DATASTORE_BASE_TYPES]]
 
 

--- a/src/viur/core/modules/file.py
+++ b/src/viur/core/modules/file.py
@@ -749,7 +749,7 @@ class File(Tree):
 
         if isinstance(file, str):
             file = db.Query("file").filter("dlkey =", file).order(
-                db.QueryOrder("creationdate", db.SortOrder.Ascending)).getEntry()
+                db.QueryOrder("creationdate")).getEntry()
 
         if not file:
             return ""

--- a/src/viur/core/modules/file.py
+++ b/src/viur/core/modules/file.py
@@ -748,7 +748,8 @@ class File(Tree):
             return ""
 
         if isinstance(file, str):
-            file = db.Query("file").filter("dlkey =", file).order(db.QueryOrder("creationdate", db.SortOrder.Ascending)).getEntry()
+            file = db.Query("file").filter("dlkey =", file).order(
+                db.QueryOrder("creationdate", db.SortOrder.Ascending)).getEntry()
 
         if not file:
             return ""

--- a/src/viur/core/modules/file.py
+++ b/src/viur/core/modules/file.py
@@ -748,7 +748,7 @@ class File(Tree):
             return ""
 
         if isinstance(file, str):
-            file = db.Query("file").filter("dlkey =", file).order(("creationdate", db.SortOrder.Ascending)).getEntry()
+            file = db.Query("file").filter("dlkey =", file).order(db.QueryOrder("creationdate", db.SortOrder.Ascending)).getEntry()
 
         if not file:
             return ""

--- a/src/viur/core/prototypes/skelmodule.py
+++ b/src/viur/core/prototypes/skelmodule.py
@@ -8,7 +8,7 @@ from viur.core.skeleton import skeletonByKind, Skeleton, SkeletonInstance
 import typing as t
 
 
-SINGLE_ORDER_TYPE = str | tuple[str, db.SortOrder]
+SINGLE_ORDER_TYPE = str | db.QueryOrder | tuple[str, db.SortOrder]
 """
 Type for exactly one sort order definitions.
 """
@@ -190,16 +190,9 @@ class SkelModule(Module):
             elif default_order:
                 logging.debug(f"Applying {default_order=}")
 
-                # FIXME: This ugly test can be removed when there is type that abstracts SortOrders
-                if (
-                    isinstance(default_order, str)
-                    or (
-                        isinstance(default_order, tuple)
-                        and len(default_order) == 2
-                        and isinstance(default_order[0], str)
-                        and isinstance(default_order[1], db.SortOrder)
-                    )
-                ):
+                if isinstance(default_order, (str, db.QueryOrder)):
+                    query.order(default_order)
+                elif isinstance(default_order, tuple) and len(default_order) == 2 and isinstance(default_order[0], str) and isinstance(default_order[1], db.SortOrder):
                     query.order(default_order)
                 else:
                     query.order(*default_order)

--- a/src/viur/core/prototypes/skelmodule.py
+++ b/src/viur/core/prototypes/skelmodule.py
@@ -193,7 +193,7 @@ class SkelModule(Module):
                 if isinstance(default_order, (str, db.QueryOrder)):
                     query.order(default_order)
                 elif (
-                    isinstance(default_order, (tuple,list)) and
+                    isinstance(default_order, (tuple, list)) and
                     len(default_order) == 2 and
                     isinstance(default_order[0], str) and
                     isinstance(default_order[1], db.SortOrder)

--- a/src/viur/core/prototypes/skelmodule.py
+++ b/src/viur/core/prototypes/skelmodule.py
@@ -192,7 +192,12 @@ class SkelModule(Module):
 
                 if isinstance(default_order, (str, db.QueryOrder)):
                     query.order(default_order)
-                elif isinstance(default_order, tuple) and len(default_order) == 2 and isinstance(default_order[0], str) and isinstance(default_order[1], db.SortOrder):
+                elif (
+                    isinstance(default_order, (tuple,list)) and
+                    len(default_order) == 2 and
+                    isinstance(default_order[0], str) and
+                    isinstance(default_order[1], db.SortOrder)
+                ):
                     query.order(default_order)
                 else:
                     query.order(*default_order)

--- a/src/viur/core/tasks.py
+++ b/src/viur/core/tasks.py
@@ -808,7 +808,7 @@ class QueryIter(object, metaclass=MetaQueryIter):
         qry = db.Query(qryDict["kind"])
         qry.srcSkel = skeletonByKind(qryDict["srcSkel"])() if qryDict["srcSkel"] else None
         qry.queries.filters = qryDict["filters"]
-        qry.queries.orders = [(propName, db.SortOrder(sortOrder)) for propName, sortOrder in qryDict["orders"]]
+        qry.queries.orders = [db.QueryOrder(propName, db.SortOrder(sortOrder)) for propName, sortOrder in qryDict["orders"]]
         qry.setCursor(qryDict["startCursor"], qryDict["endCursor"])
         qry.origKind = qryDict["origKind"]
         qry.queries.distinct = qryDict["distinct"]

--- a/src/viur/core/tasks.py
+++ b/src/viur/core/tasks.py
@@ -808,8 +808,7 @@ class QueryIter(object, metaclass=MetaQueryIter):
         qry = db.Query(qryDict["kind"])
         qry.srcSkel = skeletonByKind(qryDict["srcSkel"])() if qryDict["srcSkel"] else None
         qry.queries.filters = qryDict["filters"]
-        qry.queries.orders = [db.QueryOrder(propName, db.SortOrder(sortOrder)) for propName, sortOrder in
-                              qryDict["orders"]]
+        qry.queries.orders = [db.QueryOrder(name, db.SortOrder(order)) for name, order in qryDict["orders"]]
         qry.setCursor(qryDict["startCursor"], qryDict["endCursor"])
         qry.origKind = qryDict["origKind"]
         qry.queries.distinct = qryDict["distinct"]

--- a/src/viur/core/tasks.py
+++ b/src/viur/core/tasks.py
@@ -808,7 +808,8 @@ class QueryIter(object, metaclass=MetaQueryIter):
         qry = db.Query(qryDict["kind"])
         qry.srcSkel = skeletonByKind(qryDict["srcSkel"])() if qryDict["srcSkel"] else None
         qry.queries.filters = qryDict["filters"]
-        qry.queries.orders = [db.QueryOrder(propName, db.SortOrder(sortOrder)) for propName, sortOrder in qryDict["orders"]]
+        qry.queries.orders = [db.QueryOrder(propName, db.SortOrder(sortOrder)) for propName, sortOrder in
+                              qryDict["orders"]]
         qry.setCursor(qryDict["startCursor"], qryDict["endCursor"])
         qry.origKind = qryDict["origKind"]
         qry.queries.distinct = qryDict["distinct"]

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -32,10 +32,14 @@ class TestDb(ViURTestCase):
 class TestQueryOrder(ViURTestCase):
     def test_queryorder_is_namedtuple(self) -> None:
         from viur.core import db
-        qo = db.QueryOrder("name", db.SortOrder.Ascending)
+        qo = db.QueryOrder("name")
         self.assertIsInstance(qo, tuple)
         self.assertEqual(qo.name, "name")
-        self.assertEqual(qo.order, db.SortOrder.Ascending)
+        self.assertEqual(qo.order, db.SortOrder.Ascending)  # default
+
+    def test_queryorder_default_is_ascending(self) -> None:
+        from viur.core import db
+        self.assertEqual(db.QueryOrder("x").order, db.SortOrder.Ascending)
 
     def test_queryorder_tuple_compat(self) -> None:
         from viur.core import db

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -27,3 +27,51 @@ class TestDb(ViURTestCase):
         key = db.Key("viur", "bar", parent=parent_key)
         self.assertEqual(key.name, "bar")
         self.assertEqual(key.parent, parent_key)
+
+
+class TestQueryOrder(ViURTestCase):
+    def test_queryorder_is_namedtuple(self) -> None:
+        from viur.core import db
+        qo = db.QueryOrder("name", db.SortOrder.Ascending)
+        self.assertIsInstance(qo, tuple)
+        self.assertEqual(qo.name, "name")
+        self.assertEqual(qo.order, db.SortOrder.Ascending)
+
+    def test_queryorder_tuple_compat(self) -> None:
+        from viur.core import db
+        qo = db.QueryOrder("age", db.SortOrder.Descending)
+        # Index-Zugriff
+        self.assertEqual(qo[0], "age")
+        self.assertEqual(qo[1], db.SortOrder.Descending)
+        # Tuple-Unpacking
+        name, direction = qo
+        self.assertEqual(name, "age")
+        self.assertEqual(direction, db.SortOrder.Descending)
+
+    def test_query_order_method_returns_queryorder(self) -> None:
+        from viur.core import db
+        q = db.Query("TestKind")
+        q.order(("name", db.SortOrder.Ascending))
+        orders = q.get_orders()
+        self.assertIsNotNone(orders)
+        self.assertIsInstance(orders[0], db.QueryOrder)
+        self.assertEqual(orders[0].name, "name")
+        self.assertEqual(orders[0].order, db.SortOrder.Ascending)
+
+    def test_query_order_string_shortcut(self) -> None:
+        from viur.core import db
+        q = db.Query("TestKind")
+        q.order("name")
+        orders = q.get_orders()
+        self.assertIsNotNone(orders)
+        self.assertIsInstance(orders[0], db.QueryOrder)
+        self.assertEqual(orders[0].name, "name")
+        self.assertEqual(orders[0].order, db.SortOrder.Ascending)
+
+    def test_query_order_plain_tuple_compat(self) -> None:
+        from viur.core import db
+        q = db.Query("TestKind")
+        q.order(("age", db.SortOrder.Descending))
+        orders = q.get_orders()
+        self.assertIsNotNone(orders)
+        self.assertIsInstance(orders[0], db.QueryOrder)


### PR DESCRIPTION
Replace anonymous order tuples with QueryOrder NamedTuple
  
  Introduces `db.QueryOrder(name, order)` as the canonical type for sort
  orders, replacing the untyped `tuple[str, SortOrder]`. Plain tuples are
  still accepted in `Query.order()` and converted automatically.