### PR TITLE
fix(bones): reject invalid domain labels in `EmailBone`

### DIFF
--- a/src/viur/core/bones/email.py
+++ b/src/viur/core/bones/email.py
@@ -1,7 +1,12 @@
+import re
 import string
 from encodings import idna
 from viur.core.bones.string import StringBone
 from viur.core import i18n
+
+_DNS_LABEL_RE = re.compile(r"(?!-)[a-z0-9-]{1,63}(?<!-)", re.IGNORECASE)
+"""A single DNS label per RFC 1035: 1-63 alphanumerics or hyphens, no leading or trailing hyphen."""
+
 
 class EmailBone(StringBone):
     """
@@ -41,9 +46,7 @@ class EmailBone(StringBone):
         try:
             assert len(value) < 256
             account, domain = value.split(u"@")
-            subDomain, tld = domain.rsplit(".", 1)
-            assert account and subDomain and tld
-            assert subDomain[0] != "."
+            assert account and domain
             assert len(account) <= 64
         except (ValueError, AssertionError):
             is_valid = False
@@ -56,26 +59,20 @@ class EmailBone(StringBone):
                 if not (char in validChars or (char >= unicodeLowerBound and char <= unicodeUpperBound)):
                     is_valid = False
             # Validate each domain label (RFC 1035). idna.ToASCII does not reject a
-            # leading or trailing hyphen (e.g. "-online"), so the label structure is
-            # checked explicitly; otherwise addresses like "foo@-online.de" pass.
+            # leading or trailing hyphen (e.g. "-online") or an over-long label, so the
+            # label structure is checked with _DNS_LABEL_RE on the IDNA-encoded form;
+            # otherwise addresses like "foo@-online.de" pass.
             labels = domain.split(".")
             if len(labels) < 2 or labels[-1].isdigit():
                 is_valid = False
             else:
                 for label in labels:
-                    if not label or " " in label:
-                        is_valid = False
-                        break
                     try:
                         asciiLabel = idna.ToASCII(label).decode("ascii")
                     except Exception:
                         is_valid = False
                         break
-                    if (
-                        asciiLabel.startswith("-")
-                        or asciiLabel.endswith("-")
-                        or not all(char.isalnum() or char == "-" for char in asciiLabel)
-                    ):
+                    if not _DNS_LABEL_RE.fullmatch(asciiLabel):
                         is_valid = False
                         break
 

--- a/src/viur/core/bones/email.py
+++ b/src/viur/core/bones/email.py
@@ -55,14 +55,29 @@ class EmailBone(StringBone):
             for char in account:
                 if not (char in validChars or (char >= unicodeLowerBound and char <= unicodeUpperBound)):
                     is_valid = False
-            try:
-                idna.ToASCII(subDomain)
-                idna.ToASCII(tld)
-            except Exception:
+            # Validate each domain label (RFC 1035). idna.ToASCII does not reject a
+            # leading or trailing hyphen (e.g. "-online"), so the label structure is
+            # checked explicitly; otherwise addresses like "foo@-online.de" pass.
+            labels = domain.split(".")
+            if len(labels) < 2 or labels[-1].isdigit():
                 is_valid = False
-
-            if " " in subDomain or " " in tld:
-                is_valid = False
+            else:
+                for label in labels:
+                    if not label or " " in label:
+                        is_valid = False
+                        break
+                    try:
+                        asciiLabel = idna.ToASCII(label).decode("ascii")
+                    except Exception:
+                        is_valid = False
+                        break
+                    if (
+                        asciiLabel.startswith("-")
+                        or asciiLabel.endswith("-")
+                        or not all(char.isalnum() or char == "-" for char in asciiLabel)
+                    ):
+                        is_valid = False
+                        break
 
         if not is_valid:
             return i18n.translate("core.bones.error.invalidemail", "Invalid email entered")

--- a/tests/bones/test_email_bone.py
+++ b/tests/bones/test_email_bone.py
@@ -1,0 +1,48 @@
+from abstract import ViURTestCase
+
+
+class TestEmailBone(ViURTestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.bone_name = "emailTestBone"
+
+    def assert_valid(self, bone, value):
+        res = bone.singleValueFromClient(value, {}, self.bone_name, None)
+        self.assertEqual((value, None), res, f"{value!r} should be accepted")
+
+    def assert_invalid(self, bone, value):
+        from viur.core.bones import ReadFromClientError, ReadFromClientErrorSeverity
+        res = bone.singleValueFromClient(value, {}, self.bone_name, None)
+        self.assertIsInstance(res[1], list)
+        self.assertTrue(res[1], f"{value!r} should be rejected")
+        self.assertIsInstance(rfce := res[1][0], ReadFromClientError)
+        self.assertIs(ReadFromClientErrorSeverity.Invalid, rfce.severity)
+
+    def test_singleValueFromClient(self):
+        from viur.core.bones import EmailBone
+        bone = EmailBone()
+
+        for value in (
+            "test@example.com",
+            "test@online.de",
+            "info@t-online.de",
+            "test@sub.domain.co.uk",
+            "john.doe+tag@example.com",
+            "user@xn--mnchen-3ya.de",  # already IDNA-encoded
+            "user@münchen.de",  # unicode domain
+        ):
+            self.assert_valid(bone, value)
+
+        for value in (
+            "",
+            "no-at-sign.de",
+            "test@domain",  # missing TLD
+            "test@.de",  # empty label
+            "test@dom..de",  # empty inner label
+            "test@-example.de",  # label with leading hyphen
+            "test@example-.de",  # label with trailing hyphen
+            "test@-.de",
+            "test@exa mple.de",  # space in domain
+            "user@127.0.0.1",  # purely numeric TLD / bare IP not supported
+        ):
+            self.assert_invalid(bone, value)

--- a/tests/bones/test_email_bone.py
+++ b/tests/bones/test_email_bone.py
@@ -30,6 +30,7 @@ class TestEmailBone(ViURTestCase):
             "john.doe+tag@example.com",
             "user@xn--mnchen-3ya.de",  # already IDNA-encoded
             "user@münchen.de",  # unicode domain
+            f"test@{'a' * 63}.de",  # label at the 63-char limit
         ):
             self.assert_valid(bone, value)
 
@@ -44,5 +45,7 @@ class TestEmailBone(ViURTestCase):
             "test@-.de",
             "test@exa mple.de",  # space in domain
             "user@127.0.0.1",  # purely numeric TLD / bare IP not supported
+            f"test@{'a' * 64}.de",  # label exceeding the 63-char limit
+            "test@ex_ample.de",  # underscore is not a valid label character
         ):
             self.assert_invalid(bone, value)


### PR DESCRIPTION
`encodings.idna.ToASCII` does not reject domain labels with a leading or trailing hyphen (e.g. `-online`), so addresses like `foo@-online.de` passed validation. Such addresses are later rejected by mail providers, which can make the email send-task retry indefinitely.

Validate each domain label explicitly: every label must be non-empty, must not start or end with a hyphen, and must contain only alphanumerics and hyphens after IDNA encoding; the TLD must not be purely numeric. Add tests covering valid and invalid addresses.