### PR TITLE
fix(i18n): Tolerate relative filenames in `add_missing_translation`

### DIFF
--- a/src/viur/core/i18n.py
+++ b/src/viur/core/i18n.py
@@ -510,7 +510,10 @@ def add_missing_translation(
 
     if isinstance(filename, str):
         filename = Path(filename)
-        if filename.is_relative_to(conf.instance.project_base_path):
+        if not filename.is_absolute():
+            # Already a relative path (e.g. a Jinja template name) — keep as-is
+            filename = str(filename)
+        elif filename.is_relative_to(conf.instance.project_base_path):
             filename = str(filename.relative_to(conf.instance.project_base_path, walk_up=True))
         else:
             filename = str(filename.relative_to(conf.instance.core_base_path, walk_up=True))


### PR DESCRIPTION
Template translations provide a relative filename (Jinja's `parser.stream.filename` or the traceback fallback's `frame.f_code.co_filename`, e.g. `html/foo.html`). The normalization assumed an absolute path and called `relative_to(..., walk_up=True)`, raising `ValueError: ... have different anchors`.

Keep already-relative paths as-is; only normalize absolute ones.