### PR TITLE
feat: Replace client-side MultiQuery with native Datastore operators

### DIFF
--- a/src/viur/core/db/query.py
+++ b/src/viur/core/db/query.py
@@ -16,6 +16,7 @@ from .types import (
     SortOrder,
     TFilters,
     TOrders,
+    TOrFilters,
     Key
 )
 from . import utils
@@ -29,7 +30,11 @@ TFilterHook = t.TypeVar("TFilterHook", bound=t.Callable[
 ])
 
 
-def _entryMatchesQuery(entry: Entity, singleFilter: dict) -> bool:
+def _entryMatchesQuery(
+    entry: Entity,
+    singleFilter: dict,
+    or_filters: TOrFilters | None = None,
+) -> bool:
     """
     Utility function which checks if the given entity could have been returned by a query filtering by the
     properties in singleFilter. This can be used if a list of entities have been retrieved (e.g. by a 3rd party
@@ -37,6 +42,7 @@ def _entryMatchesQuery(entry: Entity, singleFilter: dict) -> bool:
     :meth:`viur.core.prototypes.list.listFilter` method.
     :param entry: The entity which will be tested
     :param singleFilter: A dictionary containing all the filters from the query
+    :param or_filters: Optional list of OR groups; each group is a list of (filterStr, value) pairs
     :return: True if the entity could have been returned by such an query, False otherwise
     """
 
@@ -53,6 +59,13 @@ def _entryMatchesQuery(entry: Entity, singleFilter: dict) -> bool:
             return True
         elif opcode == ">=" and entryValue >= requestedValue:
             return True
+        elif opcode == "IN" and entryValue in requestedValue:
+            return True
+        elif opcode == "NOT_IN" and entryValue not in requestedValue:
+            return True
+        # any()-semantics for multi-value properties: list dispatch above handles iteration
+        elif opcode == "!=" and entryValue != requestedValue:
+            return True
         return False
 
     for filterStr, filterValue in singleFilter.items():
@@ -60,6 +73,15 @@ def _entryMatchesQuery(entry: Entity, singleFilter: dict) -> bool:
         entryValue = entry.get(field)
         if not doesMatch(entryValue, filterValue, opcode):
             return False
+
+    if or_filters:
+        for or_group in or_filters:
+            if not any(
+                doesMatch(entry.get(fs.split(" ", 1)[0]), v, fs.split(" ", 1)[1])
+                for fs, v in or_group
+            ):
+                return False
+
     return True
 
 
@@ -238,55 +260,82 @@ class Query(object):
                 return self
             prop, value = r
         if " " not in prop:
-            # Ensure that an equality filter is explicitly postfixed with " ="
             field = prop
             op = "="
         else:
             field, op = prop.split(" ")
-        if op.lower() in {"!=", "in"}:
-            if isinstance(self.queries, list):
-                raise NotImplementedError("You cannot use multiple IN or != filter")
-            origQuery = self.queries
-            self.queries = []
-            if op == "!=":
-                newFilter = copy.deepcopy(origQuery)
-                newFilter.filters[f"{field} <"] = value
-                self.queries.append(newFilter)
-                newFilter = copy.deepcopy(origQuery)
-                newFilter.filters[f"{field} >"] = value
-                self.queries.append(newFilter)
-            else:  # IN filter
-                if not isinstance(value, (list, tuple)):
-                    raise ValueError("Value must be list or tuple if using IN filter!")
-                for val in value:
-                    newFilter = copy.deepcopy(origQuery)
-                    newFilter.filters[f"{field} ="] = val
-                    self.queries.append(newFilter)
+
+        # Normalize to uppercase for native Datastore operators passed as lowercase
+        op = op.upper() if op.lower() in {"in", "!=", "not_in"} else op
+
+        if op in {"IN", "!=", "NOT_IN"} and not isinstance(self.queries, list):
+            if f"{field} {op}" in self.queries.filters:
+                raise ValueError(f"Cannot use multiple {op} filters on the same field '{field}'")
+
+        filterStr = f"{field} {op}"
+        if isinstance(self.queries, list):
+            for singleFilter in self.queries:
+                if filterStr not in singleFilter.filters:
+                    singleFilter.filters[filterStr] = value
+                else:
+                    if not isinstance(singleFilter.filters[filterStr], list):
+                        singleFilter.filters[filterStr] = [singleFilter.filters[filterStr]]
+                    singleFilter.filters[filterStr].append(value)
         else:
-            filterStr = f"{field} {op}"
+            if filterStr not in self.queries.filters:
+                self.queries.filters[filterStr] = value
+            else:
+                if not isinstance(self.queries.filters[filterStr], list):
+                    self.queries.filters[filterStr] = [self.queries.filters[filterStr]]
+                self.queries.filters[filterStr].append(value)
+
+        if op in {"<", "<=", ">", ">="}:
             if isinstance(self.queries, list):
-                for singeFilter in self.queries:
-                    if filterStr not in singeFilter.filters:
-                        singeFilter.filters[filterStr] = value
-                    else:
-                        if not isinstance(singeFilter.filters[filterStr]):
-                            singeFilter.filters[filterStr] = [singeFilter.filters[filterStr]]
-                        singeFilter.filters[filterStr].append(value)
-            else:  # It must be still a dict (we tested for None already above)
-                if filterStr not in self.queries.filters:
-                    self.queries.filters[filterStr] = value
-                else:
-                    if not isinstance(self.queries.filters[filterStr], list):
-                        self.queries.filters[filterStr] = [self.queries.filters[filterStr]]
-                    self.queries.filters[filterStr].append(value)
-            if op in {"<", "<=", ">", ">="}:
-                if isinstance(self.queries, list):
-                    for queryObj in self.queries:
-                        if not queryObj.orders or queryObj.orders[0][0] != field:
-                            queryObj.orders = [(field, SortOrder.Ascending)] + (queryObj.orders or [])
-                else:
-                    if not self.queries.orders or self.queries.orders[0][0] != field:
-                        self.queries.orders = [(field, SortOrder.Ascending)] + (self.queries.orders or [])
+                for queryObj in self.queries:
+                    if not queryObj.orders or queryObj.orders[0][0] != field:
+                        queryObj.orders = [(field, SortOrder.Ascending)] + (queryObj.orders or [])
+            else:
+                if not self.queries.orders or self.queries.orders[0][0] != field:
+                    self.queries.orders = [(field, SortOrder.Ascending)] + (self.queries.orders or [])
+        return self
+
+    def or_filter(self, *conditions: tuple[str, DATASTORE_BASE_TYPES]) -> t.Self:
+        """
+        Add an OR composite filter group.
+
+        Each call appends one OR group; multiple calls produce multiple groups
+        that are AND-ed together with each other and with any regular filters.
+
+        Example — continent is Africa OR Asia::
+
+            q.or_filter(("continent =", "Africa"), ("continent =", "Asia"))
+
+        Example — two independent OR groups (both must match)::
+
+            q.or_filter(("continent =", "Africa"), ("continent =", "Asia"))
+            q.or_filter(("sortindex >", 200), ("sortindex <", 50))
+
+        :param conditions: One or more ``("field op", value)`` pairs to OR together.
+        :returns: Returns the query itself for chaining.
+        """
+        if self.queries is None:
+            return self
+
+        parsed = []
+        for prop, value in conditions:
+            if " " not in prop:
+                field, op = prop, "="
+            else:
+                field, op = prop.split(" ", 1)
+            op = op.upper() if op.lower() in {"in", "!=", "not_in"} else op
+            parsed.append((f"{field} {op}", value))
+
+        if isinstance(self.queries, list):
+            for q in self.queries:
+                q.or_filters.append(parsed)
+        else:
+            self.queries.or_filters.append(parsed)
+
         return self
 
     def order(self, *orderings: t.Tuple[str, SortOrder]) -> t.Self:
@@ -509,8 +558,8 @@ class Query(object):
     ) -> t.List[Entity]:
         """
         Internal helper that takes a (deduplicated) list of entities that has been fetched from different internal
-        queries (the datastore does not support IN filters itself, so we have to query each item in that array
-        separately) and resorts the list so it matches the query again.
+        queries (e.g. from SpatialBone or RandomSliceBone custom multi-queries) and resorts the list so it matches
+        the query again. Regular IN/!= filters no longer use this path — they are handled natively by the Datastore.
 
         :param entities: t.List of entities to resort
         :param filters: The filter used in the query (used to determine implicit sort order by an inequality filter)
@@ -597,8 +646,6 @@ class Query(object):
 
         :raises: :exc:`BadFilterError` if a filter string is invalid
         :raises: :exc:`BadValueError` if a filter value is invalid.
-        :raises: :exc:`BadQueryError` if an IN filter in combination with a sort order on\
-        another property is provided
         """
         if self.queries is None:
             if conf.debug.trace_queries:
@@ -617,9 +664,9 @@ class Query(object):
             if not self.srcSkel.customDatabaseAdapter.fulltextSearchGuaranteesQueryConstrains:
                 # Search might yield results that are not included in the listfilter
                 if isinstance(self.queries, QueryDefinition):  # Just one
-                    res = [x for x in res if _entryMatchesQuery(x, self.queries.filters)]
+                    res = [x for x in res if _entryMatchesQuery(x, self.queries.filters, self.queries.or_filters)]
                 else:  # Multi-Query, must match at least one
-                    res = [x for x in res if any([_entryMatchesQuery(x, y.filters) for y in self.queries])]
+                    res = [x for x in res if any([_entryMatchesQuery(x, y.filters, y.or_filters) for y in self.queries])]
 
         elif isinstance(self.queries, list):
             limit = limit if limit >= 0 else self.queries[0].limit
@@ -693,8 +740,6 @@ class Query(object):
 
         :raises: :exc:`BadFilterError` if a filter string is invalid
         :raises: :exc:`BadValueError` if a filter value is invalid.
-        :raises: :exc:`BadQueryError` if an IN filter in combination with a sort order on
-            another property is provided
         """
         from viur.core.skeleton import SkelList, SkeletonInstance
 

--- a/src/viur/core/db/query.py
+++ b/src/viur/core/db/query.py
@@ -666,7 +666,8 @@ class Query(object):
                 if isinstance(self.queries, QueryDefinition):  # Just one
                     res = [x for x in res if _entryMatchesQuery(x, self.queries.filters, self.queries.or_filters)]
                 else:  # Multi-Query, must match at least one
-                    res = [x for x in res if any([_entryMatchesQuery(x, y.filters, y.or_filters) for y in self.queries])]
+                    res = [x for x in res if
+                           any([_entryMatchesQuery(x, y.filters, y.or_filters) for y in self.queries])]
 
         elif isinstance(self.queries, list):
             limit = limit if limit >= 0 else self.queries[0].limit

--- a/src/viur/core/db/query.py
+++ b/src/viur/core/db/query.py
@@ -267,7 +267,7 @@ class Query(object):
             field, op = prop.split(" ")
 
         # Normalize to uppercase for native Datastore operators passed as lowercase
-        op = op.upper() if op.lower() in {"in", "!=", "not_in"} else op
+        op = op.upper() if op.upper() in {"IN", "NOT_IN"} else op
 
         if op in {"IN", "!=", "NOT_IN"} and not isinstance(self.queries, list):
             if f"{field} {op}" in self.queries.filters:
@@ -328,7 +328,7 @@ class Query(object):
                 field, op = prop, "="
             else:
                 field, op = prop.split(" ", 1)
-            op = op.upper() if op.lower() in {"in", "!=", "not_in"} else op
+            op = op.upper() if op.upper() in {"IN", "NOT_IN"} else op
             parsed.append((f"{field} {op}", value))
 
         if isinstance(self.queries, list):

--- a/src/viur/core/db/transport.py
+++ b/src/viur/core/db/transport.py
@@ -164,11 +164,24 @@ def count(kind: str = None, up_to=2 ** 31 - 1, queryDefinition: QueryDefinition 
     if queryDefinition and queryDefinition.filters:
         for k, v in queryDefinition.filters.items():
             key, op = k.split(" ")
-            if not isinstance(v, list):  # multi equal filters
-                v = [v]
-            for val in v:
-                f = datastore.query.PropertyFilter(key, op, val)
+            if op in ("IN", "!="):
+                # Native operators: pass value as-is in a single PropertyFilter
+                f = datastore.query.PropertyFilter(key, op, v)
                 query.add_filter(filter=f)
+            else:
+                if not isinstance(v, list):  # multi equal filters
+                    v = [v]
+                for val in v:
+                    f = datastore.query.PropertyFilter(key, op, val)
+                    query.add_filter(filter=f)
+
+    if queryDefinition and queryDefinition.or_filters:
+        for or_group in queryDefinition.or_filters:
+            or_conditions = [
+                datastore.query.PropertyFilter(fs.split(" ", 1)[0], fs.split(" ", 1)[1], v)
+                for fs, v in or_group
+            ]
+            query.add_filter(filter=datastore.query.Or(or_conditions))
 
     aggregation_query = __client__.aggregation_query(query)
 
@@ -194,16 +207,31 @@ def run_single_filter(query: QueryDefinition, limit: int, keys_only: bool) -> t.
     startCursor = None
     endCursor = None
     hasInvertedOrderings = None
+    if conf.debug.trace_queries:
+        logging.info(f"Running query: {query}")
 
     if query:
         if query.filters:
             for k, v in query.filters.items():
                 key, op = k.split(" ")
-                if not isinstance(v, list):  # multi equal filters
-                    v = [v]
-                for val in v:
-                    f = datastore.query.PropertyFilter(key, op, val)
+                if op in ("IN", "!=", "NOT_IN"):
+                    # Native multi-value operators: pass value as-is, not split per element
+                    f = datastore.query.PropertyFilter(key, op, v)
                     qry.add_filter(filter=f)
+                else:
+                    if not isinstance(v, list):  # multi equal filters
+                        v = [v]
+                    for val in v:
+                        f = datastore.query.PropertyFilter(key, op, val)
+                        qry.add_filter(filter=f)
+
+        if query.or_filters:
+            for or_group in query.or_filters:
+                or_conditions = [
+                    datastore.query.PropertyFilter(fs.split(" ", 1)[0], fs.split(" ", 1)[1], v)
+                    for fs, v in or_group
+                ]
+                qry.add_filter(filter=datastore.query.Or(or_conditions))
 
         if query.orders:
             hasInvertedOrderings = any(

--- a/src/viur/core/db/types.py
+++ b/src/viur/core/db/types.py
@@ -167,6 +167,7 @@ Alias that describes a key-type.
 
 TOrders: t.TypeAlias = list[tuple[str, SortOrder]]
 TFilters: t.TypeAlias = dict[str, DATASTORE_BASE_TYPES | list[DATASTORE_BASE_TYPES]]
+TOrFilters: t.TypeAlias = list[list[tuple[str, DATASTORE_BASE_TYPES | list[DATASTORE_BASE_TYPES]]]]
 
 
 @dataclass
@@ -186,6 +187,10 @@ class QueryDefinition:
 
     distinct: t.Optional[list[str]] = None
     """If set, a list of fields that we should return distinct values of"""
+
+    or_filters: "TOrFilters" = field(default_factory=list)
+    """Each entry is a list of (filterStr, value) pairs that are OR-ed together.
+    Multiple entries are AND-ed with each other and with the AND filters."""
 
     limit: int = field(init=False)
     """The maximum amount of entities that should be returned"""

--- a/src/viur/core/tasks.py
+++ b/src/viur/core/tasks.py
@@ -755,7 +755,8 @@ class QueryIter(object, metaclass=MetaQueryIter):
         """
         assert not (query._customMultiQueryMerge or query._calculateInternalMultiQueryLimit), \
             "Cannot iter a query with postprocessing"
-        assert isinstance(query.queries, db.QueryDefinition), "Unsatisfiable query or query with a custom multi-query (SpatialBone/RandomSliceBone)"
+        assert isinstance(query.queries, db.QueryDefinition), ("Unsatisfiable query or query with a custom multi-query "
+                                                               "(SpatialBone/RandomSliceBone)")
         assert not query.queries.or_filters, "Cannot serialize a query with OR filters into a deferred task"
         qryDict = {
             "kind": query.kind,

--- a/src/viur/core/tasks.py
+++ b/src/viur/core/tasks.py
@@ -755,7 +755,8 @@ class QueryIter(object, metaclass=MetaQueryIter):
         """
         assert not (query._customMultiQueryMerge or query._calculateInternalMultiQueryLimit), \
             "Cannot iter a query with postprocessing"
-        assert isinstance(query.queries, db.QueryDefinition), "Unsatisfiable query or query with an IN filter"
+        assert isinstance(query.queries, db.QueryDefinition), "Unsatisfiable query or query with a custom multi-query (SpatialBone/RandomSliceBone)"
+        assert not query.queries.or_filters, "Cannot serialize a query with OR filters into a deferred task"
         qryDict = {
             "kind": query.kind,
             "srcSkel": query.srcSkel.kindName if query.srcSkel is not None else None,

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -29,7 +29,6 @@ class TestDb(ViURTestCase):
         self.assertEqual(key.parent, parent_key)
 
 
-
 class TestEntryMatchesQuery(ViURTestCase):
     def _make_entity(self, **kwargs):
         from viur.core import db
@@ -432,4 +431,3 @@ class TestQueryOrder(ViURTestCase):
         orders = q.get_orders()
         self.assertIsNotNone(orders)
         self.assertIsInstance(orders[0], db.QueryOrder)
-

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -27,3 +27,356 @@ class TestDb(ViURTestCase):
         key = db.Key("viur", "bar", parent=parent_key)
         self.assertEqual(key.name, "bar")
         self.assertEqual(key.parent, parent_key)
+
+
+class TestEntryMatchesQuery(ViURTestCase):
+    def _make_entity(self, **kwargs):
+        from viur.core import db
+        e = db.Entity(db.Key("Test", 1))
+        for k, v in kwargs.items():
+            e[k] = v
+        return e
+
+    def test_in_filter_matches(self) -> None:
+        from viur.core.db.query import _entryMatchesQuery
+        entry = self._make_entity(continent="Africa")
+        self.assertTrue(_entryMatchesQuery(entry, {"continent IN": ["Africa", "Asia"]}))
+
+    def test_in_filter_no_match(self) -> None:
+        from viur.core.db.query import _entryMatchesQuery
+        entry = self._make_entity(continent="Europe")
+        self.assertFalse(_entryMatchesQuery(entry, {"continent IN": ["Africa", "Asia"]}))
+
+    def test_neq_filter_matches(self) -> None:
+        from viur.core.db.query import _entryMatchesQuery
+        entry = self._make_entity(continent="Europe")
+        self.assertTrue(_entryMatchesQuery(entry, {"continent !=": "Africa"}))
+
+    def test_neq_filter_no_match(self) -> None:
+        from viur.core.db.query import _entryMatchesQuery
+        entry = self._make_entity(continent="Africa")
+        self.assertFalse(_entryMatchesQuery(entry, {"continent !=": "Africa"}))
+
+    def test_in_filter_multivalued_matches(self) -> None:
+        from viur.core.db.query import _entryMatchesQuery
+        # Entity with multiple continents — one is in the filter list
+        entry = self._make_entity(continent=["Africa", "Europe"])
+        self.assertTrue(_entryMatchesQuery(entry, {"continent IN": ["Africa", "Asia"]}))
+
+    def test_in_filter_multivalued_no_match(self) -> None:
+        from viur.core.db.query import _entryMatchesQuery
+        # Entity with multiple continents — none is in the filter list
+        entry = self._make_entity(continent=["Antarctica", "Europe"])
+        self.assertFalse(_entryMatchesQuery(entry, {"continent IN": ["Africa", "Asia"]}))
+
+    def test_not_in_filter_matches(self) -> None:
+        from viur.core.db.query import _entryMatchesQuery
+        entry = self._make_entity(continent="Europe")
+        self.assertTrue(_entryMatchesQuery(entry, {"continent NOT_IN": ["Africa", "Asia"]}))
+
+    def test_not_in_filter_no_match(self) -> None:
+        from viur.core.db.query import _entryMatchesQuery
+        entry = self._make_entity(continent="Africa")
+        self.assertFalse(_entryMatchesQuery(entry, {"continent NOT_IN": ["Africa", "Asia"]}))
+
+
+class TestRunSingleFilter(ViURTestCase):
+    def test_in_filter_builds_single_property_filter(self) -> None:
+        """IN filter must be passed as a single PropertyFilter with the list as value."""
+        from unittest.mock import patch, MagicMock
+        from viur.core.db.transport import run_single_filter
+        from viur.core.db.types import QueryDefinition
+
+        qdef = QueryDefinition(kind="Country", filters={"continent IN": ["Africa", "Asia"]}, orders=[])
+
+        mock_fetch_result = MagicMock()
+        mock_fetch_result.__iter__ = MagicMock(return_value=iter([]))
+        mock_fetch_result.next_page_token = None
+        mock_query = MagicMock()
+        mock_client = MagicMock()
+        mock_client.query.return_value = mock_query
+        mock_query.fetch.return_value = mock_fetch_result
+
+        with patch("viur.core.db.transport.__client__", mock_client):
+            run_single_filter(qdef, limit=10, keys_only=False)
+
+        from google.cloud.datastore.query import PropertyFilter
+        mock_query.add_filter.assert_called_once()
+        args, kwargs = mock_query.add_filter.call_args
+        passed_filter = kwargs.get("filter") or args[0]
+        self.assertIsInstance(passed_filter, PropertyFilter)
+        self.assertEqual(passed_filter.property_name, "continent")
+        self.assertEqual(passed_filter.operator, "IN")
+        self.assertEqual(passed_filter.value, ["Africa", "Asia"])
+
+    def test_not_in_filter_builds_single_property_filter(self) -> None:
+        """NOT_IN filter must be passed as a single PropertyFilter with the list as value."""
+        from unittest.mock import patch, MagicMock
+        from viur.core.db.transport import run_single_filter
+        from viur.core.db.types import QueryDefinition
+
+        qdef = QueryDefinition(kind="Country", filters={"continent NOT_IN": ["Africa", "Asia"]}, orders=[])
+
+        mock_fetch_result = MagicMock()
+        mock_fetch_result.__iter__ = MagicMock(return_value=iter([]))
+        mock_fetch_result.next_page_token = None
+        mock_query = MagicMock()
+        mock_client = MagicMock()
+        mock_client.query.return_value = mock_query
+        mock_query.fetch.return_value = mock_fetch_result
+
+        with patch("viur.core.db.transport.__client__", mock_client):
+            run_single_filter(qdef, limit=10, keys_only=False)
+
+        from google.cloud.datastore.query import PropertyFilter
+        mock_query.add_filter.assert_called_once()
+        args, kwargs = mock_query.add_filter.call_args
+        passed_filter = kwargs.get("filter") or args[0]
+        self.assertIsInstance(passed_filter, PropertyFilter)
+        self.assertEqual(passed_filter.property_name, "continent")
+        self.assertEqual(passed_filter.operator, "NOT_IN")
+        self.assertEqual(passed_filter.value, ["Africa", "Asia"])
+
+    def test_neq_filter_builds_single_property_filter(self) -> None:
+        """!= filter must be passed as a single PropertyFilter with a scalar value."""
+        from unittest.mock import patch, MagicMock
+        from viur.core.db.transport import run_single_filter
+        from viur.core.db.types import QueryDefinition
+
+        qdef = QueryDefinition(kind="Country", filters={"continent !=": "Africa"}, orders=[])
+
+        mock_fetch_result = MagicMock()
+        mock_fetch_result.__iter__ = MagicMock(return_value=iter([]))
+        mock_fetch_result.next_page_token = None
+        mock_query = MagicMock()
+        mock_client = MagicMock()
+        mock_client.query.return_value = mock_query
+        mock_query.fetch.return_value = mock_fetch_result
+
+        with patch("viur.core.db.transport.__client__", mock_client):
+            run_single_filter(qdef, limit=10, keys_only=False)
+
+        from google.cloud.datastore.query import PropertyFilter
+        mock_query.add_filter.assert_called_once()
+        args, kwargs = mock_query.add_filter.call_args
+        passed_filter = kwargs.get("filter") or args[0]
+        self.assertIsInstance(passed_filter, PropertyFilter)
+        self.assertEqual(passed_filter.property_name, "continent")
+        self.assertEqual(passed_filter.operator, "!=")
+        self.assertEqual(passed_filter.value, "Africa")
+
+    def test_or_filter_builds_or_composite_filter(self) -> None:
+        """OR group must be passed as a single Or composite filter."""
+        from unittest.mock import patch, MagicMock
+        from viur.core.db.transport import run_single_filter
+        from viur.core.db.types import QueryDefinition
+        from google.cloud.datastore.query import Or, PropertyFilter
+
+        qdef = QueryDefinition(
+            kind="Country",
+            filters={},
+            orders=[],
+            or_filters=[[("continent =", "Africa"), ("continent =", "Asia")]],
+        )
+
+        mock_fetch_result = MagicMock()
+        mock_fetch_result.__iter__ = MagicMock(return_value=iter([]))
+        mock_fetch_result.next_page_token = None
+        mock_query = MagicMock()
+        mock_client = MagicMock()
+        mock_client.query.return_value = mock_query
+        mock_query.fetch.return_value = mock_fetch_result
+
+        with patch("viur.core.db.transport.__client__", mock_client):
+            run_single_filter(qdef, limit=10, keys_only=False)
+
+        mock_query.add_filter.assert_called_once()
+        args, kwargs = mock_query.add_filter.call_args
+        passed_filter = kwargs.get("filter") or args[0]
+        self.assertIsInstance(passed_filter, Or)
+        self.assertEqual(len(passed_filter.filters), 2)
+        self.assertIsInstance(passed_filter.filters[0], PropertyFilter)
+        self.assertEqual(passed_filter.filters[0].property_name, "continent")
+        self.assertEqual(passed_filter.filters[0].value, "Africa")
+        self.assertEqual(passed_filter.filters[1].value, "Asia")
+
+    def test_two_or_groups_produce_two_add_filter_calls(self) -> None:
+        """Two OR groups must produce two separate Or composite filter calls."""
+        from unittest.mock import patch, MagicMock
+        from viur.core.db.transport import run_single_filter
+        from viur.core.db.types import QueryDefinition
+        from google.cloud.datastore.query import Or
+
+        qdef = QueryDefinition(
+            kind="Country",
+            filters={},
+            orders=[],
+            or_filters=[
+                [("continent =", "Africa"), ("continent =", "Asia")],
+                [("sortindex >", 100), ("sortindex <", 50)],
+            ],
+        )
+
+        mock_fetch_result = MagicMock()
+        mock_fetch_result.__iter__ = MagicMock(return_value=iter([]))
+        mock_fetch_result.next_page_token = None
+        mock_query = MagicMock()
+        mock_client = MagicMock()
+        mock_client.query.return_value = mock_query
+        mock_query.fetch.return_value = mock_fetch_result
+
+        with patch("viur.core.db.transport.__client__", mock_client):
+            run_single_filter(qdef, limit=10, keys_only=False)
+
+        self.assertEqual(mock_query.add_filter.call_count, 2)
+        for call in mock_query.add_filter.call_args_list:
+            args, kwargs = call
+            passed_filter = kwargs.get("filter") or args[0]
+            self.assertIsInstance(passed_filter, Or)
+
+
+class TestQueryFilter(ViURTestCase):
+    def test_in_filter_does_not_create_multiquery(self) -> None:
+        """IN filter must not create a multi-query (list of QueryDefinitions)."""
+        from viur.core import db
+        q = db.Query("Country")
+        q.filter("continent IN", ["Africa", "Asia"])
+        self.assertIsInstance(q.queries, db.QueryDefinition)
+        self.assertIn("continent IN", q.queries.filters)
+        self.assertEqual(q.queries.filters["continent IN"], ["Africa", "Asia"])
+
+    def test_neq_filter_does_not_create_multiquery(self) -> None:
+        """!= filter must not create a multi-query (list of QueryDefinitions)."""
+        from viur.core import db
+        q = db.Query("Country")
+        q.filter("continent !=", "Africa")
+        self.assertIsInstance(q.queries, db.QueryDefinition)
+        self.assertIn("continent !=", q.queries.filters)
+        self.assertEqual(q.queries.filters["continent !="], "Africa")
+
+    def test_in_filter_lowercase_op_normalized(self) -> None:
+        """Lowercase op 'in' must be normalized to 'IN'."""
+        from viur.core import db
+        q = db.Query("Country")
+        q.filter("continent in", ["Africa", "Asia"])
+        self.assertIsInstance(q.queries, db.QueryDefinition)
+        self.assertIn("continent IN", q.queries.filters)
+
+    def test_regular_filter_unchanged(self) -> None:
+        """Regular equality filters must not be affected by the refactor."""
+        from viur.core import db
+        q = db.Query("Country")
+        q.filter("continent =", "Africa")
+        self.assertIsInstance(q.queries, db.QueryDefinition)
+        self.assertEqual(q.queries.filters["continent ="], "Africa")
+
+    def test_not_in_filter_does_not_create_multiquery(self) -> None:
+        """NOT_IN filter must not create a multi-query (list of QueryDefinitions)."""
+        from viur.core import db
+        q = db.Query("Country")
+        q.filter("continent NOT_IN", ["Africa", "Asia"])
+        self.assertIsInstance(q.queries, db.QueryDefinition)
+        self.assertIn("continent NOT_IN", q.queries.filters)
+        self.assertEqual(q.queries.filters["continent NOT_IN"], ["Africa", "Asia"])
+
+    def test_not_in_filter_lowercase_op_normalized(self) -> None:
+        """Lowercase op 'not_in' must be normalized to 'NOT_IN'."""
+        from viur.core import db
+        q = db.Query("Country")
+        q.filter("continent not_in", ["Africa", "Asia"])
+        self.assertIsInstance(q.queries, db.QueryDefinition)
+        self.assertIn("continent NOT_IN", q.queries.filters)
+
+
+class TestQueryDefinitionOrFilters(ViURTestCase):
+    def test_querydef_has_empty_or_filters_by_default(self) -> None:
+        from viur.core import db
+        qdef = db.QueryDefinition(kind="Test", filters={}, orders=[])
+        self.assertEqual(qdef.or_filters, [])
+
+
+class TestQueryOrFilter(ViURTestCase):
+    def test_or_filter_stores_group_in_or_filters(self) -> None:
+        from viur.core import db
+        q = db.Query("Country")
+        q.or_filter(("continent =", "Africa"), ("continent =", "Asia"))
+        self.assertIsInstance(q.queries, db.QueryDefinition)
+        self.assertEqual(len(q.queries.or_filters), 1)
+        self.assertEqual(q.queries.or_filters[0], [
+            ("continent =", "Africa"),
+            ("continent =", "Asia"),
+        ])
+
+    def test_or_filter_multiple_calls_produce_multiple_groups(self) -> None:
+        from viur.core import db
+        q = db.Query("Country")
+        q.or_filter(("continent =", "Africa"), ("continent =", "Asia"))
+        q.or_filter(("sortindex >", 100), ("sortindex <", 50))
+        self.assertEqual(len(q.queries.or_filters), 2)
+
+    def test_or_filter_lowercase_op_normalized(self) -> None:
+        from viur.core import db
+        q = db.Query("Country")
+        q.or_filter(("continent in", ["Africa", "Asia"]))
+        self.assertEqual(q.queries.or_filters[0][0][0], "continent IN")
+
+    def test_or_filter_no_space_defaults_to_equality(self) -> None:
+        from viur.core import db
+        q = db.Query("Country")
+        q.or_filter(("continent", "Africa"))
+        self.assertEqual(q.queries.or_filters[0][0][0], "continent =")
+
+    def test_or_filter_not_in_op_normalized(self) -> None:
+        from viur.core import db
+        q = db.Query("Country")
+        q.or_filter(("continent not_in", ["Africa", "Asia"]))
+        self.assertEqual(q.queries.or_filters[0][0][0], "continent NOT_IN")
+
+    def test_or_filter_chaining(self) -> None:
+        from viur.core import db
+        q = db.Query("Country")
+        result = q.or_filter(("continent =", "Africa"), ("continent =", "Asia"))
+        self.assertIs(result, q)
+        result2 = result.or_filter(("sortindex >", 100))
+        self.assertIs(result2, q)
+        self.assertEqual(len(q.queries.or_filters), 2)
+
+
+class TestEntryMatchesQueryOrFilters(ViURTestCase):
+    def _make_entity(self, **kwargs):
+        from viur.core import db
+        e = db.Entity(db.Key("Test", 1))
+        for k, v in kwargs.items():
+            e[k] = v
+        return e
+
+    def test_or_group_matches_when_one_condition_is_true(self) -> None:
+        from viur.core.db.query import _entryMatchesQuery
+        entry = self._make_entity(continent="Africa")
+        or_filters = [[("continent =", "Europe"), ("continent =", "Africa")]]
+        self.assertTrue(_entryMatchesQuery(entry, {}, or_filters))
+
+    def test_or_group_fails_when_no_condition_matches(self) -> None:
+        from viur.core.db.query import _entryMatchesQuery
+        entry = self._make_entity(continent="Antarctica")
+        or_filters = [[("continent =", "Europe"), ("continent =", "Africa")]]
+        self.assertFalse(_entryMatchesQuery(entry, {}, or_filters))
+
+    def test_multiple_or_groups_are_anded(self) -> None:
+        from viur.core.db.query import _entryMatchesQuery
+        # continent matches group 1, but sortindex does not match group 2
+        entry = self._make_entity(continent="Africa", sortindex=50)
+        or_filters = [
+            [("continent =", "Africa"), ("continent =", "Asia")],
+            [("sortindex >", 100), ("sortindex <", 30)],
+        ]
+        self.assertFalse(_entryMatchesQuery(entry, {}, or_filters))
+
+    def test_and_plus_or_filters_both_must_pass(self) -> None:
+        from viur.core.db.query import _entryMatchesQuery
+        entry = self._make_entity(continent="Africa", sortindex=200)
+        self.assertTrue(_entryMatchesQuery(
+            entry,
+            {"sortindex >": 100},
+            [[("continent =", "Africa"), ("continent =", "Asia")]],
+        ))


### PR DESCRIPTION
This PR replace client-side MultiQuery with native Datastore operators add or_filter()

  IN, != and NOT_IN filters are no longer split into multiple sub-queries
  and merged client-side. They are now passed as native PropertyFilter
  operators directly to Cloud Datastore, reducing RPC calls from N to 1
  for IN queries and fixing default_order not being applied to these
  queries (fixes #1569).

  New Query.or_filter() method allows expressing OR composite filters
  that are sent to Datastore as Or([PropertyFilter, ...]) groups.
  Multiple or_filter() calls are AND-ed together with each other and
  with any regular filter() calls.

  - query.py: remove MultiQuery split logic for IN/!=/NOT_IN; add or_filter() method; extend _entryMatchesQuery for IN/!=/NOT_IN/OR
  - transport.py: handle IN/!=/NOT_IN natively; send Or composites
  - types.py: add TOrFilters type alias and or_filters field to QueryDefinition
  - tasks.py: guard against serializing queries with OR filters