### PR TITLE
fix: Normalize parsed `db.Key` to current `project_id`

### DIFF
--- a/src/viur/core/db/utils.py
+++ b/src/viur/core/db/utils.py
@@ -54,7 +54,7 @@ def fix_unindexable_properties(entry: Entity, *, keep_exclusions: bool = True) -
 
 def normalize_key(key: t.Union[None, Key, str]) -> t.Union[None, Key]:
     """
-        Normalizes a datastore key (replacing _application with the current one)
+        Normalizes a datastore key (replacing the key's project with conf.instance.project_id)
 
         :param key: Key to be normalized.
         :return: Normalized key in string representation.

--- a/src/viur/core/db/utils.py
+++ b/src/viur/core/db/utils.py
@@ -1,4 +1,5 @@
 import datetime
+import fnmatch
 import sys
 import typing as t
 
@@ -6,6 +7,7 @@ from deprecated.sphinx import deprecated
 from google.cloud.datastore.transaction import Transaction
 
 from viur.core import current
+from viur.core.config import conf
 from .transport import __client__, get, put, run_in_transaction
 from .types import Entity, Key, current_db_access_log
 
@@ -56,17 +58,28 @@ def normalize_key(key: t.Union[None, Key, str]) -> t.Union[None, Key]:
     """
         Normalizes a datastore key (replacing the key's project with conf.instance.project_id)
 
+        The key's project is only allowed to be normalized when it matches one of the patterns
+        configured in `conf.valid_application_ids`; otherwise a ValueError is raised.
+
         :param key: Key to be normalized.
         :return: Normalized key in string representation.
         """
     if key is None:
         return None
+
     if isinstance(key, str):
         key = Key.from_legacy_urlsafe(key)
+
+    if key.project != conf.instance.project_id and not any(
+        fnmatch.fnmatch(key.project, application_id) for application_id in conf.valid_application_ids
+    ):
+        raise ValueError(f"{key=} cannot be normalized; Only keys from conf.valid_application_ids can be provided.")
+
     if key.parent:
         parent = normalize_key(key.parent)
     else:
         parent = None
+
     return Key(key.kind, key.id_or_name, parent=parent)
 
 

--- a/src/viur/core/module.py
+++ b/src/viur/core/module.py
@@ -133,11 +133,13 @@ class Method:
             elif annotation is db.Key:
                 if isinstance(value, db.Key):
                     return value
+
                 elif isinstance(value, str):  # Maybe we have an url encoded Key
                     try:
-                        return db.Key.from_legacy_urlsafe(value)
+                        return db.normalize_key(db.Key.from_legacy_urlsafe(value))
                     except Exception:
                         pass
+
                 return parse_value_by_annotation(int | str, name, value)
 
             elif isinstance(annotation, enum.EnumMeta):

--- a/src/viur/core/module.py
+++ b/src/viur/core/module.py
@@ -136,7 +136,7 @@ class Method:
 
                 elif isinstance(value, str):  # Maybe we have an url encoded Key
                     try:
-                        return db.normalize_key(db.Key.from_legacy_urlsafe(value))
+                        return db.normalize_key(value)
                     except Exception:
                         pass
 


### PR DESCRIPTION
This caused errors "ValueError: Keys do not match project" when passing the key of a different project to any Method annotated with `db.Key`-type.