### PR TITLE
fix(file): guard against already-removed blob-lock in GC

### DIFF
--- a/src/viur/core/modules/file.py
+++ b/src/viur/core/modules/file.py
@@ -1460,6 +1460,9 @@ def startCheckForUnreferencedBlobs():
 def doCheckForUnreferencedBlobs(cursor=None):
     def getOldBlobKeysTxn(dbKey):
         obj = db.get(dbKey)
+        if obj is None:
+            # The lock was already processed and removed by a concurrent run
+            return []
         res = obj["old_blob_references"] or []
         if obj["is_stale"]:
             db.delete(dbKey)


### PR DESCRIPTION
## Summary

- `getOldBlobKeysTxn` in `doCheckForUnreferencedBlobs` now returns early when the blob-lock no longer exists in the database.

## Motivation

`doCheckForUnreferencedBlobs` queries `viur-blob-locks` for `has_old_blob_references == True` and re-fetches each lock inside a transaction. The task is `@CallDeferred` and scheduled by a 4h `PeriodicTask`, so two runs can overlap. When a concurrent run already processed and deleted the same lock, `db.get()` returns `None` and `obj["old_blob_references"]` raised:

```
TypeError: 'NoneType' object is not subscriptable
```

Returning `[]` in that case treats the lock as already handled, which is the correct outcome.
