### PR TITLE
fix(request): allow same-site requests in FetchMetaDataValidator

### DIFF
--- a/src/viur/core/request.py
+++ b/src/viur/core/request.py
@@ -74,15 +74,16 @@ class FetchMetaDataValidator(RequestValidator):
         headers = request.request.headers
 
         match headers.get("sec-fetch-site"):
-            case None | "same-origin" | "none":
-                # A Request from our site, or browser didn't send "sec-fetch-site"
+            case None | "same-origin" | "same-site" | "none":
+                # Browser didn't send "sec-fetch-site", or the request is
+                # same-origin, same-site (e.g. subdomain or redirect within the
+                # same registrable domain) or browser-initiated ("none").
+                # These are allowed per the reference policy on
+                # https://web.dev/fetch-metadata/
                 return None
-            case "same-site":
-                # We are accepting a request with same-site only in local dev mode
-                if conf.instance.is_dev_server:
-                    return None
             case _:
-                # Incoming navigation GET request
+                # Incoming cross-site request: allow only simple top-level
+                # navigation GET requests, except <object> and <embed>.
                 if (
                     not request.isPostRequest
                     and headers.get("sec-fetch-mode") == "navigate"


### PR DESCRIPTION
The validator only accepted `same-site` requests on the dev server, so in production a legitimate same-site navigation was rejected with `403 Request rejected due to fetch metadata`. This happens e.g. when a request is redirected within the same registrable domain (non-www to www) or upgraded from http to https, both of which downgrade `Sec-Fetch-Site` to `same-site`.

Treat `same-site` like `same-origin` and `none`, as recommended by the reference resource isolation policy on https://web.dev/fetch-metadata/.