### PR TITLE
fix(file): honor the configured download-URL expiration in `add`

### DIFF
--- a/src/viur/core/modules/file.py
+++ b/src/viur/core/modules/file.py
@@ -1302,8 +1302,11 @@ class File(Tree):
             skel.write()
             self.onAdded("leaf", skel)
 
-            # Add updated download-URL as the auto-generated isn't valid yet
-            skel["downloadUrl"] = self.create_download_url(skel["dlkey"], skel["name"])
+            # Add updated download-URL as the auto-generated isn't valid yet.
+            # Same lifetime as DownloadUrlBone, which this replaces.
+            skel["downloadUrl"] = self.create_download_url(
+                skel["dlkey"], skel["name"], expires=conf.render_json_download_url_expiration
+            )
 
             return self.render.addSuccess(skel)
 


### PR DESCRIPTION
###  Description
`File.add` built the `downloadUrl` it returns without passing `expires`, so it
inherited the `timedelta(hours=1)` default of `create_download_url` instead of
`conf.render_json_download_url_expiration`.

That line only exists to redo what `DownloadUrlBone.unserialize` did too early
(`name` and `dlkey` are not final at unserialize time), and the bone honors the
config — so the replacement has to use the same lifetime.

Impact: clients that persist the URL from an `/file/add` response get a link
that stops working after an hour. The CKEditor upload adapter in vi-admin does
exactly that: it writes the returned URL into `TextBone` content, where it later
resolves to `errors.Gone`.