### PR TITLE
fix: guard Skeleton_Cls import in instance.py to break circular import

### DIFF
--- a/src/viur/core/skeleton/instance.py
+++ b/src/viur/core/skeleton/instance.py
@@ -8,8 +8,13 @@ import warnings
 from functools import partial
 
 from viur.core import db
-from .meta import Skeleton_Cls
 from .skeleton import Skeleton
+
+if t.TYPE_CHECKING:
+    from .meta import Skeleton_Cls
+else:
+    # Avoid circular import at runtime: meta.py → bones/__init__.py → image.py → relskel.py → meta.py
+    Skeleton_Cls = t.TypeVar("Skeleton_Cls")
 from ..bones.base import BaseBone
 
 


### PR DESCRIPTION
  Introduced by #1412 , which added `from .meta import Skeleton_Cls`
  at module level, creating a circular import chain at runtime:

    ImportError: cannot import name 'BaseSkeleton' from partially initialized
    module 'viur.core.skeleton.meta' (most likely due to a circular import)

  Guard the import behind TYPE_CHECKING so type checkers still see the
  correct TypeVar while the runtime uses a plain TypeVar that doesn't
  trigger the cycle