### PR TITLE
fix: `SkelModule.add_or_edit` should use `amend=True` on edit

### DIFF
--- a/src/viur/core/prototypes/skelmodule.py
+++ b/src/viur/core/prototypes/skelmodule.py
@@ -233,7 +233,10 @@ class SkelModule(Module):
 
         if (
             not kwargs  # no data supplied
-            or not skel.fromClient(kwargs)  # failure on reading into the bones
+            or not skel.fromClient(  # failure on reading into the bones
+                kwargs,
+                amend=not is_add,  # amend=True on edit-mode
+            )
         ):
             # render the skeleton in the version it could as far as it could be read.
             return self.render.render("add_or_edit", skel)


### PR DESCRIPTION
This caused unwanted dataset changes when using importers with only a subset of fields.