### PR TITLE
feat: add Query.iter_skel() to iterate over SkeletonInstances

### DIFF
--- a/src/viur/core/db/query.py
+++ b/src/viur/core/db/query.py
@@ -787,7 +787,7 @@ class Query(object):
         for a query for more than ~30 seconds.
         """
         if self.queries is None:  # Noting to pull here
-            raise StopIteration()
+            return
         elif isinstance(self.queries, list):
             raise ValueError("No iter on Multiqueries")
         while True:
@@ -795,6 +795,46 @@ class Query(object):
             if not self.queries.currentCursor:  # We reached the end of that query
                 break
             self.queries.startCursor = self.queries.currentCursor
+
+    def iter_skel(self) -> t.Iterator["SkeletonInstance"]:
+        """
+        Run this query and return an iterator yielding :class:`core.skeleton.SkeletonInstance`.
+
+        This function is to :meth:`iter` what :meth:`fetch` is to :meth:`run`: it allows for
+        iterating over a large result-set without pulling it from the datastore in advance,
+        but yields SkeletonInstances instead of Entities.
+
+        It's only possible to use this function if this query has been created using
+        :func:`core.skeleton.Skeleton.all`.
+
+        Every result is a separate SkeletonInstance which shares the bone-map of the
+        source-skeleton, therefore collecting the results in a list or writing them
+        within the loop behaves as expected.
+
+        This function intentionally ignores a limit set by :meth:`limit`.
+
+        :warning: If iterating over a large result set, make sure the query supports cursors. \
+        Otherwise, it might not return all results as the AppEngine doesn't maintain the view \
+        for a query for more than ~30 seconds.
+
+        :raises NotImplementedError: If this query has not been created using skel.all().
+        :raises ValueError: If this is a multi-query, which cannot be iterated.
+        """
+        if self.srcSkel is None:
+            raise NotImplementedError("This query has not been created using skel.all()")
+        elif isinstance(self.queries, list):
+            raise ValueError("No iter_skel on Multiqueries")
+
+        from viur.core.skeleton import SkeletonInstance
+
+        # Wrapped in an inner generator, so the checks above are raised on call and not on first next()
+        def _iterate() -> t.Iterator["SkeletonInstance"]:
+            for entity in self.iter():
+                skel_instance = SkeletonInstance(self.srcSkel.skeletonCls, bone_map=self.srcSkel.boneMap)
+                skel_instance.dbEntity = entity
+                yield skel_instance
+
+        return _iterate()
 
     def getEntry(self) -> t.Union[None, Entity]:
         """

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -238,6 +238,107 @@ class TestRunSingleFilter(ViURTestCase):
             self.assertIsInstance(passed_filter, Or)
 
 
+class TestQueryIterSkel(ViURTestCase):
+    """Tests for Query.iter_skel(), the SkeletonInstance-counterpart of Query.iter()."""
+
+    def _make_src_skel(self):
+        """Build a minimal SkeletonInstance usable as srcSkel, without a Skeleton class on disk."""
+        from viur.core.bones import KeyBone, StringBone
+        from viur.core.skeleton import SkeletonInstance
+
+        class FakeSkelCls:
+            kindName = "test_iter_skel"
+            __boneMap__ = {}
+
+        key_bone, name_bone = KeyBone(), StringBone()
+        key_bone.__set_name__(FakeSkelCls, "key")
+        name_bone.__set_name__(FakeSkelCls, "name")
+
+        return SkeletonInstance(FakeSkelCls, bone_map={"key": key_bone, "name": name_bone})
+
+    def _make_entity(self, num: int, name: str):
+        from viur.core import db
+        entity = db.Entity(db.Key("test_iter_skel", num))
+        entity["name"] = name
+        return entity
+
+    def test_yields_skeleton_instances_over_all_batches(self) -> None:
+        """iter_skel() must yield one SkeletonInstance per entity, following the query cursor."""
+        from unittest.mock import patch
+        from viur.core import db
+        from viur.core.skeleton import SkeletonInstance
+
+        src_skel = self._make_src_skel()
+        query = db.Query("test_iter_skel", src_skel)
+        entities = [self._make_entity(1, "a"), self._make_entity(2, "b"), self._make_entity(3, "c")]
+
+        batches = [(entities[:2], b"cursor"), (entities[2:], None)]
+
+        def fake_run(queries, limit, keys_only):
+            result, cursor = batches.pop(0)
+            queries.currentCursor = cursor
+            return result
+
+        with patch.object(db.Query, "_run_single_filter_query", side_effect=fake_run):
+            res = list(query.iter_skel())
+
+        self.assertEqual(len(res), 3)
+        for skel in res:
+            self.assertIsInstance(skel, SkeletonInstance)
+        self.assertEqual([skel["name"] for skel in res], ["a", "b", "c"])
+        self.assertEqual([skel.dbEntity for skel in res], entities)
+
+    def test_yields_distinct_instances(self) -> None:
+        """Each result must be its own instance, so collecting or writing them is safe."""
+        from unittest.mock import patch
+        from viur.core import db
+
+        src_skel = self._make_src_skel()
+        query = db.Query("test_iter_skel", src_skel)
+        entities = [self._make_entity(1, "a"), self._make_entity(2, "b")]
+
+        def fake_run(queries, limit, keys_only):
+            queries.currentCursor = None
+            return entities
+
+        with patch.object(db.Query, "_run_single_filter_query", side_effect=fake_run):
+            res = list(query.iter_skel())
+
+        self.assertEqual(len({id(skel) for skel in res}), 2)
+        # The bone-map is shared with the source skeleton, the source skeleton itself is untouched
+        self.assertTrue(all(skel.boneMap is src_skel.boneMap for skel in res))
+        self.assertTrue(all(skel.skeletonCls is src_skel.skeletonCls for skel in res))
+        self.assertIsNone(src_skel.dbEntity)
+
+    def test_without_src_skel_raises_on_call(self) -> None:
+        """A query not created by skel.all() must fail immediately, not on first iteration."""
+        from viur.core import db
+        with self.assertRaises(NotImplementedError):
+            db.Query("test_iter_skel").iter_skel()
+
+    def test_multi_query_raises_on_call(self) -> None:
+        """Multi-queries cannot be iterated; the error must be raised immediately."""
+        from viur.core import db
+        query = db.Query("test_iter_skel", self._make_src_skel())
+        query.queries = [query.queries, query.queries]
+        with self.assertRaises(ValueError):
+            query.iter_skel()
+
+    def test_unsatisfiable_query_yields_nothing(self) -> None:
+        """A query which cannot be satisfied must result in an empty iteration."""
+        from viur.core import db
+        query = db.Query("test_iter_skel", self._make_src_skel())
+        query.queries = None
+        self.assertEqual(list(query.iter_skel()), [])
+
+    def test_iter_on_unsatisfiable_query_yields_nothing(self) -> None:
+        """Query.iter() must end cleanly instead of raising RuntimeError (PEP 479)."""
+        from viur.core import db
+        query = db.Query("test_iter_skel")
+        query.queries = None
+        self.assertEqual(list(query.iter()), [])
+
+
 class TestQueryFilter(ViURTestCase):
     def test_in_filter_does_not_create_multiquery(self) -> None:
         """IN filter must not create a multi-query (list of QueryDefinitions)."""


### PR DESCRIPTION
`iter_skel()` is to `iter()` what` fetch()` is to `run()`: it walks a large result set via the query cursor 
without pulling it in advance, but yields SkeletonInstances instead of Entities. Every result is a  
 separate instance sharing the source skeleton's bone-map, so collecting or writing the results      
 inside the loop behaves as expected.                                                                
                                                                                                     
The query must have been created by skel.all(); queries without a srcSkel and multi-queries raise   
immediately on call instead of on the first next(), which is why the iteration itself lives in an   
inner generator.

Also fix Query.iter() raising StopIteration inside a generator: PEP 479 turns that into a           
RuntimeError, so an unsatisfiable query now ends the iteration cleanly.