### PR TITLE
fix: Loosen overly strict dependency ranges

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "viur-core"
 dynamic = ["version"]
 dependencies = [
-    "appengine-python-standard~=1.0",
+    "appengine-python-standard~=2.0",
     "Deprecated~=1.2",
     "google-api-core[grpc]~=2.0",
     "google-auth~=2.0",
@@ -15,22 +15,21 @@ dependencies = [
     "google-cloud-iam~=2.0",
     "google-cloud-logging~=3.0",
     "google-cloud-secret-manager~=2.0",
-    "google-cloud-storage~=2.0",
+    "google-cloud-storage>=2,<4",
     "google-cloud-tasks~=2.0",
     "google-resumable-media~=2.0",
     "googleapis-common-protos[grpc]~=1.0",
-    "gunicorn~=23.0",
+    "gunicorn>=23,<27",
     "jinja2~=3.0",
     "jsonschema~=4.0",
     "logics-py==0.0.12",
-    "pillow~=11.0",
+    "pillow>=11,<13",
     "pyotp~=2.0",
-    "pytz~=2023.0",
+    "pytz>=2023",
     "pyyaml~=6.0",
-    "qrcode~=7.0",
+    "qrcode>=7,<9",
     "requests~=2.0",
     "tzlocal~=5.0",
-    "urllib3==1.26.20", # for appengine-python-standard (https://github.com/GoogleCloudPlatform/appengine-python-standard/blob/main/setup.py#L28)
     "user-agents~=2.0",
     "webob~=1.0",
 ]


### PR DESCRIPTION
Several deps used compatible-release pins (`~=X.0`) that blocked the current major, or were frozen to a stale version, which causes needless resolution conflicts for projects consuming viur-core.

- `appengine-python-standard`: `~=1.0` -> `~=2.0` (2.0 is additive only, brings gthread WSGI bugfix)
- `google-cloud-storage`: `~=2.0` -> `>=2,<4` (allow 3.x; removed APIs num_retries/text_mode/from_string are unused)
- `gunicorn`: `~=23.0` -> `>=23,<27` (eventlet worker drop in 26 not used)
- `pillow`: `~=11.0` -> `>=11,<13` (12.x ICC/resampling APIs unchanged)
- `pytz`: `~=2023.0` -> `>=2023` (date-based; was frozen to 2023 tz data)
- `qrcode`: `~=7.0` -> `>=7,<9` (8.x embedded-image change not used)
- drop `urllib3==1.26.20`: not imported directly; the <2 cap already comes transitively from appengine-python-standard

`logics-py==0.0.12` left pinned: host API is stable but built-in formula semantics changed (split delimiter, max/min/sum wrapping), which can alter evaluation of stored expressions.