### PR TITLE
feat:  `SpatialBone`  extend `setBoneValue` to accept `dict` with lat/lng aliases

### DIFF
--- a/src/viur/core/bones/spatial.py
+++ b/src/viur/core/bones/spatial.py
@@ -378,7 +378,8 @@ class SpatialBone(BaseBone):
 
         :param skel: Dictionary with the current values from the skeleton the bone belongs to
         :param boneName: The name of the bone that should be modified
-        :param value: The value that should be assigned. Its type depends on the type of the bone
+        :param value: The value that should be assigned. Either a tuple/list of (lat, lng) or a dict
+            with keys ``lat``/``latitude`` and ``lng``/``lon``/``longitude``
         :param append: If True, the given value will be appended to the existing bone values instead of
             replacing them. Only supported on bones with multiple=True
         :param language: Optional, the language of the value if the bone is language-aware
@@ -387,7 +388,14 @@ class SpatialBone(BaseBone):
         """
         if append:
             raise ValueError(f"append is not possible on {self.type} bones")
-        if not isinstance(value, (tuple, list)) and len(value) == 2:
+        if isinstance(value, dict):
+            try:
+                raw_lat = next(value[k] for k in ("lat", "latitude") if k in value)
+                raw_lng = next(value[k] for k in ("lng", "lon", "longitude") if k in value)
+                value = (float(raw_lat), float(raw_lng))
+            except (StopIteration, TypeError, ValueError):
+                raise ValueError("Value dict must contain a lat/latitude and lng/lon/longitude key as floats")
+        if not isinstance(value, (tuple, list)) or len(value) != 2:
             raise ValueError("Value must be a tuple or a list of (lat, lng)")
         skel[boneName] = tuple(value)
 

--- a/src/viur/core/bones/spatial.py
+++ b/src/viur/core/bones/spatial.py
@@ -379,7 +379,7 @@ class SpatialBone(BaseBone):
         :param skel: Dictionary with the current values from the skeleton the bone belongs to
         :param boneName: The name of the bone that should be modified
         :param value: The value that should be assigned. Either a tuple/list of (lat, lng) or a dict
-            with keys ``lat``/``latitude`` and ``lng``/``lon``/``longitude``
+            with keys ``lat`` and ``lng``
         :param append: If True, the given value will be appended to the existing bone values instead of
             replacing them. Only supported on bones with multiple=True
         :param language: Optional, the language of the value if the bone is language-aware
@@ -390,11 +390,9 @@ class SpatialBone(BaseBone):
             raise ValueError(f"append is not possible on {self.type} bones")
         if isinstance(value, dict):
             try:
-                raw_lat = next(value[k] for k in ("lat", "latitude") if k in value)
-                raw_lng = next(value[k] for k in ("lng", "lon", "longitude") if k in value)
-                value = (float(raw_lat), float(raw_lng))
-            except (StopIteration, TypeError, ValueError):
-                raise ValueError("Value dict must contain a lat/latitude and lng/lon/longitude key as floats")
+                value = (float(value["lat"]), float(value["lng"]))
+            except (KeyError, TypeError, ValueError):
+                raise ValueError("Value dict must contain 'lat' and 'lng' keys as floats")
         if not isinstance(value, (tuple, list)) or len(value) != 2:
             raise ValueError("Value must be a tuple or a list of (lat, lng)")
         skel[boneName] = tuple(value)

--- a/tests/bones/test_spatial_bone.py
+++ b/tests/bones/test_spatial_bone.py
@@ -196,11 +196,13 @@ class TestSpatialBoneSetBoneValue(ViURTestCase):
     def test_dict_lat_lng(self):
         self.assertEqual((51.0, 10.0), self._set({"lat": 51.0, "lng": 10.0}))
 
-    def test_dict_lat_lon(self):
-        self.assertEqual((51.0, 10.0), self._set({"lat": 51.0, "lon": 10.0}))
+    def test_dict_lat_lon_raises(self):
+        with self.assertRaises(ValueError):
+            self._set({"lat": 51.0, "lon": 10.0})
 
-    def test_dict_latitude_longitude(self):
-        self.assertEqual((51.0, 10.0), self._set({"latitude": 51.0, "longitude": 10.0}))
+    def test_dict_latitude_longitude_raises(self):
+        with self.assertRaises(ValueError):
+            self._set({"latitude": 51.0, "longitude": 10.0})
 
     def test_dict_string_values_parsed(self):
         self.assertEqual((51.0, 10.0), self._set({"lat": "51.0", "lng": "10.0"}))

--- a/tests/bones/test_spatial_bone.py
+++ b/tests/bones/test_spatial_bone.py
@@ -176,6 +176,52 @@ class TestSpatialBoneSingleValueFromClient(ViURTestCase):
         self.assertIsNotNone(err)
 
 
+class TestSpatialBoneSetBoneValue(ViURTestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.bone = _bone()
+
+    def _set(self, value, append=False):
+        skel = {}
+        self.bone.setBoneValue(skel, "location", value, append)
+        return skel.get("location")
+
+    def test_tuple(self):
+        self.assertEqual((51.0, 10.0), self._set((51.0, 10.0)))
+
+    def test_list(self):
+        self.assertEqual((51.0, 10.0), self._set([51.0, 10.0]))
+
+    def test_dict_lat_lng(self):
+        self.assertEqual((51.0, 10.0), self._set({"lat": 51.0, "lng": 10.0}))
+
+    def test_dict_lat_lon(self):
+        self.assertEqual((51.0, 10.0), self._set({"lat": 51.0, "lon": 10.0}))
+
+    def test_dict_latitude_longitude(self):
+        self.assertEqual((51.0, 10.0), self._set({"latitude": 51.0, "longitude": 10.0}))
+
+    def test_dict_string_values_parsed(self):
+        self.assertEqual((51.0, 10.0), self._set({"lat": "51.0", "lng": "10.0"}))
+
+    def test_dict_missing_lng_raises(self):
+        with self.assertRaises(ValueError):
+            self._set({"lat": 51.0})
+
+    def test_dict_missing_lat_raises(self):
+        with self.assertRaises(ValueError):
+            self._set({"lng": 10.0})
+
+    def test_invalid_type_raises(self):
+        with self.assertRaises(ValueError):
+            self._set("52.5,13.4")
+
+    def test_append_raises(self):
+        with self.assertRaises(ValueError):
+            self._set((51.0, 10.0), append=True)
+
+
 class TestSpatialBoneSingleValueUnserialize(ViURTestCase):
 
     def setUp(self):


### PR DESCRIPTION
  SpatialBone.setBoneValue now accepts dicts with lat and
  lng keys in addition to tuple/list. Also fixes a logic
  bug in the existing type check (and → or, == 2 → != 2).