### PR TITLE
fix: Tree: Handle broken `parententry`-chains on `move`

### DIFF
--- a/src/viur/core/prototypes/tree.py
+++ b/src/viur/core/prototypes/tree.py
@@ -702,7 +702,7 @@ class Tree(SkelModule):
         # Check if parentNodeSkel is descendant of the skel
         walk_skel = parentnode_skel.clone()
 
-        while walk_skel["parententry"]:
+        while walk_skel and walk_skel["parententry"]:
             if walk_skel["parententry"] == skel["key"]:
                 raise errors.NotAcceptable(
                     f"Invalid move: Entry {key} cannot be moved below its own descendant {parentNode}."

--- a/src/viur/core/prototypes/tree.py
+++ b/src/viur/core/prototypes/tree.py
@@ -710,6 +710,9 @@ class Tree(SkelModule):
 
             walk_skel = walk_skel.read(walk_skel["parententry"])
 
+        if not walk_skel:
+            logging.warning(f"The parententry chain of {skel["key"]!r} seems to be broken")
+
         old_parentrepo = skel["parentrepo"]
 
         self.onEdit(skelType, skel)


### PR DESCRIPTION
Fixes #1723