### PR TITLE
cicd: Add Python 3.14 to Test GitHub Action

### DIFF
--- a/.github/workflows/python-test.yaml
+++ b/.github/workflows/python-test.yaml
@@ -12,7 +12,7 @@ jobs:
   test:
     strategy:
       matrix:
-        python: [ "3.12", "3.13" ]
+        python: [ "3.12", "3.13", "3.14" ]
     runs-on: ubuntu-latest
 
     steps:
@@ -40,7 +40,7 @@ jobs:
           pwd
 
       - name: Build Coverage
-        if: ${{ matrix.python == '3.13' && github.event_name == 'push' && github.ref_name == 'main' }}
+        if: ${{ matrix.python == '3.14' && github.event_name == 'push' && github.ref_name == 'main' }}
         working-directory: viur/tests/
         run: |
           # generate coverage
@@ -57,7 +57,7 @@ jobs:
 
       - name: Deploy Coverage
         uses: peaceiris/actions-gh-pages@v3
-        if: ${{ matrix.python == '3.13' && github.event_name == 'push' && github.ref_name == 'main' }}
+        if: ${{ matrix.python == '3.14' && github.event_name == 'push' && github.ref_name == 'main' }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./viur/tests/htmlcov


### PR DESCRIPTION
* Extend test matrix by Python 3.14
* Use latest version (3.14) for coverage builds