### PR TITLE
feat: `edit`-function in List/Tree/Singleton using `Skeleton.patch()`

### DIFF
--- a/src/viur/core/bones/base.py
+++ b/src/viur/core/bones/base.py
@@ -11,6 +11,7 @@ import hashlib
 import inspect
 import logging
 import typing as t
+import warnings
 from collections.abc import Iterable
 from dataclasses import dataclass, field
 from datetime import timedelta
@@ -73,11 +74,15 @@ class ReadFromClientErrorSeverity(Enum):
 
 
 @dataclass
-class ReadFromClientError:
+class ReadFromClientError(ValueError):
     """
     The ReadFromClientError class represents an error that occurs while reading data from the client.
     This class is used to store information about the error, including its severity, an error message,
     the field path where the error occurred, and a list of invalidated fields.
+
+    It is also an Exception, so a single error can be raised directly. Use :meth:`raise_from` to raise
+    one or several errors at once (e.g. the accumulated skel.errors of a Skeleton) - if there are
+    several, the raised ReadFromClientError carries them in its `errors` attribute.
     """
     severity: ReadFromClientErrorSeverity
     """A ReadFromClientErrorSeverity enumeration value representing the severity of the error."""
@@ -87,6 +92,8 @@ class ReadFromClientError:
     """A list of strings representing the path to the field where the error occurred."""
     invalidatedFields: list[str] = None
     """A list of strings containing the names of invalidated fields, if any."""
+    errors: tuple["ReadFromClientError", ...] = None
+    """If set, this instance represents several errors at once; see :meth:`raise_from`."""
 
     def __post_init__(self):
         if not self.errorMessage:
@@ -102,12 +109,45 @@ class ReadFromClientError:
             }[self.severity]
 
     def __str__(self):
+        if self.errors:
+            return "\n".join(str(error) for error in self.errors)
+
         return f"{'.'.join(self.fieldPath)}: {self.errorMessage} [{self.severity.name}]"
+
+    @staticmethod
+    def raise_from(errors: "ReadFromClientError | t.Iterable[ReadFromClientError]") -> t.NoReturn:
+        """
+        Raises one or several ReadFromClientErrors at once.
+
+        Raises the sole error directly if only one is given; otherwise raises a single
+        ReadFromClientError representing all of them (see its `errors` attribute).
+
+        :param errors: Either one or an iterable of errors.
+        """
+        if isinstance(errors, ReadFromClientError):
+            raise errors
+
+        error_tuple = tuple(error for error in errors if isinstance(error, ReadFromClientError))
+
+        if not error_tuple:
+            raise ValueError("raise_from() requires at least one ReadFromClientError")
+
+        if len(error_tuple) == 1:
+            raise error_tuple[0]
+
+        raise ReadFromClientError(
+            severity=max(error_tuple, key=lambda error: error.severity.value).severity,
+            errorMessage=f"{len(error_tuple)} errors occurred",
+            errors=error_tuple,
+        )
 
 
 class ReadFromClientException(Exception):
     """
-    ReadFromClientError as an Exception to raise.
+    Deprecated: ReadFromClientError as an Exception to raise.
+
+    ReadFromClientError is an Exception itself now; raise it directly, or use
+    :meth:`ReadFromClientError.raise_from` to raise several errors at once.
     """
 
     def __init__(self, errors: ReadFromClientError | t.Iterable[ReadFromClientError]):
@@ -116,11 +156,15 @@ class ReadFromClientException(Exception):
 
         :param errors: Either one or an iterable of errors.
         """
+        msg = "ReadFromClientException is deprecated; use ReadFromClientError.raise_from() instead."
+        warnings.warn(msg, DeprecationWarning, stacklevel=2)
+        logging.warning(msg, stacklevel=2)
+
         super().__init__()
 
         # Allow to specifiy a single ReadFromClientError
         if isinstance(errors, ReadFromClientError):
-            errors = (ReadFromClientError, )
+            errors = (errors, )
 
         self.errors = tuple(error for error in errors if isinstance(error, ReadFromClientError))
 

--- a/src/viur/core/prototypes/list.py
+++ b/src/viur/core/prototypes/list.py
@@ -1,7 +1,7 @@
 import logging
 import typing as t
 from viur.core import current, db, errors, utils
-from viur.core.bones import ReadFromClientException
+from viur.core.bones import ReadFromClientError
 from viur.core.decorators import *
 from viur.core.cache import flushCache
 from viur.core.skeleton import SkeletonInstance, SkeletonNotFoundError
@@ -256,7 +256,7 @@ class List(SkelModule):
             )
         except SkeletonNotFoundError:
             raise errors.NotFound()
-        except ReadFromClientException:
+        except ReadFromClientError:
             return self.render.edit(skel)
 
         self.onEdited(skel)

--- a/src/viur/core/prototypes/list.py
+++ b/src/viur/core/prototypes/list.py
@@ -4,7 +4,7 @@ from viur.core import current, db, errors, utils
 from viur.core.bones import ReadFromClientException
 from viur.core.decorators import *
 from viur.core.cache import flushCache
-from viur.core.skeleton import SkeletonInstance
+from viur.core.skeleton import SkeletonInstance, SkeletonNotFoundError
 from .skelmodule import SkelModule
 
 
@@ -228,24 +228,34 @@ class List(SkelModule):
             :raises: :exc:`viur.core.errors.PreconditionFailed`, if the *skey* could not be verified.
         """
         skel = self.editSkel()
-        if not skel.read(key):
-            raise errors.NotFound()
 
-        if not self.canEdit(skel):
-            raise errors.Unauthorized()
+        if not kwargs or not current.request.get().isPostRequest or bounce:
+            if not skel.read(key):
+                raise errors.NotFound()
 
-        if (
-            not kwargs  # no data supplied
-            or not current.request.get().isPostRequest  # failure if not using POST-method
-        ):
+            if not self.canEdit(skel):
+                raise errors.Unauthorized()
+
+            if kwargs:
+                skel.fromClient(kwargs, amend=True)
+
             return self.render.edit(skel)
 
-        if bounce:  # review before changing: preview the submitted data, without writing it
-            skel.fromClient(kwargs, amend=True)
-            return self.render.edit(skel)
+        def check(skel):
+            if not self.canEdit(skel):
+                raise errors.Unauthorized()
 
         try:
-            skel.patch(kwargs, ignore=None, internal=False, preprocess=self.onEdit)
+            skel.patch(
+                kwargs,
+                key=key,
+                ignore=None,
+                internal=False,
+                check=check,
+                preprocess=self.onEdit,
+            )
+        except SkeletonNotFoundError:
+            raise errors.NotFound()
         except ReadFromClientException:
             return self.render.edit(skel)
 

--- a/src/viur/core/prototypes/list.py
+++ b/src/viur/core/prototypes/list.py
@@ -1,6 +1,7 @@
 import logging
 import typing as t
 from viur.core import current, db, errors, utils
+from viur.core.bones import ReadFromClientException
 from viur.core.decorators import *
 from viur.core.cache import flushCache
 from viur.core.skeleton import SkeletonInstance
@@ -236,14 +237,18 @@ class List(SkelModule):
         if (
             not kwargs  # no data supplied
             or not current.request.get().isPostRequest  # failure if not using POST-method
-            or not skel.fromClient(kwargs, amend=True)  # failure on reading into the bones
-            or bounce  # review before changing
         ):
-            # render the skeleton in the version it could as far as it could be read.
             return self.render.edit(skel)
 
-        self.onEdit(skel)
-        skel.write()  # write it!
+        if bounce:  # review before changing: preview the submitted data, without writing it
+            skel.fromClient(kwargs, amend=True)
+            return self.render.edit(skel)
+
+        try:
+            skel.patch(kwargs, ignore=None, internal=False, preprocess=self.onEdit)
+        except ReadFromClientException:
+            return self.render.edit(skel)
+
         self.onEdited(skel)
 
         return self.render.editSuccess(skel)

--- a/src/viur/core/prototypes/singleton.py
+++ b/src/viur/core/prototypes/singleton.py
@@ -150,26 +150,37 @@ class Singleton(SkelModule):
         :raises: :exc:`viur.core.errors.Unauthorized`, if the current user does not have the required permissions.
         :raises: :exc:`viur.core.errors.PreconditionFailed`, if the *skey* could not be verified.
         """
-        if not self.canEdit():
-            raise errors.Unauthorized()
-
         skel = self.editSkel()
+
+        if not kwargs or not current.request.get().isPostRequest or bounce:
+            if not self.canEdit():
+                raise errors.Unauthorized()
+
+            key = db.Key(skel.kindName, self.getKey())
+            if not skel.read(key):
+                skel["key"] = key
+
+            if kwargs:
+                skel.fromClient(kwargs, amend=True)
+
+            return self.render.edit(skel)
+
         key = db.Key(skel.kindName, self.getKey())
-        if not skel.read(key):  # Its not there yet; we need to set the key again
-            skel["key"] = key
 
-        if (
-            not kwargs  # no data supplied
-            or not current.request.get().isPostRequest  # failure if not using POST-method
-        ):
-            return self.render.edit(skel)
-
-        if bounce:
-            skel.fromClient(kwargs, amend=True)
-            return self.render.edit(skel)
+        def check(skel):
+            if not self.canEdit():
+                raise errors.Unauthorized()
 
         try:
-            skel.patch(kwargs, key=key, ignore=None, internal=False, create=True, preprocess=self.onEdit)
+            skel.patch(
+                kwargs,
+                key=key,
+                ignore=None,
+                internal=False,
+                create=True,
+                check=check,
+                preprocess=self.onEdit,
+            )
         except ReadFromClientException:
             return self.render.edit(skel)
 

--- a/src/viur/core/prototypes/singleton.py
+++ b/src/viur/core/prototypes/singleton.py
@@ -1,6 +1,7 @@
 import logging
 import typing as t
 from viur.core import db, current, utils, errors
+from viur.core.bones import ReadFromClientException
 from viur.core.decorators import *
 from viur.core.cache import flushCache
 from viur.core.skeleton import SkeletonInstance
@@ -160,13 +161,18 @@ class Singleton(SkelModule):
         if (
             not kwargs  # no data supplied
             or not current.request.get().isPostRequest  # failure if not using POST-method
-            or not skel.fromClient(kwargs, amend=True)  # failure on reading into the bones
-            or bounce  # review before changing
         ):
             return self.render.edit(skel)
 
-        self.onEdit(skel)
-        skel.write()
+        if bounce:
+            skel.fromClient(kwargs, amend=True)
+            return self.render.edit(skel)
+
+        try:
+            skel.patch(kwargs, key=key, ignore=None, internal=False, create=True, preprocess=self.onEdit)
+        except ReadFromClientException:
+            return self.render.edit(skel)
+
         self.onEdited(skel)
         return self.render.editSuccess(skel)
 

--- a/src/viur/core/prototypes/singleton.py
+++ b/src/viur/core/prototypes/singleton.py
@@ -1,7 +1,7 @@
 import logging
 import typing as t
 from viur.core import db, current, utils, errors
-from viur.core.bones import ReadFromClientException
+from viur.core.bones import ReadFromClientError
 from viur.core.decorators import *
 from viur.core.cache import flushCache
 from viur.core.skeleton import SkeletonInstance
@@ -181,7 +181,7 @@ class Singleton(SkelModule):
                 check=check,
                 preprocess=self.onEdit,
             )
-        except ReadFromClientException:
+        except ReadFromClientError:
             return self.render.edit(skel)
 
         self.onEdited(skel)

--- a/src/viur/core/prototypes/tree.py
+++ b/src/viur/core/prototypes/tree.py
@@ -5,7 +5,7 @@ import typing as t
 from deprecated.sphinx import deprecated
 
 from viur.core import current, db, errors
-from viur.core.bones import BooleanBone, KeyBone, SortIndexBone
+from viur.core.bones import BooleanBone, KeyBone, ReadFromClientException, SortIndexBone
 from viur.core.cache import flushCache
 from viur.core.decorators import *
 from viur.core.skeleton import Skeleton, SkeletonInstance
@@ -569,13 +569,18 @@ class Tree(SkelModule):
         if (
             not kwargs  # no data supplied
             or not current.request.get().isPostRequest  # failure if not using POST-method
-            or not skel.fromClient(kwargs, amend=True)  # failure on reading into the bones
-            or bounce  # review before adding
         ):
             return self.render.edit(skel)
 
-        self.onEdit(skelType, skel)
-        skel.write()
+        if bounce:
+            skel.fromClient(kwargs, amend=True)
+            return self.render.edit(skel)
+
+        try:
+            skel.patch(kwargs, ignore=None, internal=False, preprocess=lambda skel: self.onEdit(skelType, skel))
+        except ReadFromClientException:
+            return self.render.edit(skel)
+
         self.onEdited(skelType, skel)
 
         return self.render.editSuccess(skel)

--- a/src/viur/core/prototypes/tree.py
+++ b/src/viur/core/prototypes/tree.py
@@ -5,7 +5,7 @@ import typing as t
 from deprecated.sphinx import deprecated
 
 from viur.core import current, db, errors
-from viur.core.bones import BooleanBone, KeyBone, ReadFromClientException, SortIndexBone
+from viur.core.bones import BooleanBone, KeyBone, ReadFromClientError, SortIndexBone
 from viur.core.cache import flushCache
 from viur.core.decorators import *
 from viur.core.skeleton import Skeleton, SkeletonInstance, SkeletonNotFoundError
@@ -588,7 +588,7 @@ class Tree(SkelModule):
             )
         except SkeletonNotFoundError:
             raise errors.NotFound()
-        except ReadFromClientException:
+        except ReadFromClientError:
             return self.render.edit(skel)
 
         self.onEdited(skelType, skel)

--- a/src/viur/core/prototypes/tree.py
+++ b/src/viur/core/prototypes/tree.py
@@ -8,7 +8,7 @@ from viur.core import current, db, errors
 from viur.core.bones import BooleanBone, KeyBone, ReadFromClientException, SortIndexBone
 from viur.core.cache import flushCache
 from viur.core.decorators import *
-from viur.core.skeleton import Skeleton, SkeletonInstance
+from viur.core.skeleton import Skeleton, SkeletonInstance, SkeletonNotFoundError
 from viur.core.tasks import CallDeferred
 from .skelmodule import SkelModule
 
@@ -557,27 +557,37 @@ class Tree(SkelModule):
         :raises: :exc:`viur.core.errors.PreconditionFailed`, if the *skey* could not be verified.
         """
         if not (skelType := self._checkSkelType(skelType)):
-            raise errors.NotAcceptable(f"Invalid skelType provided.")
+            raise errors.NotAcceptable("Invalid skelType provided.")
 
         skel = self.editSkel(skelType)
-        if not skel.read(key):
-            raise errors.NotFound()
 
-        if not self.canEdit(skelType, skel):
-            raise errors.Unauthorized()
+        if not kwargs or not current.request.get().isPostRequest or bounce:
+            if not skel.read(key):
+                raise errors.NotFound()
 
-        if (
-            not kwargs  # no data supplied
-            or not current.request.get().isPostRequest  # failure if not using POST-method
-        ):
+            if not self.canEdit(skelType, skel):
+                raise errors.Unauthorized()
+
+            if kwargs:
+                skel.fromClient(kwargs, amend=True)
+
             return self.render.edit(skel)
 
-        if bounce:
-            skel.fromClient(kwargs, amend=True)
-            return self.render.edit(skel)
+        def check(skel):
+            if not self.canEdit(skelType, skel):
+                raise errors.Unauthorized()
 
         try:
-            skel.patch(kwargs, ignore=None, internal=False, preprocess=lambda skel: self.onEdit(skelType, skel))
+            skel.patch(
+                kwargs,
+                key=key,
+                ignore=None,
+                internal=False,
+                check=check,
+                preprocess=lambda skel: self.onEdit(skelType, skel),
+            )
+        except SkeletonNotFoundError:
+            raise errors.NotFound()
         except ReadFromClientException:
             return self.render.edit(skel)
 

--- a/src/viur/core/skeleton/__init__.py
+++ b/src/viur/core/skeleton/__init__.py
@@ -5,7 +5,7 @@ from .adapter import DatabaseAdapter, ViurTagsSearchAdapter
 from .instance import SkeletonInstance
 from .meta import ABSTRACT_SKEL_CLS_SUFFIX, BaseSkeleton, MetaBaseSkel, MetaSkel, Skeleton_Cls
 from .relskel import RefSkel, RelSkel
-from .skeleton import SeoKeyBone, Skeleton, _UNDEFINED_KINDNAME
+from .skeleton import SeoKeyBone, Skeleton, SkeletonNotFoundError, _UNDEFINED_KINDNAME
 from .tasks import SkelIterTask, SkeletonMaintenanceTask, update_relations
 from .utils import (  # noqa
     SkelList,
@@ -58,6 +58,7 @@ __all__ = [
     Skeleton_Cls,
     SkeletonInstance,
     SkeletonMaintenanceTask,
+    SkeletonNotFoundError,
     ViurTagsSearchAdapter,
     _UNDEFINED_KINDNAME,
     is_skeletoninstance_of,

--- a/src/viur/core/skeleton/skeleton.py
+++ b/src/viur/core/skeleton/skeleton.py
@@ -63,6 +63,13 @@ class SeoKeyBone(StringBone):
         return True
 
 
+class SkeletonNotFoundError(ValueError):
+    """
+    Raised by :meth:`Skeleton.patch` when the entry addressed by *key* (or skel["key"]) does not
+    exist, and *create* was not provided to allow creating it on demand.
+    """
+
+
 class Skeleton(BaseSkeleton, metaclass=MetaSkel):
     kindName: str = _UNDEFINED_KINDNAME
     """
@@ -771,6 +778,8 @@ class Skeleton(BaseSkeleton, metaclass=MetaSkel):
 
         Raises:
             ValueError: In case parameters where given wrong or incomplete.
+            SkeletonNotFoundError: In case the entry addressed by *key* does not exist, and *create*
+                was not provided to allow creating it on demand. A subclass of ValueError.
             AssertionError: In case an asserted check parameter did not match.
             ReadFromClientException: In case a skel.fromClient() failed with a high severity.
         """
@@ -780,7 +789,9 @@ class Skeleton(BaseSkeleton, metaclass=MetaSkel):
             # Try to read the skeleton, create on demand
             if not skel.read(key):
                 if create is None or create is False:
-                    raise ValueError("Creation during update is forbidden - explicitly provide `create=True` to allow.")
+                    raise SkeletonNotFoundError(
+                        "Creation during update is forbidden - explicitly provide `create=True` to allow."
+                    )
 
                 if not (key or skel["key"]) and create in (False, None):
                     return ValueError("No valid key provided")

--- a/src/viur/core/skeleton/skeleton.py
+++ b/src/viur/core/skeleton/skeleton.py
@@ -17,7 +17,6 @@ from ..bones.base import (
     ComputeMethod,
     ReadFromClientError,
     ReadFromClientErrorSeverity,
-    ReadFromClientException,
 )
 from ..bones.date import DateBone
 from ..bones.key import KeyBone
@@ -311,7 +310,7 @@ class Skeleton(BaseSkeleton, metaclass=MetaSkel):
             return None
         elif isinstance(create, dict):
             if create and not skel.fromClient(create, amend=True, ignore=()):
-                raise ReadFromClientException(skel.errors)
+                ReadFromClientError.raise_from(skel.errors)
         elif callable(create):
             create(skel)
         elif create is not True:
@@ -781,7 +780,9 @@ class Skeleton(BaseSkeleton, metaclass=MetaSkel):
             SkeletonNotFoundError: In case the entry addressed by *key* does not exist, and *create*
                 was not provided to allow creating it on demand. A subclass of ValueError.
             AssertionError: In case an asserted check parameter did not match.
-            ReadFromClientException: In case a skel.fromClient() failed with a high severity.
+            ReadFromClientError: In case a skel.fromClient() failed with a high severity. If several
+                bones failed, a single ReadFromClientError representing all of them is raised instead
+                (see its `errors` attribute).
         """
 
         # Transactional function
@@ -801,7 +802,7 @@ class Skeleton(BaseSkeleton, metaclass=MetaSkel):
 
                 if isinstance(create, dict):
                     if create and not skel.fromClient(create, amend=True, ignore=ignore):
-                        raise ReadFromClientException(skel.errors)
+                        ReadFromClientError.raise_from(skel.errors)
                 elif callable(create):
                     create(skel)
                 elif create is not True:
@@ -819,7 +820,7 @@ class Skeleton(BaseSkeleton, metaclass=MetaSkel):
             # Set values
             if isinstance(values, dict):
                 if values and not skel.fromClient(values, amend=True, ignore=ignore) and not internal:
-                    raise ReadFromClientException(skel.errors)
+                    ReadFromClientError.raise_from(skel.errors)
 
                 # In case we're in internal-mode, only raise fatal errors.
                 if skel.errors and internal:
@@ -828,7 +829,7 @@ class Skeleton(BaseSkeleton, metaclass=MetaSkel):
                                 ReadFromClientErrorSeverity.Invalid,
                                 ReadFromClientErrorSeverity.InvalidatesOther,
                         ):
-                            raise ReadFromClientException(skel.errors)
+                            ReadFromClientError.raise_from(skel.errors)
 
                     # otherwise, ignore any reported errors
                     skel.errors.clear()


### PR DESCRIPTION
This runs the edit-action of List/Tree/Singleton-prototypes in a transaction.
Previously, it could be possible that data would become lost due race conditions.