### PR TITLE
feat: add lifecycle hooks for `Request`

### DIFF
--- a/src/viur/core/__init__.py
+++ b/src/viur/core/__init__.py
@@ -18,6 +18,7 @@ from types import ModuleType
 from viur.core import i18n, request, utils
 from viur.core.config import conf
 from viur.core.decorators import access, exposed, force_post, force_ssl, internal_exposed, skey
+from viur.core.request import after_request, before_request
 from viur.core.i18n import translate
 from viur.core.module import Method, Module
 import inspect
@@ -60,6 +61,8 @@ __all__ = [
     "PeriodicTask",
     # Decorators
     "access",
+    "after_request",
+    "before_request",
     "exposed",
     "force_post",
     "force_ssl",

--- a/src/viur/core/__init__.py
+++ b/src/viur/core/__init__.py
@@ -18,7 +18,7 @@ from types import ModuleType
 from viur.core import i18n, request, utils
 from viur.core.config import conf
 from viur.core.decorators import access, exposed, force_post, force_ssl, internal_exposed, skey
-from viur.core.request import after_request, before_request
+from viur.core.request import post_request, pre_request
 from viur.core.i18n import translate
 from viur.core.module import Method, Module
 import inspect
@@ -61,8 +61,8 @@ __all__ = [
     "PeriodicTask",
     # Decorators
     "access",
-    "after_request",
-    "before_request",
+    "post_request",
+    "pre_request",
     "exposed",
     "force_post",
     "force_ssl",

--- a/src/viur/core/__init__.py
+++ b/src/viur/core/__init__.py
@@ -18,7 +18,7 @@ from types import ModuleType
 from viur.core import i18n, request, utils
 from viur.core.config import conf
 from viur.core.decorators import access, exposed, force_post, force_ssl, internal_exposed, skey
-from viur.core.request import post_request, pre_request
+from viur.core.request import before_request, after_request
 from viur.core.i18n import translate
 from viur.core.module import Method, Module
 import inspect
@@ -61,8 +61,8 @@ __all__ = [
     "PeriodicTask",
     # Decorators
     "access",
-    "post_request",
-    "pre_request",
+    "after_request",
+    "before_request",
     "exposed",
     "force_post",
     "force_ssl",

--- a/src/viur/core/bones/base.py
+++ b/src/viur/core/bones/base.py
@@ -802,19 +802,19 @@ class BaseBone(object):
                     ReadFromClientError(ReadFromClientErrorSeverity.Empty, fieldPath=[lang])
                     for lang in missing
                 ]
-                self.after_from_client(skel, name, result_errors)
+                self.post_from_client(skel, name, result_errors)
                 return result_errors or None
 
         if isEmpty:
             result_errors = [ReadFromClientError(ReadFromClientErrorSeverity.Empty)]
-            self.after_from_client(skel, name, result_errors)
+            self.post_from_client(skel, name, result_errors)
             return result_errors or None
 
         # Check multiple constraints on demand
         if self.multiple and isinstance(self.multiple, MultipleConstraints):
             errors.extend(self._validate_multiple_contraints(self.multiple, skel, name))
 
-        self.after_from_client(skel, name, errors)
+        self.post_from_client(skel, name, errors)
         return errors or None
 
     def _get_single_destinct_hash(self, value) -> t.Any:
@@ -1392,7 +1392,7 @@ class BaseBone(object):
         """
         pass
 
-    def after_from_client(self, skel: "SkeletonInstance", name: str, errors: list[ReadFromClientError]) -> None:
+    def post_from_client(self, skel: "SkeletonInstance", name: str, errors: list[ReadFromClientError]) -> None:
         """
         Called at the end of :meth:`fromClient` after ``skel[name]`` has been set and all
         validation (including multiple-constraints) has run.

--- a/src/viur/core/bones/base.py
+++ b/src/viur/core/bones/base.py
@@ -798,18 +798,23 @@ class BaseBone(object):
         if self.languages and isinstance(self.required, (list, tuple)):
             missing = set(self.required).difference(filled_languages)
             if missing:
-                return [
+                result_errors = [
                     ReadFromClientError(ReadFromClientErrorSeverity.Empty, fieldPath=[lang])
                     for lang in missing
                 ]
+                self.after_from_client(skel, name, result_errors)
+                return result_errors or None
 
         if isEmpty:
-            return [ReadFromClientError(ReadFromClientErrorSeverity.Empty)]
+            result_errors = [ReadFromClientError(ReadFromClientErrorSeverity.Empty)]
+            self.after_from_client(skel, name, result_errors)
+            return result_errors or None
 
         # Check multiple constraints on demand
         if self.multiple and isinstance(self.multiple, MultipleConstraints):
             errors.extend(self._validate_multiple_contraints(self.multiple, skel, name))
 
+        self.after_from_client(skel, name, errors)
         return errors or None
 
     def _get_single_destinct_hash(self, value) -> t.Any:
@@ -1384,6 +1389,24 @@ class BaseBone(object):
             :param skel: The skeleton this bone belongs to
             :param boneName: Name of this bone
             :param key: The old Database Key of the entity we've deleted
+        """
+        pass
+
+    def after_from_client(self, skel: "SkeletonInstance", name: str, errors: list[ReadFromClientError]) -> None:
+        """
+        Called at the end of :meth:`fromClient` after ``skel[name]`` has been set and all
+        validation (including multiple-constraints) has run.
+
+        Override to post-process or normalize ``skel[name]`` in-place, or to add/remove
+        entries from ``errors``. Always called when the field was part of the submitted data
+        (i.e. ``skel[name]`` has been written), regardless of whether errors occurred.
+        The ``NotSet`` early-return (field absent from request) is the only case where this
+        hook is *not* called.
+
+        :param skel: The skeleton instance whose bone value was just read.
+        :param name: The attribute name of this bone within the skeleton.
+        :param errors: Mutable list of :class:`ReadFromClientError` collected so far.
+            Changes here affect the return value of :meth:`fromClient`.
         """
         pass
 

--- a/src/viur/core/bones/base.py
+++ b/src/viur/core/bones/base.py
@@ -798,23 +798,18 @@ class BaseBone(object):
         if self.languages and isinstance(self.required, (list, tuple)):
             missing = set(self.required).difference(filled_languages)
             if missing:
-                result_errors = [
+                return [
                     ReadFromClientError(ReadFromClientErrorSeverity.Empty, fieldPath=[lang])
                     for lang in missing
                 ]
-                self.post_from_client(skel, name, result_errors)
-                return result_errors or None
 
         if isEmpty:
-            result_errors = [ReadFromClientError(ReadFromClientErrorSeverity.Empty)]
-            self.post_from_client(skel, name, result_errors)
-            return result_errors or None
+            return [ReadFromClientError(ReadFromClientErrorSeverity.Empty)]
 
         # Check multiple constraints on demand
         if self.multiple and isinstance(self.multiple, MultipleConstraints):
             errors.extend(self._validate_multiple_contraints(self.multiple, skel, name))
 
-        self.post_from_client(skel, name, errors)
         return errors or None
 
     def _get_single_destinct_hash(self, value) -> t.Any:
@@ -1389,24 +1384,6 @@ class BaseBone(object):
             :param skel: The skeleton this bone belongs to
             :param boneName: Name of this bone
             :param key: The old Database Key of the entity we've deleted
-        """
-        pass
-
-    def post_from_client(self, skel: "SkeletonInstance", name: str, errors: list[ReadFromClientError]) -> None:
-        """
-        Called at the end of :meth:`fromClient` after ``skel[name]`` has been set and all
-        validation (including multiple-constraints) has run.
-
-        Override to post-process or normalize ``skel[name]`` in-place, or to add/remove
-        entries from ``errors``. Always called when the field was part of the submitted data
-        (i.e. ``skel[name]`` has been written), regardless of whether errors occurred.
-        The ``NotSet`` early-return (field absent from request) is the only case where this
-        hook is *not* called.
-
-        :param skel: The skeleton instance whose bone value was just read.
-        :param name: The attribute name of this bone within the skeleton.
-        :param errors: Mutable list of :class:`ReadFromClientError` collected so far.
-            Changes here affect the return value of :meth:`fromClient`.
         """
         pass
 

--- a/src/viur/core/request.py
+++ b/src/viur/core/request.py
@@ -105,11 +105,11 @@ class Router:
         - Load or initialize a new session
         - Set up i18n (choosing the language etc)
         - Run the request preprocessor (if any)
-        - Run before_request hooks (if any)
+        - Run pre_request hooks (if any)
         - Normalize & sanity check the parameters
         - Resolve the exposed function and call it
         - Save the session / tear down the request
-        - Run after_request hooks (if any)
+        - Run post_request hooks (if any)
         - Return the response generated
 
 
@@ -119,8 +119,8 @@ class Router:
     # List of requestValidators used to preflight-check an request before it's being dispatched within ViUR
     requestValidators = [FetchMetaDataValidator]
 
-    before_request_funcs: t.ClassVar[list[t.Callable[[], None]]] = []
-    after_request_funcs: t.ClassVar[list[t.Callable[[], None]]] = []
+    pre_request_funcs: t.ClassVar[list[t.Callable[[], None]]] = []
+    post_request_funcs: t.ClassVar[list[t.Callable[[], None]]] = []
 
     def __init__(self, environ: dict):
         super().__init__()
@@ -159,13 +159,13 @@ class Router:
         current.session.set(session.Session())
         current.request_data.set({})
 
-        for fn in Router.before_request_funcs:
+        for fn in Router.pre_request_funcs:
             fn()
 
         # Process actual request
         self._process()
 
-        for fn in Router.after_request_funcs:
+        for fn in Router.post_request_funcs:
             fn()
 
         self._cors()
@@ -791,7 +791,7 @@ class Router:
         current.session.get().save()
 
 
-def before_request(fn: t.Callable[[], None]) -> t.Callable[[], None]:
+def pre_request(fn: t.Callable[[], None]) -> t.Callable[[], None]:
     """Register a function to be called before each request is processed.
 
     The function is called after context variables are set (``current.request``,
@@ -803,17 +803,17 @@ def before_request(fn: t.Callable[[], None]) -> t.Callable[[], None]:
 
     Usage::
 
-        from viur.core import before_request
+        from viur.core import pre_request
 
-        @before_request
+        @pre_request
         def my_hook():
             ...
     """
-    Router.before_request_funcs.append(fn)
+    Router.pre_request_funcs.append(fn)
     return fn
 
 
-def after_request(fn: t.Callable[[], None]) -> t.Callable[[], None]:
+def post_request(fn: t.Callable[[], None]) -> t.Callable[[], None]:
     """Register a function to be called after each request has been processed.
 
     The function is called after :meth:`Router._process` completes — the response
@@ -825,13 +825,13 @@ def after_request(fn: t.Callable[[], None]) -> t.Callable[[], None]:
 
     Usage::
 
-        from viur.core import after_request
+        from viur.core import post_request
 
-        @after_request
+        @post_request
         def my_hook():
             ...
     """
-    Router.after_request_funcs.append(fn)
+    Router.post_request_funcs.append(fn)
     return fn
 
 

--- a/src/viur/core/request.py
+++ b/src/viur/core/request.py
@@ -105,9 +105,11 @@ class Router:
         - Load or initialize a new session
         - Set up i18n (choosing the language etc)
         - Run the request preprocessor (if any)
+        - Run before_request hooks (if any)
         - Normalize & sanity check the parameters
         - Resolve the exposed function and call it
         - Save the session / tear down the request
+        - Run after_request hooks (if any)
         - Return the response generated
 
 
@@ -116,6 +118,9 @@ class Router:
 
     # List of requestValidators used to preflight-check an request before it's being dispatched within ViUR
     requestValidators = [FetchMetaDataValidator]
+
+    before_request_funcs: t.ClassVar[list[t.Callable[[], None]]] = []
+    after_request_funcs: t.ClassVar[list[t.Callable[[], None]]] = []
 
     def __init__(self, environ: dict):
         super().__init__()
@@ -154,8 +159,14 @@ class Router:
         current.session.set(session.Session())
         current.request_data.set({})
 
+        for fn in Router.before_request_funcs:
+            fn()
+
         # Process actual request
         self._process()
+
+        for fn in Router.after_request_funcs:
+            fn()
 
         self._cors()
 
@@ -778,6 +789,50 @@ class Router:
 
     def saveSession(self) -> None:
         current.session.get().save()
+
+
+def before_request(fn: t.Callable[[], None]) -> t.Callable[[], None]:
+    """Register a function to be called before each request is processed.
+
+    The function is called after context variables are set (``current.request``,
+    ``current.session``, ``current.request_data`` are available), but a fresh
+    ``Session`` container has not been loaded yet — call ``current.session.get().load()``
+    explicitly if you need session data. ``current.user`` is not set. Exceptions
+    raised by the hook propagate and abort request processing. No arguments are passed;
+    use ``current.request.get()`` to access the request. The function must not return a value.
+
+    Usage::
+
+        from viur.core import before_request
+
+        @before_request
+        def my_hook():
+            ...
+    """
+    Router.before_request_funcs.append(fn)
+    return fn
+
+
+def after_request(fn: t.Callable[[], None]) -> t.Callable[[], None]:
+    """Register a function to be called after each request has been processed.
+
+    The function is called after :meth:`Router._process` completes — the response
+    is fully generated, the session is saved, and ``current.user.get()`` is still
+    available. The call happens before CORS headers are applied. Exceptions raised
+    by the hook propagate and abort CORS processing. No arguments are passed;
+    use ``current.request.get().response`` to inspect the response. The function
+    must not return a value.
+
+    Usage::
+
+        from viur.core import after_request
+
+        @after_request
+        def my_hook():
+            ...
+    """
+    Router.after_request_funcs.append(fn)
+    return fn
 
 
 from .i18n import translate  # noqa: E402

--- a/src/viur/core/request.py
+++ b/src/viur/core/request.py
@@ -105,11 +105,11 @@ class Router:
         - Load or initialize a new session
         - Set up i18n (choosing the language etc)
         - Run the request preprocessor (if any)
-        - Run pre_request hooks (if any)
+        - Run before_request hooks (if any)
         - Normalize & sanity check the parameters
         - Resolve the exposed function and call it
         - Save the session / tear down the request
-        - Run post_request hooks (if any)
+        - Run after_request hooks (if any)
         - Return the response generated
 
 
@@ -119,8 +119,8 @@ class Router:
     # List of requestValidators used to preflight-check an request before it's being dispatched within ViUR
     requestValidators = [FetchMetaDataValidator]
 
-    pre_request_funcs: t.ClassVar[list[t.Callable[[], None]]] = []
-    post_request_funcs: t.ClassVar[list[t.Callable[[], None]]] = []
+    before_request_funcs: t.ClassVar[list[t.Callable[[], None]]] = []
+    after_request_funcs: t.ClassVar[list[t.Callable[[], None]]] = []
 
     def __init__(self, environ: dict):
         super().__init__()
@@ -159,13 +159,13 @@ class Router:
         current.session.set(session.Session())
         current.request_data.set({})
 
-        for fn in Router.pre_request_funcs:
+        for fn in Router.before_request_funcs:
             fn()
 
         # Process actual request
         self._process()
 
-        for fn in Router.post_request_funcs:
+        for fn in Router.after_request_funcs:
             fn()
 
         self._cors()
@@ -791,7 +791,7 @@ class Router:
         current.session.get().save()
 
 
-def pre_request(fn: t.Callable[[], None]) -> t.Callable[[], None]:
+def before_request(fn: t.Callable[[], None]) -> t.Callable[[], None]:
     """Register a function to be called before each request is processed.
 
     The function is called after context variables are set (``current.request``,
@@ -803,17 +803,17 @@ def pre_request(fn: t.Callable[[], None]) -> t.Callable[[], None]:
 
     Usage::
 
-        from viur.core import pre_request
+        from viur.core import before_request
 
-        @pre_request
+        @before_request
         def my_hook():
             ...
     """
-    Router.pre_request_funcs.append(fn)
+    Router.before_request_funcs.append(fn)
     return fn
 
 
-def post_request(fn: t.Callable[[], None]) -> t.Callable[[], None]:
+def after_request(fn: t.Callable[[], None]) -> t.Callable[[], None]:
     """Register a function to be called after each request has been processed.
 
     The function is called after :meth:`Router._process` completes — the response
@@ -825,13 +825,13 @@ def post_request(fn: t.Callable[[], None]) -> t.Callable[[], None]:
 
     Usage::
 
-        from viur.core import post_request
+        from viur.core import after_request
 
-        @post_request
+        @after_request
         def my_hook():
             ...
     """
-    Router.post_request_funcs.append(fn)
+    Router.after_request_funcs.append(fn)
     return fn
 
 


### PR DESCRIPTION
Implements two of the hooks proposed in #1599.

  **`@before_request` / `@after_request`**
  Two decorator-based hooks for the request lifecycle, registered via class-level
  lists on `Router`. `@before_request` fires before `_process()` (context variables
  are set, session not yet loaded). `@after_request` fires after `_process()` (response
  generated, session saved, `current.user` still available), before CORS headers.
  Exceptions propagate unhandled. Both decorators are exported from `viur.core`.

  ```python
  from viur.core import before_request, after_request
  
  @before_request
  def my_before_hook():
      ...

  @after_request
  def my_after_hook():
      ...
  ```