### PR TITLE
feat: make translation sources pluggable

### DIFF
--- a/src/viur/core/config.py
+++ b/src/viur/core/config.py
@@ -613,6 +613,9 @@ class I18N(ConfigType):
     language_alias_map: dict[str, str] = {}
     """Allows mapping of certain languages to one translation (i.e. us->en)"""
 
+    sources: Multiple["i18n.TranslationSource"] = None
+    """Translation sources, loaded in order; None uses i18n.DEFAULT_TRANSLATION_SOURCES"""
+
     language_method: t.Literal["session", "url", "domain", "header"] = "session"
     """Defines how translations are applied:
         - session: Per Session

--- a/src/viur/core/i18n.py
+++ b/src/viur/core/i18n.py
@@ -73,6 +73,7 @@ and you only have to enter the translated values.
 Of course you can create skeletons / entries in the datastore in your project
 on your own. Just use the TranslateSkel).
 """  # FIXME: grammar, rst syntax
+import abc
 import datetime
 import enum
 import fnmatch
@@ -425,53 +426,113 @@ class TranslationExtension(jinja2.Extension):
         return translate.substitute_vars(res, **kwargs)
 
 
+class TranslationSource(abc.ABC):
+    """A source of translations, loaded by :meth:`initializeTranslations`
+
+    Set instances to :attr:`core.config.I18N.sources`. Sources are loaded in
+    order, a later source replaces the entries of an earlier one per key.
+    """
+
+    @abc.abstractmethod
+    def load(self) -> dict[str, dict[str, t.Any]]:
+        """Return the translations of this source as {key: {lang: value}}
+
+        Keys starting with an underscore are metadata (`_default_text_`,
+        `_public_`) and not treated as a language.
+        """
+        ...
+
+
+class StaticModuleSource(TranslationSource):
+    """Translations from the dicts of a python module, e.g. viur.core.languages"""
+
+    def __init__(self, module: t.Any = languages):
+        super().__init__()
+        self.module = module
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}({self.module.__name__})"
+
+    def load(self) -> dict[str, dict[str, t.Any]]:
+        res = {}
+        for lang, mapping in vars(self.module).items():
+            if lang.startswith("_") or not isinstance(mapping, dict):
+                continue
+            for name, tr_value in mapping.items():
+                res.setdefault(name, {})[lang] = tr_value
+
+        return res
+
+
+class DatastoreSource(TranslationSource):
+    """Translations from the datastore, as managed by the translation module"""
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}()"
+
+    def load(self) -> dict[str, dict[str, t.Any]]:
+        res = {}
+        # TODO: iter() would be more memory efficient, but unfortunately takes much longer than run()
+        # for entity in db.Query(KINDNAME).iter():
+        for entity in db.Query(KINDNAME).run(10_000):
+            if "name" not in entity:
+                logging.warning(f"translations entity {entity.key} has no name set --> Call migration")
+                migrate_translation(entity.key)
+                # Before the migration has run do a quick modification to get it loaded as is
+                entity["name"] = entity["key"] or entity.key.name
+            if not entity.get("name"):
+                logging.error(f'translations entity {entity.key} has an empty {entity["name"]=} set. Skipping.')
+                continue
+            if entity and not isinstance(entity["translations"], dict):
+                logging.error(f'translations entity {entity.key} has invalid '
+                              f'translations set: {entity["translations"]}. Skipping.')
+                continue
+
+            res[entity["name"]] = entity["translations"] | {
+                "_default_text_": entity.get("default_text") or None,
+                "_public_": entity.get("public") or False,
+            }
+
+        return res
+
+
+DEFAULT_TRANSLATION_SOURCES: tuple[TranslationSource, ...] = (StaticModuleSource(), DatastoreSource())
+"""Used when :attr:`core.config.I18N.sources` is None"""
+
+
+def normalize_translations(translations: dict[str, t.Any]) -> dict[str, t.Any]:
+    """Drop unknown languages and empty values, but keep the metadata entries"""
+    res = {}
+    for lang, tr_value in translations.items():
+        if lang.startswith("_"):
+            # Metadata, not a language
+            res[lang] = tr_value
+        elif lang in conf.i18n.available_dialects and tr_value and str(tr_value).strip():
+            # Don't store unknown languages or empty values in the memory
+            res[lang] = tr_value
+
+    return res
+
+
 def initializeTranslations() -> None:
     """
-    Fetches all translations from the datastore and populates the *systemTranslations* dictionary of this module.
+    Loads all translations of :attr:`core.config.I18N.sources` into the *systemTranslations* of this module.
     Currently, the translate-class will resolve using that dictionary; but as we expect projects to grow and
     accumulate translations that are no longer/not yet used, we plan to made the translation-class fetch it's
     translations directly from the datastore, so we don't have to allocate memory for unused translations.
     """
-    # Load translations from static languages module into systemTranslations
-    # If they're in the datastore, they will be overwritten below.
-    for lang in dir(languages):
-        if lang.startswith("__"):
-            continue
-        for name, tr_value in getattr(languages, lang).items():
-            systemTranslations.setdefault(name, {})[lang] = tr_value
+    for source in conf.i18n.sources if conf.i18n.sources is not None else DEFAULT_TRANSLATION_SOURCES:
+        try:
+            loaded = source.load()
+        except Exception:
+            logging.error(f"Translation source {source!r} failed to load")
+            raise
 
-    # Load translations from datastore into systemTranslations
-    # TODO: iter() would be more memory efficient, but unfortunately takes much longer than run()
-    # for entity in db.Query(KINDNAME).iter():
-    for entity in db.Query(KINDNAME).run(10_000):
-        if "name" not in entity:
-            logging.warning(f"translations entity {entity.key} has no name set --> Call migration")
-            migrate_translation(entity.key)
-            # Before the migration has run do a quick modification to get it loaded as is
-            entity["name"] = entity["key"] or entity.key.name
-        if not entity.get("name"):
-            logging.error(f'translations entity {entity.key} has an empty {entity["name"]=} set. Skipping.')
-            continue
-        if entity and not isinstance(entity["translations"], dict):
-            logging.error(f'translations entity {entity.key} has invalid '
-                          f'translations set: {entity["translations"]}. Skipping.')
-            continue
+        if not isinstance(loaded, dict):
+            raise TypeError(f"Translation source {source!r} returned {type(loaded).__name__}, expected dict")
 
-        translations = {
-            "_default_text_": entity.get("default_text") or None,
-            "_public_": entity.get("public") or False,
-        }
-
-        for lang, translation in entity["translations"].items():
-            if lang not in conf.i18n.available_dialects:
-                # Don't store unknown languages in the memory
-                continue
-            if not translation or not str(translation).strip():
-                # Skip empty values
-                continue
-            translations[lang] = translation
-
-        systemTranslations[entity["name"]] = translations
+        for name, translations in loaded.items():
+            systemTranslations[name] = normalize_translations(translations)
 
 
 @tasks.CallDeferred


### PR DESCRIPTION
## Problem

`initializeTranslations()` had two hardcoded sources: the static
`viur.core.languages` module and the datastore. A project that wants to load
translations from somewhere else (files, a build artifact) has no seam and has to
patch core.

The two sources also behaved inconsistently - the datastore branch dropped empty
values and unknown languages, the static module branch did not. And iterating
`dir(languages)` and calling `.items()` on every attribute breaks boot as soon as
that module contains anything that is not a translation table.

## Change

```python
conf.i18n.sources = [StaticModuleSource(), MyFileSource("locales/"), DatastoreSource()]
```
- TranslationSource ABC with a single load() -> dict[str, dict[str, Any]]
- StaticModuleSource(module=viur.core.languages) and DatastoreSource() as the
two built-ins, exposed as DEFAULT_TRANSLATION_SOURCES
- conf.i18n.sources defaults to None, which uses those defaults - unchanged
behaviour out of the box. Sources load in order, a later one replaces an
earlier one per key.
- normalize_translations() centralises dropping unknown languages and empty
values for all sources; keys prefixed with _ are kept as metadata
(_default_text_, _public_).
- StaticModuleSource uses vars() with an isinstance(dict) check instead of
dir(), so unrelated module attributes no longer break the boot.

A source that raises is fatal: the error is logged with the source's repr and
re-raised, so a broken source fails the deploy instead of silently serving half
the translations. A load() that does not return a dict raises TypeError.
Malformed individual datastore entries are still logged and skipped as before.

Note

Central normalisation now also applies to the static module source, so languages
outside conf.i18n.available_dialects are no longer held in memory. This is not
observable: every read path resolves through either a validated force_lang or
current.language, and translation.dump() renders via
translate(name, force_lang=...), which validates too.

add_missing_translation() is untouched - it is a write path and stays bound to
the datastore.