### PR TITLE
fix(tree): delete a node only after its entire subtree is gone

### DIFF
--- a/src/viur/core/modules/file.py
+++ b/src/viur/core/modules/file.py
@@ -933,55 +933,17 @@ class File(Tree):
         blob = bucket.blob(path)
         return io.BytesIO(blob.download_as_bytes()), blob.content_type
 
-    @CallDeferred
-    def deleteRecursive(self, parentKey, delete_self: bool = False, call_hooks: bool = False):
+    def onDeleteRecursive(self, skelType: SkelType, skel: SkeletonInstance) -> None:
         """
-        Recursively deletes all files and directories below *parentKey*,
-        bottom-up, within a single deferred call (see
-        :meth:`Tree.deleteRecursive` for why recursing via a separate
-        deferred task per directory level -- the previous behavior here --
-        allowed a directory to be deleted before its own contents were
-        confirmed gone, permanently orphaning them if that task was ever
-        lost).
+        Mark the blob of each cascaded file for deletion.
 
-        :param delete_self: If True, also delete the directory identified
-            by *parentKey* itself, after everything below it is gone.
-        :param call_hooks: If True, call :meth:`onDelete`/:meth:`onDeleted`
-            for the *parentKey* directory itself.
+        The generic recursive delete of the Tree prototype is inherited as-is
+        (see :meth:`Tree.deleteRecursive`); the only File-specific step is
+        marking a leaf's blob for deletion, which is injected via this hook.
+        Directories (nodes) have no blob and are ignored.
         """
-        if delete_self and self._is_locked_by_relation(parentKey):
-            # See Tree.deleteRecursive: checked before touching the subtree,
-            # so nothing is deleted at all if this directory is locked.
-            logging.warning(f"Not deleting {parentKey!r} and its subtree: "
-                            f"still referenced by a PreventDeletion relation")
-            return
-        self._deleteSubtree(parentKey)
-        if delete_self:
-            skel = self.nodeSkelCls()
-            if skel.read(parentKey):
-                if call_hooks:
-                    self.onDelete("node", skel)
-                skel.delete()
-                if call_hooks:
-                    self.onDeleted("node", skel)
-
-    def _deleteSubtree(self, parentKey) -> None:
-        """Synchronously delete all files/directories below *parentKey* (not
-        *parentKey* itself), bottom-up. Internal helper for
-        :meth:`deleteRecursive`."""
-        files = db.Query(self.leafSkelCls().kindName).filter("parententry =", parentKey).iter()
-        for fileEntry in files:
-            self.mark_for_deletion(fileEntry["dlkey"])
-            skel = self.leafSkelCls()
-
-            if skel.read(str(fileEntry.key())):
-                skel.delete()
-        dirs = db.Query(self.nodeSkelCls().kindName).filter("parententry =", parentKey).iter()
-        for d in dirs:
-            self._deleteSubtree(d.key)
-            skel = self.nodeSkelCls()
-            if skel.read(d.key):
-                skel.delete()
+        if skelType == "leaf":
+            self.mark_for_deletion(skel["dlkey"])
 
     @exposed
     @skey

--- a/src/viur/core/modules/file.py
+++ b/src/viur/core/modules/file.py
@@ -949,6 +949,12 @@ class File(Tree):
         :param call_hooks: If True, call :meth:`onDelete`/:meth:`onDeleted`
             for the *parentKey* directory itself.
         """
+        if delete_self and self._is_locked_by_relation(parentKey):
+            # See Tree.deleteRecursive: checked before touching the subtree,
+            # so nothing is deleted at all if this directory is locked.
+            logging.warning(f"Not deleting {parentKey!r} and its subtree: "
+                            f"still referenced by a PreventDeletion relation")
+            return
         self._deleteSubtree(parentKey)
         if delete_self:
             skel = self.nodeSkelCls()

--- a/src/viur/core/modules/file.py
+++ b/src/viur/core/modules/file.py
@@ -969,14 +969,14 @@ class File(Tree):
         """Synchronously delete all files/directories below *parentKey* (not
         *parentKey* itself), bottom-up. Internal helper for
         :meth:`deleteRecursive`."""
-        files = db.Query(self.leafSkelCls().kindName).filter("parentdir =", parentKey).iter()
+        files = db.Query(self.leafSkelCls().kindName).filter("parententry =", parentKey).iter()
         for fileEntry in files:
             self.mark_for_deletion(fileEntry["dlkey"])
             skel = self.leafSkelCls()
 
             if skel.read(str(fileEntry.key())):
                 skel.delete()
-        dirs = db.Query(self.nodeSkelCls().kindName).filter("parentdir", parentKey).iter()
+        dirs = db.Query(self.nodeSkelCls().kindName).filter("parententry =", parentKey).iter()
         for d in dirs:
             self._deleteSubtree(d.key)
             skel = self.nodeSkelCls()

--- a/src/viur/core/modules/file.py
+++ b/src/viur/core/modules/file.py
@@ -934,7 +934,35 @@ class File(Tree):
         return io.BytesIO(blob.download_as_bytes()), blob.content_type
 
     @CallDeferred
-    def deleteRecursive(self, parentKey):
+    def deleteRecursive(self, parentKey, delete_self: bool = False, call_hooks: bool = False):
+        """
+        Recursively deletes all files and directories below *parentKey*,
+        bottom-up, within a single deferred call (see
+        :meth:`Tree.deleteRecursive` for why recursing via a separate
+        deferred task per directory level -- the previous behavior here --
+        allowed a directory to be deleted before its own contents were
+        confirmed gone, permanently orphaning them if that task was ever
+        lost).
+
+        :param delete_self: If True, also delete the directory identified
+            by *parentKey* itself, after everything below it is gone.
+        :param call_hooks: If True, call :meth:`onDelete`/:meth:`onDeleted`
+            for the *parentKey* directory itself.
+        """
+        self._deleteSubtree(parentKey)
+        if delete_self:
+            skel = self.nodeSkelCls()
+            if skel.read(parentKey):
+                if call_hooks:
+                    self.onDelete("node", skel)
+                skel.delete()
+                if call_hooks:
+                    self.onDeleted("node", skel)
+
+    def _deleteSubtree(self, parentKey) -> None:
+        """Synchronously delete all files/directories below *parentKey* (not
+        *parentKey* itself), bottom-up. Internal helper for
+        :meth:`deleteRecursive`."""
         files = db.Query(self.leafSkelCls().kindName).filter("parentdir =", parentKey).iter()
         for fileEntry in files:
             self.mark_for_deletion(fileEntry["dlkey"])
@@ -944,7 +972,7 @@ class File(Tree):
                 skel.delete()
         dirs = db.Query(self.nodeSkelCls().kindName).filter("parentdir", parentKey).iter()
         for d in dirs:
-            self.deleteRecursive(d.key)
+            self._deleteSubtree(d.key)
             skel = self.nodeSkelCls()
             if skel.read(d.key):
                 skel.delete()

--- a/src/viur/core/prototypes/tree.py
+++ b/src/viur/core/prototypes/tree.py
@@ -612,8 +612,9 @@ class Tree(SkelModule):
         :raises: :exc:`viur.core.errors.NotFound`, when no entry with the given *key* was found.
         :raises: :exc:`viur.core.errors.Unauthorized`, if the current user does not have the required permissions.
         :raises: :exc:`viur.core.errors.PreconditionFailed`, if the *skey* could not be verified.
-        :raises: :exc:`viur.core.errors.Locked`, if the entry is a node that is still
-            referenced by a ``PreventDeletion`` relation.
+        :raises: whatever :meth:`checkDeletePreconditions` raises (by default
+            :exc:`viur.core.errors.Locked` for an entry still referenced by a
+            ``PreventDeletion`` relation).
         """
         if not (skelType := self._checkSkelType(skelType)):
             raise errors.NotAcceptable(f"Invalid skelType provided.")
@@ -625,9 +626,12 @@ class Tree(SkelModule):
         if not self.canDelete(skelType, skel):
             raise errors.Unauthorized()
 
+        # Fail fast for the entry the delete was invoked on, so the caller
+        # gets an immediate error and (for a node) no deferred cascade is
+        # even started. Descendants are validated in deleteRecursive.
+        self.checkDeletePreconditions(skelType, skel)
+
         if skelType == "node":
-            if self._is_locked_by_relation(skel["key"]):
-                raise errors.Locked("This entry is still referenced by other Skeletons, which prevents deleting!")
             self.deleteRecursive(skel["key"], delete_self=True, call_hooks=True)
         else:
             self.onDelete(skelType, skel)
@@ -636,16 +640,48 @@ class Tree(SkelModule):
 
         return self.render.deleteSuccess(skel, skelType=skelType)
 
+    def checkDeletePreconditions(self, skelType: SkelType, skel: SkeletonInstance) -> None:
+        """
+        Verify that *skel* may be deleted in its current state, raising if not.
+
+        This is a *state* precondition, distinct from :meth:`canDelete`, which
+        answers whether the current *user* is permitted to delete. Raise an
+        :class:`~viur.core.errors.HTTPException` (e.g.
+        :class:`~viur.core.errors.Locked`, :class:`~viur.core.errors.Forbidden`)
+        to veto the deletion.
+
+        The default refuses to delete an entry that is still referenced by a
+        ``RelationalConsistency.PreventDeletion`` relation (mirroring the check
+        inside ``Skeleton.delete()``, but *before* a cascade removes anything).
+
+        It is called
+
+        * synchronously in :meth:`delete` for the entry the delete was invoked
+          on (immediate error to the caller), and
+        * for **every** entry of a node's subtree in :meth:`deleteRecursive`,
+          in a read-only pre-pass *before* anything is deleted -- so a veto
+          anywhere in the subtree aborts the whole delete without leaving a
+          partially-deleted, orphaned state behind.
+
+        Override it (calling ``super()``) to add domain-specific rules, e.g.::
+
+            def checkDeletePreconditions(self, skelType, skel):
+                super().checkDeletePreconditions(skelType, skel)
+                if skel["is_locked"]:
+                    raise errors.Forbidden("This entry is locked.")
+
+        :param skelType: Type of the entry ("node" or "leaf").
+        :param skel: The already-read skeleton of the entry.
+        """
+        if self._is_locked_by_relation(skel["key"]):
+            raise errors.Locked("This entry is still referenced by other Skeletons, which prevents deleting!")
+
     @staticmethod
     def _is_locked_by_relation(key: db.Key) -> bool:
         """
         Check whether *key* is referenced by a ``RelationalConsistency.PreventDeletion`` relation.
 
-        Mirrors the check inside ``Skeleton.delete()``. Used here to fail
-        fast -- before touching any part of a node's subtree -- instead of
-        only finding out once the node's own deletion is attempted as the
-        last step of a cascading delete that may already have removed
-        everything below it.
+        Mirrors the check inside ``Skeleton.delete()``.
 
         :param key: Key of the entity to check.
         :return: True if a ``PreventDeletion`` relation still points at *key*.
@@ -668,6 +704,16 @@ class Tree(SkelModule):
         spawn a separate deferred task for it, so there is no window in
         which a node could be deleted (or considered done) before its
         own children actually are.
+
+        Before anything is deleted, a read-only pre-pass validates the
+        whole subtree (and, if *delete_self*, *parentKey* itself) via
+        :meth:`checkDeletePreconditions`. If any entry vetoes deletion, the
+        call aborts and logs without deleting a single entry -- so a veto
+        (e.g. a ``PreventDeletion`` relation, or a domain rule added by a
+        subclass) can never leave a partially-deleted, orphaned subtree
+        behind. Validate-all-then-delete-all rather than checking each entry
+        only as it is about to be deleted (which, being bottom-up, would
+        already have removed the vetoed entry's own children).
 
         If *delete_self* is set, *parentKey* itself is deleted last, once
         everything below it is already gone. This is what makes deferring
@@ -695,15 +741,9 @@ class Tree(SkelModule):
             descendants are removed without hooks, same as before.
         """
         nodeKey = db.key_helper(parentKey, self.viewSkel("node").kindName)
-        if delete_self and self._is_locked_by_relation(nodeKey):
-            # :meth:`delete` already checked this synchronously before
-            # enqueuing; this is a safety net for a lock added in the
-            # meantime, or for other direct callers of this method. Checked
-            # before touching the subtree, so nothing is deleted at all --
-            # unlike checking only once we'd try to delete the node itself,
-            # which would have already wiped out everything below it.
-            logging.warning(f"Not deleting {nodeKey!r} and its subtree: "
-                            f"still referenced by a PreventDeletion relation")
+        if not self._checkSubtreeDeletable(nodeKey, check_self=delete_self):
+            # A veto was found (and logged) during the read-only pre-pass;
+            # nothing has been deleted, keeping the tree consistent.
             return
         self._deleteSubtree(nodeKey)
         if delete_self:
@@ -714,6 +754,37 @@ class Tree(SkelModule):
                 nodeSkel.delete()
                 if call_hooks:
                     self.onDeleted("node", nodeSkel)
+
+    def _checkSubtreeDeletable(self, nodeKey: db.Key, check_self: bool) -> bool:
+        """
+        Read-only pre-pass for :meth:`deleteRecursive`.
+
+        Returns True only if every entry of *nodeKey*'s subtree (and
+        *nodeKey* itself when *check_self*) passes
+        :meth:`checkDeletePreconditions`. On the first veto it logs and
+        returns False without having deleted anything.
+
+        :param nodeKey: Key of the node whose subtree is validated.
+        :param check_self: Whether to also validate *nodeKey* itself.
+        :return: True if the whole subtree may be deleted.
+        """
+        try:
+            if check_self:
+                nodeSkel = self.viewSkel("node")
+                if nodeSkel.read(nodeKey):
+                    self.checkDeletePreconditions("node", nodeSkel)
+            if self.leafSkelCls:
+                for leaf in db.Query(self.viewSkel("leaf").kindName).filter("parententry =", nodeKey).iter():
+                    leafSkel = self.viewSkel("leaf")
+                    if leafSkel.read(leaf.key):
+                        self.checkDeletePreconditions("leaf", leafSkel)
+        except errors.HTTPException as exc:
+            logging.warning(f"Refusing to delete subtree of {nodeKey!r}: {exc}")
+            return False
+        for node in db.Query(self.viewSkel("node").kindName).filter("parententry =", nodeKey).iter():
+            if not self._checkSubtreeDeletable(node.key, check_self=True):
+                return False
+        return True
 
     def onDeleteRecursive(self, skelType: SkelType, skel: SkeletonInstance) -> None:
         """

--- a/src/viur/core/prototypes/tree.py
+++ b/src/viur/core/prototypes/tree.py
@@ -715,6 +715,22 @@ class Tree(SkelModule):
                 if call_hooks:
                     self.onDeleted("node", nodeSkel)
 
+    def onDeleteRecursive(self, skelType: SkelType, skel: SkeletonInstance) -> None:
+        """
+        Hook, called for every *descendant* entry cascaded away during a
+        recursive delete, right before that entry is deleted.
+
+        In contrast to :meth:`onDelete`/:meth:`onDeleted` — which fire once,
+        for the very entry the delete was invoked on — this fires for each
+        cascaded child/grandchild/... removed by :meth:`deleteRecursive`.
+        The default implementation does nothing; override it to run
+        per-entry cleanup (e.g. releasing external resources tied to a leaf).
+
+        :param skelType: Type of the descendant being deleted ("node" or "leaf").
+        :param skel: The already-read skeleton of the descendant.
+        """
+        pass
+
     def _deleteSubtree(self, nodeKey: db.Key) -> None:
         """
         Synchronously delete all descendants of *nodeKey* (not *nodeKey*
@@ -724,7 +740,8 @@ class Tree(SkelModule):
         instead of spawning a new deferred task per tree level, so the
         whole subtree is processed within a single execution and strictly
         in the correct order (a sub-node is only deleted once every one of
-        *its* descendants is confirmed gone).
+        *its* descendants is confirmed gone). :meth:`onDeleteRecursive` is
+        called for each descendant right before it is deleted.
 
         :param nodeKey: Key of the node whose descendants get deleted.
         """
@@ -733,11 +750,13 @@ class Tree(SkelModule):
                 leafSkel = self.viewSkel("leaf")
                 if not leafSkel.read(leaf.key):
                     continue
+                self.onDeleteRecursive("leaf", leafSkel)
                 leafSkel.delete()
         for node in db.Query(self.viewSkel("node").kindName).filter("parententry =", nodeKey).iter():
             self._deleteSubtree(node.key)
             nodeSkel = self.viewSkel("node")
             if nodeSkel.read(node.key):
+                self.onDeleteRecursive("node", nodeSkel)
                 nodeSkel.delete()
 
     @exposed

--- a/src/viur/core/prototypes/tree.py
+++ b/src/viur/core/prototypes/tree.py
@@ -5,7 +5,7 @@ import typing as t
 from deprecated.sphinx import deprecated
 
 from viur.core import current, db, errors
-from viur.core.bones import BooleanBone, KeyBone, SortIndexBone
+from viur.core.bones import BooleanBone, KeyBone, RelationalConsistency, SortIndexBone
 from viur.core.cache import flushCache
 from viur.core.decorators import *
 from viur.core.skeleton import Skeleton, SkeletonInstance
@@ -596,6 +596,12 @@ class Tree(SkelModule):
         ``onDelete``/``onDeleted`` for the node still fire exactly once,
         just from within that deferred job instead of within this request.
 
+        If the node is locked by a ``RelationalConsistency.PreventDeletion``
+        relation, this is checked synchronously here (matching
+        ``Skeleton.delete()``'s own check) so the caller gets an immediate
+        error and no deferred job -- and therefore no cascading deletion of
+        the subtree -- is ever started for it.
+
         .. seealso:: :func:`canDelete`, :func:`onDelete`, :func:`onDeleted`
 
         :param skelType: Defines the type of the entry that should be deleted and may either be "node" or "leaf".
@@ -606,6 +612,8 @@ class Tree(SkelModule):
         :raises: :exc:`viur.core.errors.NotFound`, when no entry with the given *key* was found.
         :raises: :exc:`viur.core.errors.Unauthorized`, if the current user does not have the required permissions.
         :raises: :exc:`viur.core.errors.PreconditionFailed`, if the *skey* could not be verified.
+        :raises: :exc:`viur.core.errors.Locked`, if the entry is a node that is still
+            referenced by a ``PreventDeletion`` relation.
         """
         if not (skelType := self._checkSkelType(skelType)):
             raise errors.NotAcceptable(f"Invalid skelType provided.")
@@ -618,6 +626,8 @@ class Tree(SkelModule):
             raise errors.Unauthorized()
 
         if skelType == "node":
+            if self._is_locked_by_relation(skel["key"]):
+                raise errors.Locked("This entry is still referenced by other Skeletons, which prevents deleting!")
             self.deleteRecursive(skel["key"], delete_self=True, call_hooks=True)
         else:
             self.onDelete(skelType, skel)
@@ -625,6 +635,26 @@ class Tree(SkelModule):
             self.onDeleted(skelType, skel)
 
         return self.render.deleteSuccess(skel, skelType=skelType)
+
+    @staticmethod
+    def _is_locked_by_relation(key: db.Key) -> bool:
+        """
+        Check whether *key* is referenced by a ``RelationalConsistency.PreventDeletion`` relation.
+
+        Mirrors the check inside ``Skeleton.delete()``. Used here to fail
+        fast -- before touching any part of a node's subtree -- instead of
+        only finding out once the node's own deletion is attempted as the
+        last step of a cascading delete that may already have removed
+        everything below it.
+
+        :param key: Key of the entity to check.
+        :return: True if a ``PreventDeletion`` relation still points at *key*.
+        """
+        return (
+            db.Query("viur-relations")
+            .filter("dest.__key__ =", key)
+            .filter("viur_relational_consistency =", RelationalConsistency.PreventDeletion.value)
+        ).getEntry() is not None
 
     @CallDeferred
     def deleteRecursive(self, parentKey: str, delete_self: bool = False, call_hooks: bool = False):
@@ -665,6 +695,16 @@ class Tree(SkelModule):
             descendants are removed without hooks, same as before.
         """
         nodeKey = db.key_helper(parentKey, self.viewSkel("node").kindName)
+        if delete_self and self._is_locked_by_relation(nodeKey):
+            # :meth:`delete` already checked this synchronously before
+            # enqueuing; this is a safety net for a lock added in the
+            # meantime, or for other direct callers of this method. Checked
+            # before touching the subtree, so nothing is deleted at all --
+            # unlike checking only once we'd try to delete the node itself,
+            # which would have already wiped out everything below it.
+            logging.warning(f"Not deleting {nodeKey!r} and its subtree: "
+                            f"still referenced by a PreventDeletion relation")
+            return
         self._deleteSubtree(nodeKey)
         if delete_self:
             nodeSkel = self.viewSkel("node")

--- a/src/viur/core/prototypes/tree.py
+++ b/src/viur/core/prototypes/tree.py
@@ -590,6 +590,12 @@ class Tree(SkelModule):
 
         The function runs several access control checks on the data before it is deleted.
 
+        For a node, the node itself and its entire subtree are deleted
+        bottom-up as a single deferred job -- see :meth:`deleteRecursive`
+        for why the node must not be deleted synchronously here.
+        ``onDelete``/``onDeleted`` for the node still fire exactly once,
+        just from within that deferred job instead of within this request.
+
         .. seealso:: :func:`canDelete`, :func:`onDelete`, :func:`onDeleted`
 
         :param skelType: Defines the type of the entry that should be deleted and may either be "node" or "leaf".
@@ -612,24 +618,76 @@ class Tree(SkelModule):
             raise errors.Unauthorized()
 
         if skelType == "node":
-            self.deleteRecursive(skel["key"])
-
-        self.onDelete(skelType, skel)
-        skel.delete()
-        self.onDeleted(skelType, skel)
+            self.deleteRecursive(skel["key"], delete_self=True, call_hooks=True)
+        else:
+            self.onDelete(skelType, skel)
+            skel.delete()
+            self.onDeleted(skelType, skel)
 
         return self.render.deleteSuccess(skel, skelType=skelType)
 
     @CallDeferred
-    def deleteRecursive(self, parentKey: str):
+    def deleteRecursive(self, parentKey: str, delete_self: bool = False, call_hooks: bool = False):
         """
         Recursively processes a delete request.
 
-        This will delete all entries which are children of *nodeKey*, except *key* nodeKey.
+        Deletes all entries which are children of *parentKey*, bottom-up:
+        leafs first, then each sub-node only after its own descendants
+        have been removed. The whole subtree is processed within this
+        single deferred call -- recursing into a sub-node does *not*
+        spawn a separate deferred task for it, so there is no window in
+        which a node could be deleted (or considered done) before its
+        own children actually are.
 
-        :param parentKey: URL-safe key of the node which children should be deleted.
+        If *delete_self* is set, *parentKey* itself is deleted last, once
+        everything below it is already gone. This is what makes deferring
+        the deletion of a node safe: if this task is lost entirely (queue
+        purge, crash, a task pinned to an App Engine version that no
+        longer exists, ...), *nothing* in the subtree has been touched
+        yet, so nothing is left behind; if it fails partway through, a
+        retry simply continues with what remains (deleting an
+        already-deleted entry is a no-op read-then-skip). The previous
+        behavior -- the node deleted synchronously by :meth:`delete`
+        while its children's removal was merely enqueued as a separate,
+        independent job -- could leave orphaned entries permanently
+        behind: children whose ``parententry`` points to an
+        already-deleted, nonexistent node, which then breaks anything
+        that relies on the tree being intact (e.g. relation updates,
+        aggregations).
+
+        :param parentKey: URL-safe key of the node whose children (and,
+            if *delete_self*, the node itself) should be deleted.
+        :param delete_self: If True, also delete the node identified by
+            *parentKey*, after all of its descendants have been removed.
+        :param call_hooks: If True, call :meth:`onDelete`/:meth:`onDeleted`
+            for the *parentKey* node itself (only meaningful together
+            with *delete_self*). Not applied recursively: cascaded
+            descendants are removed without hooks, same as before.
         """
         nodeKey = db.key_helper(parentKey, self.viewSkel("node").kindName)
+        self._deleteSubtree(nodeKey)
+        if delete_self:
+            nodeSkel = self.viewSkel("node")
+            if nodeSkel.read(nodeKey):
+                if call_hooks:
+                    self.onDelete("node", nodeSkel)
+                nodeSkel.delete()
+                if call_hooks:
+                    self.onDeleted("node", nodeSkel)
+
+    def _deleteSubtree(self, nodeKey: db.Key) -> None:
+        """
+        Synchronously delete all descendants of *nodeKey* (not *nodeKey*
+        itself), bottom-up.
+
+        Internal helper for :meth:`deleteRecursive`: recurses directly
+        instead of spawning a new deferred task per tree level, so the
+        whole subtree is processed within a single execution and strictly
+        in the correct order (a sub-node is only deleted once every one of
+        *its* descendants is confirmed gone).
+
+        :param nodeKey: Key of the node whose descendants get deleted.
+        """
         if self.leafSkelCls:
             for leaf in db.Query(self.viewSkel("leaf").kindName).filter("parententry =", nodeKey).iter():
                 leafSkel = self.viewSkel("leaf")
@@ -637,11 +695,10 @@ class Tree(SkelModule):
                     continue
                 leafSkel.delete()
         for node in db.Query(self.viewSkel("node").kindName).filter("parententry =", nodeKey).iter():
-            self.deleteRecursive(node.key)
+            self._deleteSubtree(node.key)
             nodeSkel = self.viewSkel("node")
-            if not nodeSkel.read(node.key):
-                continue
-            nodeSkel.delete()
+            if nodeSkel.read(node.key):
+                nodeSkel.delete()
 
     @exposed
     @force_ssl


### PR DESCRIPTION
Fixes a race where a tree node's synchronous deletion could outrun its deferred, fan-out-per-level child cleanup and leave orphans forever if any task was lost, by making deleteRecursive recurse synchronously bottom-up within one deferred job (deleting the node itself only as the last step), while also fixing a lock-check ordering issue and a File-specific bug where a stale parentdir filter deterministically orphaned directory contents.

---


#### Problem
`Tree.delete()` deletes a node **synchronously** in the request, while its children's cleanup (`deleteRecursive`) is merely **enqueued as a separate, independent deferred task**:

```python
if skelType == "node":
    self.deleteRecursive(skel["key"])   # deferred: only enqueues cleanup of children

self.onDelete(skelType, skel)
skel.delete()                            # synchronous: node is gone right now
self.onDeleted(skelType, skel)
```

If that deferred task is ever lost (queue purge, crash, a task pinned to an App Engine version that no longer exists, retried past its retry budget, …), the children survive their parent **forever**: orphaned entries whose `parententry` points at an already-deleted, nonexistent node. Anything that later walks the tree, refreshes relations, or aggregates over it can then break on these dangling entries.

This is not just a top-level issue — the exact same race exists at **every level** of the recursion: `deleteRecursive` deletes each sub-node synchronously right after enqueuing (not awaiting) a further deferred task for *that* sub-node's own children:

```python
for node in db.Query(...).filter("parententry =", nodeKey).iter():
    self.deleteRecursive(node.key)   # enqueue cleanup of THIS node's children
    nodeSkel = self.viewSkel("node")
    if not nodeSkel.read(node.key):
        continue
    nodeSkel.delete()                 # …but delete the node right now anyway
```

Found and confirmed via this exact bug class in a downstream project (viur-shop's `Cart.cart_remove`, see [viur-shop#184](https://github.com/viur-framework/viur-shop/pull/184)), which had literally copy-pasted this same pattern. `viur.core.modules.file.File` has its own independent `deleteRecursive` override with the identical bug, plus two further File-specific bugs uncovered while fixing it (see below).

#### Solution
This PR is a small stack of related commits:

**1. Delete a node only after its entire subtree is gone**
- `deleteRecursive` now recurses **directly** instead of spawning a new deferred task per tree level, so an entire subtree is processed within a single execution, strictly bottom-up (leafs, then each sub-node only once *its own* descendants are confirmed gone).
- A new `delete_self` flag lets it also delete the node identified by `parentKey` itself, as the very last step, once everything below it is gone.
- `Tree.delete()` now defers the node's own deletion this way (`deleteRecursive(skel["key"], delete_self=True, call_hooks=True)`) instead of deleting it synchronously up front. `onDelete`/`onDeleted` still fire exactly once for the node — just from within the deferred job instead of within the request.
- Leaf deletion is completely unchanged (no children, no async component).
- The public `deleteRecursive(parentKey)` signature stays backward compatible: existing callers using the old 1-arg form get identical semantics (deletes only descendants, not `parentKey`), just now processed within one execution instead of fanned out — which is strictly safer, not a behavior change for them.

**2. Check the `PreventDeletion` lock before touching the subtree**
- Moving the node's own deletion to the end of the cascade also moved its `PreventDeletion` check (done inside `Skeleton.delete()`) to *after* the whole subtree was already removed — a locked node would survive but its contents would be gone.
- New `Tree._is_locked_by_relation()` (mirroring the check in `Skeleton.delete()`), checked **synchronously in `delete()`** (immediate `Locked` error, no deferred job started at all) and **defensively at the top of `deleteRecursive()`** (before touching any child — safety net for a lock added in the meantime, and for other direct callers).

**3. Fix `File` querying the dead `parentdir` field**
- `File.deleteRecursive` queried its children with `.filter("parentdir", …)`, but `parentdir` is a ViUR2-only field; in ViUR3 the field is `parententry` (verified against live data: zero `file`/`file_rootNode` entities carry a `parentdir` value, and every other File operation already uses `parententry`). The child query matched nothing, so deleting a directory orphaned its entire contents **deterministically**, independent of the deferred-task race above. Switched both queries to `parententry`.

**4. Unify `File`'s cascade into `Tree` via a hook**
- With both now querying by `parententry`, the only genuinely File-specific step left was marking each cascaded leaf's blob for deletion (`mark_for_deletion`).
- Introduced `Tree.onDeleteRecursive(skelType, skel)` — a no-op hook fired for every *descendant* right before it is deleted during a recursive delete (as opposed to `onDelete`/`onDeleted`, which fire once for the entry the delete was invoked on).
- `File` drops its `deleteRecursive`/`_deleteSubtree` overrides entirely and only implements the hook to mark leaf blobs; all delete logic now lives once in `Tree`. No behavior change for File: a single-leaf delete never went through this path (its blob cleanup runs via the `viur-blob-locks` mechanism in `Skeleton.delete()`), and directory-cascade deletes still mark every descendant file's blob.
- Closes #1732.

#### Trade-off to discuss
Recursing synchronously within one deferred task trades the previous per-tree-level task fan-out for correctness. For the vast majority of trees (hundreds to a few thousand entries) this is not a practical concern — deletes are cheap batch operations and deferred tasks have generous execution time budgets. Pathologically large/deep trees could now take longer per task and, in extreme cases, risk hitting execution limits that the old fan-out avoided.

A fix that preserves the old per-level fan-out *and* is fully race-free would need a completion-tracking mechanism (e.g. a transactional pending-children counter that triggers the parent's deletion once it reaches zero) — a materially larger change that felt out of scope here. Happy to discuss if the fan-out trade-off is a concern for very large trees in practice, or to explore the completion-tracking approach as a follow-up.
