### PR TITLE
fix: Make user `Status` an `IntEnum` for cross-project comparability

### DIFF
--- a/src/viur/core/modules/user.py
+++ b/src/viur/core/modules/user.py
@@ -2,7 +2,6 @@ import abc
 import datetime
 import enum
 import fnmatch
-import functools
 import hashlib
 import hmac
 import json
@@ -35,12 +34,27 @@ from viur.core.securityheaders import extendCsp
 from viur.core.session import Session
 
 
-@functools.total_ordering
-class Status(enum.Enum):
+class Status(enum.IntEnum):
     """Status enum for a user
 
-    Has backwards compatibility to be comparable with non-enum values.
-    Will be removed with viur-core 4.0.0
+    This is an IntEnum, so it is comparable with plain ints as well as with
+    other IntEnum classes of the same values, e.g. when a project defines its
+    own Status enum to add custom status values to a subclassed UserSkel:
+
+    class Status(enum.IntEnum):
+        UNSET = 0
+        WAITING_FOR_EMAIL_VERIFICATION = 1
+        WAITING_FOR_ADMIN_VERIFICATION = 2
+        DISABLED = 5
+        ACTIVE = 10
+        PENDING_REVIEW = 15  # custom, project-specific status
+
+    class UserSkel(user.UserSkel):
+        status = SelectBone(
+            ...,
+            values=Status,
+            defaultValue=Status.ACTIVE,
+        )
     """
 
     UNSET = 0  # Status is unset
@@ -48,16 +62,6 @@ class Status(enum.Enum):
     WAITING_FOR_ADMIN_VERIFICATION = 2  # Waiting for verification through admin
     DISABLED = 5  # Account disabled
     ACTIVE = 10  # Active
-
-    def __eq__(self, other):
-        if isinstance(other, Status):
-            return super().__eq__(other)
-        return self.value == other
-
-    def __lt__(self, other):
-        if isinstance(other, Status):
-            return super().__lt__(other)
-        return self.value < other
 
 
 class UserSkel(skeleton.Skeleton):
@@ -1486,7 +1490,7 @@ class User(List):
                 except ValueError:
                     status = Status.UNSET
 
-            return status >= Status.ACTIVE.value
+            return status >= Status.ACTIVE
 
         return None
 
@@ -1928,7 +1932,7 @@ def createNewUserIfNotExists():
             uname = f"""admin@{conf.instance.project_id}.appspot.com"""
             pw = utils.string.random(13)
             addSkel["name"] = uname
-            addSkel["status"] = Status.ACTIVE.value  # Ensure it's enabled right away
+            addSkel["status"] = Status.ACTIVE  # Ensure it's enabled right away
             addSkel["access"] = ["root"]
             addSkel["password"] = pw
 

--- a/tests/modules/test_user_status.py
+++ b/tests/modules/test_user_status.py
@@ -1,0 +1,46 @@
+"""
+Tests for the user Status enum:
+  Status is an IntEnum, so it must stay comparable with plain ints and with
+  independently defined IntEnum classes (as projects do when they extend the
+  status values in a subclassed UserSkel).
+"""
+import enum
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from abstract import ViURTestCase  # noqa: E402
+
+
+class ProjectStatus(enum.IntEnum):
+    """Stand-in for a project's own Status enum that mirrors the core values
+    and adds a custom one — this is the pattern that used to break."""
+    UNSET = 0
+    WAITING_FOR_EMAIL_VERIFICATION = 1
+    WAITING_FOR_ADMIN_VERIFICATION = 2
+    DISABLED = 5
+    ACTIVE = 10
+    PENDING_REVIEW = 15
+
+
+class TestUserStatus(ViURTestCase):
+
+    def test_comparable_with_plain_int(self):
+        from viur.core.modules.user import Status
+        self.assertEqual(Status.ACTIVE, 10)
+        self.assertTrue(Status.ACTIVE > 5)
+        self.assertTrue(Status.DISABLED < Status.ACTIVE.value)
+
+    def test_comparable_with_independent_project_enum(self):
+        from viur.core.modules.user import Status
+        self.assertEqual(Status.ACTIVE, ProjectStatus.ACTIVE)
+        self.assertEqual(ProjectStatus.ACTIVE, Status.ACTIVE)
+        self.assertTrue(Status.DISABLED < ProjectStatus.ACTIVE)
+        self.assertTrue(ProjectStatus.PENDING_REVIEW > Status.ACTIVE)
+
+    def test_not_always_truthy(self):
+        # IntEnum follows int truthiness, unlike plain Enum members.
+        from viur.core.modules.user import Status
+        self.assertFalse(Status.UNSET)
+        self.assertTrue(Status.ACTIVE)


### PR DESCRIPTION
Downstream projects that redefine `Status` to add custom account states end up with two `Enum` classes that don't compare equal, even for the same value. `IntEnum` fixes this, since members compare via plain int equality across independently defined enums.

Also drops the now-obsolete `__eq__`/`__lt__` backward-compat shim and the `.value` workarounds this required.

Closes #1671