### PR TITLE
fix: propagate user-entity changes into active sessions on edit

### DIFF
--- a/src/viur/core/modules/user.py
+++ b/src/viur/core/modules/user.py
@@ -1897,9 +1897,9 @@ class User(List):
         if self.is_active(skel) is False:
             session.killSessionByUser(skel["key"])
 
-        # Update user setting in all sessions
-        for session_obj in db.Query("user").filter("user =", skel["key"]).iter():
-            session_obj["data"]["user"] = skel.dbEntity
+        # Otherwise, update the user entity cached in all the user's sessions
+        else:
+            session.update_session_user(skel["key"])
 
     def onDeleted(self, skel):
         super().onDeleted(skel)

--- a/src/viur/core/session.py
+++ b/src/viur/core/session.py
@@ -304,6 +304,29 @@ def killSessionByUser(user: t.Optional[t.Union[str, "db.Key", None]] = None):
     DeleteSessionsIter.startIterOnQuery(query)
 
 
+def update_session_user(user_key: "db.Key"):
+    """
+    Updates the cached user entity in all active sessions of the given *user*.
+
+    Whenever a user entity is modified (e.g. its access rights have changed), the copy
+    stored within the user's active sessions has to be refreshed as well; Otherwise,
+    the modification would only take effect after re-login or session expiry.
+
+    :param user_key: db.Key of the user whose sessions shall be updated.
+    """
+    logging.info(f"Updating cached user entity in all sessions for {user_key=}")
+
+    if not (user_entity := db.get(user_key)):
+        logging.warning(f"Cannot update sessions, {user_key=} not found")
+        return
+
+    for session_entity in db.Query(Session.kindName).filter("user =", str(user_key)).iter():
+        session_entity["data"]["user"] = user_entity
+        session_entity["data"] = db.fix_unindexable_properties(session_entity["data"])
+        session_entity.exclude_from_indexes = {"data"}
+        db.put(session_entity)
+
+
 @tasks.PeriodicTask(interval=datetime.timedelta(hours=4))
 def start_clear_sessions():
     """

--- a/src/viur/core/session.py
+++ b/src/viur/core/session.py
@@ -320,11 +320,16 @@ def update_session_user(user_key: "db.Key"):
         logging.warning(f"Cannot update sessions, {user_key=} not found")
         return
 
-    for session_entity in db.Query(Session.kindName).filter("user =", str(user_key)).iter():
-        session_entity["data"]["user"] = user_entity
-        session_entity["data"] = db.fix_unindexable_properties(session_entity["data"])
-        session_entity.exclude_from_indexes = {"data"}
-        db.put(session_entity)
+    def _update_txn(key):
+        if not (entity := db.get(key)):
+            return
+        entity["data"]["user"] = user_entity
+        entity["data"] = db.fix_unindexable_properties(entity["data"])
+        entity.exclude_from_indexes = {"data"}
+        db.put(entity)
+
+    for e in db.Query(Session.kindName).filter("user =", str(user_key)).iter():
+        db.run_in_transaction(_update_txn, e.key)
 
 
 @tasks.PeriodicTask(interval=datetime.timedelta(hours=4))


### PR DESCRIPTION
  The session-update loop introduced in User.onEdited was a no-op due to
  three bugs: wrong Datastore kind ("user" instead of Session.kindName),
  filtering by raw db.Key instead of str, and never calling db.put().

  Replaces the broken loop with a new deferred function
  session.update_session_user() that correctly fetches the fresh user
  entity and writes it into all active sessions of that user, so
  access-right changes take effect immediately without requiring re-login.