### PR TITLE
feat: Configurable named datastore database and namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This file documents any relevant changes done to ViUR-core since version 3.
 - doc: Fix seo_language_map in docstring
 - feat:  `SpatialBone`  extend `setBoneValue` to accept `dict` with lat/lng aliases (#1705)
 - feat: `CodeBone`, `LogicsBone`, `JinjaBone` and `PythonBone` (#1668)
+- feat: Configurable named datastore database and namespace via `conf.db.name` / `conf.db.namespace` (env: `VIUR_DB_NAME` / `VIUR_DB_NAMESPACE`), surfaced in the dev-server boot banner
 - feat: `skel.patch()` with internal-mode default (#1587)
 - feat: Add `after_from_client` (#1708)
 - feat: add `contrib` package with `RequestRateLimit` validator (#1690)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ This file documents any relevant changes done to ViUR-core since version 3.
 - doc: Fix seo_language_map in docstring
 - feat:  `SpatialBone`  extend `setBoneValue` to accept `dict` with lat/lng aliases (#1705)
 - feat: `CodeBone`, `LogicsBone`, `JinjaBone` and `PythonBone` (#1668)
-- feat: Configurable named datastore database and namespace via `conf.db.name` / `conf.db.namespace` (env: `VIUR_DB_NAME` / `VIUR_DB_NAMESPACE`), surfaced in the dev-server boot banner
 - feat: `skel.patch()` with internal-mode default (#1587)
 - feat: Add `after_from_client` (#1708)
 - feat: add `contrib` package with `RequestRateLimit` validator (#1690)

--- a/src/viur/core/__init__.py
+++ b/src/viur/core/__init__.py
@@ -245,6 +245,16 @@ def __build_app(modules: ModuleType | object, renderers: ModuleType | object, de
     conf.main_app = index
 
 
+def _datastore_banner_lines() -> list[str]:
+    """Boot-banner lines for a non-default datastore target; empty for default."""
+    extra = []
+    if conf.db.name:
+        extra.append(f"""database = \033[1;33m{conf.db.name}\033[0m""")
+    if conf.db.namespace:
+        extra.append(f"""namespace = \033[1;33m{conf.db.namespace}\033[0m""")
+    return extra
+
+
 def setup(modules:  ModuleType | object, render:  ModuleType | object = None, default: str = "html"):
     """
         Define whats going to be served by this instance.
@@ -334,6 +344,7 @@ def setup(modules:  ModuleType | object, render:  ModuleType | object = None, de
             f"""project = \033[1;31m{conf.instance.project_id}\033[0m""",
             f"""python = \033[1;32m{".".join((str(i) for i in PYTHON_VERSION))}\033[0m""",
             f"""viur = \033[1;32m{".".join((str(i) for i in conf.version))}\033[0m""",
+            *_datastore_banner_lines(),  # only when a non-default db/namespace is set
             ""  # empty line
         )
 

--- a/src/viur/core/__init__.py
+++ b/src/viur/core/__init__.py
@@ -245,16 +245,6 @@ def __build_app(modules: ModuleType | object, renderers: ModuleType | object, de
     conf.main_app = index
 
 
-def _datastore_banner_lines() -> list[str]:
-    """Boot-banner lines for a non-default datastore target; empty for default."""
-    extra = []
-    if conf.db.name:
-        extra.append(f"""database = \033[1;33m{conf.db.name}\033[0m""")
-    if conf.db.namespace:
-        extra.append(f"""namespace = \033[1;33m{conf.db.namespace}\033[0m""")
-    return extra
-
-
 def setup(modules:  ModuleType | object, render:  ModuleType | object = None, default: str = "html"):
     """
         Define whats going to be served by this instance.
@@ -338,13 +328,20 @@ def setup(modules:  ModuleType | object, render:  ModuleType | object = None, de
         FILL = "#"  # define sthe fill char (must be len(1)!)
         PYTHON_VERSION = (sys.version_info.major, sys.version_info.minor, sys.version_info.micro)
 
+        # extra banner lines for a non-default datastore target
+        datastore_lines = []
+        if conf.db.name:
+            datastore_lines.append(f"""database = \033[1;33m{conf.db.name}\033[0m""")
+        if conf.db.namespace:
+            datastore_lines.append(f"""namespace = \033[1;33m{conf.db.namespace}\033[0m""")
+
         # define lines to show
         lines = (
             " LOCAL DEVELOPMENT SERVER IS UP AND RUNNING ",  # title line
             f"""project = \033[1;31m{conf.instance.project_id}\033[0m""",
             f"""python = \033[1;32m{".".join((str(i) for i in PYTHON_VERSION))}\033[0m""",
             f"""viur = \033[1;32m{".".join((str(i) for i in conf.version))}\033[0m""",
-            *_datastore_banner_lines(),  # only when a non-default db/namespace is set
+            *datastore_lines,  # only when a non-default db/namespace is set
             ""  # empty line
         )
 

--- a/src/viur/core/config.py
+++ b/src/viur/core/config.py
@@ -322,6 +322,15 @@ class Database(ConfigType):
     create_access_log: bool = True
     """If False no access log will be created. But then the caching is disabled too."""
 
+    name: str | None = os.getenv("VIUR_DB_NAME") or None
+    """Named datastore to target instead of ``(default)``.
+
+    Env-sourced: the client is built at ``db.transport`` import time, before any
+    runtime config could set it."""
+
+    namespace: str | None = os.getenv("VIUR_DB_NAMESPACE") or None
+    """Datastore namespace to scope to. Env-sourced like `name`."""
+
 
 class Security(ConfigType):
     """Security related settings"""

--- a/src/viur/core/db/transport.py
+++ b/src/viur/core/db/transport.py
@@ -16,7 +16,16 @@ from viur.core.errors import HTTPException
 datastore.helpers.key_from_protobuf = key_from_protobuf
 datastore.helpers.entity_from_protobuf = entity_from_protobuf
 
-__client__ = datastore.Client()
+# Built once at import, kept for the process lifetime — so db/namespace have to
+# come from env (via conf.db); nothing can retarget the client afterwards.
+# Empty kwargs == datastore.Client(): no change for default deployments.
+__client_kwargs__: dict[str, str] = {}
+if conf.db.name:
+    __client_kwargs__["database"] = conf.db.name
+if conf.db.namespace:
+    __client_kwargs__["namespace"] = conf.db.namespace
+
+__client__ = datastore.Client(**__client_kwargs__)
 
 
 def allocate_ids(kind_name: str, num_ids: int = 1, retry=None, timeout=None) -> list[Key]:

--- a/src/viur/core/db/transport.py
+++ b/src/viur/core/db/transport.py
@@ -1,3 +1,28 @@
+"""
+Datastore transport layer: the process-wide client and the CRUD helpers.
+
+**Named database and namespace**
+
+The datastore client (:data:`__client__`) is built once at import time and
+kept for the whole process lifetime. Its target database and namespace come
+from :attr:`conf.db.name <viur.core.config.Database.name>` and
+:attr:`conf.db.namespace <viur.core.config.Database.namespace>`, which are sourced
+from the ``VIUR_DB_NAME`` / ``VIUR_DB_NAMESPACE`` environment variables. Both
+default to ``None`` — the standard ``(default)`` database and empty namespace —
+so existing deployments are unaffected.
+
+Because the client is created from the environment at import time, the target
+cannot be retargeted at runtime: a single process always talks to exactly one
+database. :class:`~viur.core.db.types.Key` objects inherit that database and
+namespace from the client, keeping every request on the configured target.
+
+The legacy urlsafe key encoding (App Engine "Reference") predates named
+databases and only supports the default one. Therefore
+:meth:`Key.to_legacy_urlsafe <viur.core.db.types.Key.to_legacy_urlsafe>`
+encodes a database-less copy of the key, and the client's database is restored
+on decoding — unambiguous precisely because the process is bound to a single
+database.
+"""
 from __future__ import annotations
 
 import logging

--- a/src/viur/core/db/transport.py
+++ b/src/viur/core/db/transport.py
@@ -18,14 +18,9 @@ datastore.helpers.entity_from_protobuf = entity_from_protobuf
 
 # Built once at import, kept for the process lifetime — so db/namespace have to
 # come from env (via conf.db); nothing can retarget the client afterwards.
-# Empty kwargs == datastore.Client(): no change for default deployments.
-__client_kwargs__: dict[str, str] = {}
-if conf.db.name:
-    __client_kwargs__["database"] = conf.db.name
-if conf.db.namespace:
-    __client_kwargs__["namespace"] = conf.db.namespace
-
-__client__ = datastore.Client(**__client_kwargs__)
+# Both default to None, which is the same as datastore.Client(): no change for
+# default deployments.
+__client__ = datastore.Client(database=conf.db.name, namespace=conf.db.namespace)
 
 
 def allocate_ids(kind_name: str, num_ids: int = 1, retry=None, timeout=None) -> list[Key]:

--- a/src/viur/core/db/types.py
+++ b/src/viur/core/db/types.py
@@ -63,14 +63,34 @@ class Key(Datastore_key):
                 id_or_name = int(id_or_name)
             new_path_args.extend((kind, id_or_name))
 
+        from .transport import __client__  # noqa: E402 # import works only here because circular imports
+
         if project is None:
-            from .transport import __client__  # noqa: E402 # import works only here because circular imports
             project = __client__.project
+
+        # Keys must match the client's db/namespace or Datastore rejects the
+        # request as cross-database. Default from the client; caller wins.
+        if __client__.database:
+            kwargs.setdefault("database", __client__.database)
+        if __client__.namespace:
+            kwargs.setdefault("namespace", __client__.namespace)
 
         super().__init__(*new_path_args, project=project, **kwargs)
 
     def __str__(self):
         return self.to_legacy_urlsafe().decode("ASCII")
+
+    def to_legacy_urlsafe(self, location_prefix=None):
+        # Upstream to_legacy_urlsafe() rejects keys carrying a database, but
+        # str(key)/session paths hit it constantly. Drop the db for encoding —
+        # unambiguous to restore since the process talks to a single database.
+        if self._database is None:
+            return super().to_legacy_urlsafe(location_prefix=location_prefix)
+        saved, self._database = self._database, None
+        try:
+            return super().to_legacy_urlsafe(location_prefix=location_prefix)
+        finally:
+            self._database = saved
 
     '''
     def __repr__(self):

--- a/src/viur/core/db/types.py
+++ b/src/viur/core/db/types.py
@@ -84,8 +84,6 @@ class Key(Datastore_key):
         # Upstream to_legacy_urlsafe() rejects keys carrying a database, but
         # str(key)/session paths hit it constantly. Drop the db for encoding —
         # unambiguous to restore since the process talks to a single database.
-        if self._database is None:
-            return super().to_legacy_urlsafe(location_prefix=location_prefix)
         saved, self._database = self._database, None
         try:
             return super().to_legacy_urlsafe(location_prefix=location_prefix)

--- a/src/viur/core/db/types.py
+++ b/src/viur/core/db/types.py
@@ -3,6 +3,7 @@ The constants, global variables and container classes used in the datastore api
 """
 from __future__ import annotations
 
+import copy
 import datetime
 import enum
 import itertools
@@ -82,13 +83,13 @@ class Key(Datastore_key):
 
     def to_legacy_urlsafe(self, location_prefix=None):
         # Upstream to_legacy_urlsafe() rejects keys carrying a database, but
-        # str(key)/session paths hit it constantly. Drop the db for encoding —
+        # str(key)/session paths hit it constantly. Encode a database-less copy —
         # unambiguous to restore since the process talks to a single database.
-        saved, self._database = self._database, None
-        try:
-            return super().to_legacy_urlsafe(location_prefix=location_prefix)
-        finally:
-            self._database = saved
+        # A copy keeps this thread-safe: mutating self._database in place would
+        # let concurrent encodes of the same Key clobber each other's state.
+        clone = copy.copy(self)
+        clone._database = None
+        return super(Key, clone).to_legacy_urlsafe(location_prefix=location_prefix)
 
     '''
     def __repr__(self):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -115,6 +115,24 @@ class TestConfig(ViURTestCase):
                 with self.assertWarns(DeprecationWarning):
                     _ = conf[key]
 
+    def test_db_name_and_namespace_default_to_none(self):
+        # The fields exist and select the default database/namespace unless a
+        # deployment opts into a named one.
+        from viur.core.config import conf
+        self.assertIsNone(conf.db.name)
+        self.assertIsNone(conf.db.namespace)
+
+    def test_db_name_and_namespace_are_settable(self):
+        from viur.core.config import conf
+        try:
+            conf.db.name = "viur-tests"
+            conf.db.namespace = "ns-ak"
+            self.assertEqual(conf.db.name, "viur-tests")
+            self.assertEqual(conf.db.namespace, "ns-ak")
+        finally:
+            conf.db.name = None
+            conf.db.namespace = None
+
     def test_items(self):
         from viur.core.config import conf
         self.assertIsInstance(conf.items(), types.GeneratorType)

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,5 +1,8 @@
 # TODO: Add more tests from https://github.com/viur-framework/viur-datastore/tree/master/tests
 
+import importlib
+from unittest import mock
+
 from abstract import ViURTestCase
 
 
@@ -79,3 +82,105 @@ class TestQueryOrder(ViURTestCase):
         orders = q.get_orders()
         self.assertIsNotNone(orders)
         self.assertIsInstance(orders[0], db.QueryOrder)
+
+
+class TestNamedDatabase(ViURTestCase):
+    """Covers the configurable named database/namespace support.
+
+    See `conf.db.name` / `conf.db.namespace`: keys and the legacy urlsafe
+    encoding must work while the process is wired to a non-default database.
+    """
+
+    @staticmethod
+    def _fake_client(*, database=None, namespace=None):
+        client = mock.Mock()
+        client.project = "test-project"
+        client.database = database
+        client.namespace = namespace
+        return client
+
+    def test_key_inherits_database_and_namespace_from_client(self) -> None:
+        from viur.core import db
+        from viur.core.db import transport
+        with mock.patch.object(
+            transport, "__client__",
+            self._fake_client(database="viur-tests", namespace="ns-ak"),
+        ):
+            key = db.Key("viur", 42)
+        self.assertEqual(key.database, "viur-tests")
+        self.assertEqual(key.namespace, "ns-ak")
+
+    def test_explicit_key_argument_wins_over_client_default(self) -> None:
+        from viur.core import db
+        from viur.core.db import transport
+        with mock.patch.object(
+            transport, "__client__",
+            self._fake_client(database="viur-tests", namespace="ns-ak"),
+        ):
+            key = db.Key("viur", 42, database="other-db", namespace="other-ns")
+        self.assertEqual(key.database, "other-db")
+        self.assertEqual(key.namespace, "other-ns")
+
+    def test_default_client_keeps_keys_on_default_database(self) -> None:
+        from viur.core import db
+        from viur.core.db import transport
+        with mock.patch.object(transport, "__client__", self._fake_client()):
+            key = db.Key("viur", 42)
+        self.assertIsNone(key.database)
+
+    def test_to_legacy_urlsafe_tolerates_named_database(self) -> None:
+        from viur.core import db
+        from viur.core.db import transport
+        with mock.patch.object(
+            transport, "__client__", self._fake_client(database="viur-tests"),
+        ):
+            key = db.Key("viur", "foo")
+            # Without the override both calls would raise ValueError.
+            self.assertIsInstance(key.to_legacy_urlsafe(), bytes)
+            self.assertIsInstance(str(key), str)
+
+    def test_transport_builds_client_from_conf(self) -> None:
+        from viur.core.config import conf
+        from viur.core.db import transport
+        try:
+            with (
+                mock.patch.object(conf.db, "name", "viur-tests"),
+                mock.patch.object(conf.db, "namespace", "ns-ak"),
+                mock.patch("google.cloud.datastore.Client") as MockClient,
+            ):
+                importlib.reload(transport)
+                MockClient.assert_called_once_with(
+                    database="viur-tests", namespace="ns-ak",
+                )
+        finally:
+            # Restore the real, default-database client for the other tests.
+            importlib.reload(transport)
+
+    def test_transport_unconfigured_builds_default_client(self) -> None:
+        from viur.core.db import transport
+        try:
+            with mock.patch("google.cloud.datastore.Client") as MockClient:
+                importlib.reload(transport)
+                MockClient.assert_called_once_with()
+        finally:
+            importlib.reload(transport)
+
+    def test_banner_omits_lines_for_default_database(self) -> None:
+        import viur.core
+        from viur.core.config import conf
+        with (
+            mock.patch.object(conf.db, "name", None),
+            mock.patch.object(conf.db, "namespace", None),
+        ):
+            self.assertEqual(viur.core._datastore_banner_lines(), [])
+
+    def test_banner_shows_named_database_and_namespace(self) -> None:
+        import viur.core
+        from viur.core.config import conf
+        with (
+            mock.patch.object(conf.db, "name", "viur-tests"),
+            mock.patch.object(conf.db, "namespace", "ns-ak"),
+        ):
+            lines = viur.core._datastore_banner_lines()
+        self.assertTrue(any("database = " in line and "viur-tests" in line for line in lines))
+        self.assertTrue(any("namespace = " in line and "ns-ak" in line for line in lines))

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -139,6 +139,20 @@ class TestNamedDatabase(ViURTestCase):
             self.assertIsInstance(key.to_legacy_urlsafe(), bytes)
             self.assertIsInstance(str(key), str)
 
+    def test_from_legacy_urlsafe_tolerates_named_database(self) -> None:
+        from viur.core import db
+        from viur.core.db import transport
+        with mock.patch.object(
+            transport, "__client__", self._fake_client(database="viur-tests", namespace="baz"),
+        ):
+            key = db.Key("viur", "foo")
+            key_loaded = db.Key.from_legacy_urlsafe(key.to_legacy_urlsafe())
+            self.assertEqual(key, key_loaded)
+            self.assertEqual(key.database, key_loaded.database)
+            self.assertEqual(key.namespace, key_loaded.namespace)
+            self.assertEqual(key.project, key_loaded.project)
+            self.assertEqual(key.id_or_name, key_loaded.id_or_name)
+
     def test_transport_builds_client_from_conf(self) -> None:
         from viur.core.config import conf
         from viur.core.db import transport
@@ -161,26 +175,6 @@ class TestNamedDatabase(ViURTestCase):
         try:
             with mock.patch("google.cloud.datastore.Client") as MockClient:
                 importlib.reload(transport)
-                MockClient.assert_called_once_with()
+                MockClient.assert_called_once_with(database=None, namespace=None)
         finally:
             importlib.reload(transport)
-
-    def test_banner_omits_lines_for_default_database(self) -> None:
-        import viur.core
-        from viur.core.config import conf
-        with (
-            mock.patch.object(conf.db, "name", None),
-            mock.patch.object(conf.db, "namespace", None),
-        ):
-            self.assertEqual(viur.core._datastore_banner_lines(), [])
-
-    def test_banner_shows_named_database_and_namespace(self) -> None:
-        import viur.core
-        from viur.core.config import conf
-        with (
-            mock.patch.object(conf.db, "name", "viur-tests"),
-            mock.patch.object(conf.db, "namespace", "ns-ak"),
-        ):
-            lines = viur.core._datastore_banner_lines()
-        self.assertTrue(any("database = " in line and "viur-tests" in line for line in lines))
-        self.assertTrue(any("namespace = " in line and "ns-ak" in line for line in lines))


### PR DESCRIPTION
Adds a supported way to point viur-core at a named Datastore database and/or a namespace via `conf.db`, instead of always binding to the project's `(default)` database at import time.

With nothing configured the behaviour is unchanged: the client is still built as a bare `datastore.Client()` and keys carry no database/namespace.

**`conf.db.name` / `conf.db.namespace` (config.py):**
Two new `conf.db` fields selecting the target database and namespace. Both default from the `VIUR_DB_NAME` / `VIUR_DB_NAMESPACE` environment variables.

**Client construction (db/transport.py):**
`__client__` is built with `database=` / `namespace=` taken from `conf.db`. When neither is set the call collapses to the historical parameterless `datastore.Client()`.

**Key alignment (db/types.py):**
`Key.__init__` defaults `database` / `namespace` from the client (an explicit caller argument still wins); a mismatch otherwise makes Datastore reject the request as a cross-database access. `Key.to_legacy_urlsafe` drops the database id before encoding — the upstream implementation refuses any key carrying one, while `str(key)` and session handling hit it constantly.

**Boot banner (__init__.py):**
The local dev-server banner gains a `database` / `namespace` line whenever a non-default target is configured, so it is never unnoticed which datastore viur-core is wired to.

---

This is a copy of the PR https://github.com/viur-framework/viur-core/pull/1717.
Due to a lack of editing permissions (since @akelch apparently did not enable the _"Allow edits and access to secrets by maintainers"_ option for this PR), I was unable to make any improvements within the original PR.
