### PR TITLE
fix(file): parse absolute download URLs and an appended file name

### DIFF
--- a/src/viur/core/modules/file.py
+++ b/src/viur/core/modules/file.py
@@ -11,7 +11,7 @@ import string
 import typing as t
 import warnings
 from collections import namedtuple
-from urllib.parse import quote as urlquote, unquote as urlunquote, urlencode
+from urllib.parse import parse_qs, quote as urlquote, unquote as urlunquote, urlencode, urlsplit
 from urllib.request import urlopen
 
 import PIL
@@ -678,16 +678,24 @@ class File(Tree):
         """
         Parses a file download URL in the format `/file/download/xxxx?sig=yyyy` into its FilePath.
 
+        The URL may be absolute, because admin frontends store it including scheme and host, and
+        it may carry an additional path segment after the payload: :meth:`download` accepts the
+        download file name that way, and a bare trailing slash occurs as well.
+
         If the URL cannot be parsed, the function returns None.
 
         :param url: The file download URL to be parsed.
         :return: A FilePath on success, None otherwise.
         """
-        if not url.startswith(cls.DOWNLOAD_URL_PREFIX) or "?" not in url:
+        parsed_url = urlsplit(url)
+
+        if not parsed_url.path.startswith(cls.DOWNLOAD_URL_PREFIX) or not parsed_url.query:
             return None
 
-        data, sig = url.removeprefix(cls.DOWNLOAD_URL_PREFIX).split("?", 1)  # Strip "/file/download/" and split on "?"
-        sig = sig.removeprefix("sig=")
+        # Strip "/file/download/"; the payload is urlsafe-base64 and therefore never contains a
+        # slash, so anything after the first one is the optional download file name.
+        data = parsed_url.path.removeprefix(cls.DOWNLOAD_URL_PREFIX).split("/", 1)[0]
+        sig = parse_qs(parsed_url.query).get("sig", [""])[0]
 
         if not cls.hmac_verify(data, sig):
             # Invalid signature

--- a/tests/modules/test_file.py
+++ b/tests/modules/test_file.py
@@ -61,3 +61,59 @@ class TestFileDownloadUrl(ViURTestCase):
     def test_expired_url(self):
         """A signature whose lifetime has passed must not parse."""
         self.assertIsNone(self._roundtrip("document.pdf", expires=datetime.timedelta(hours=-1)))
+
+    def _create_url(self, filename, *, derived=False, expires=None, download_filename=None):
+        """Create a download url without parsing it back."""
+        with mock.patch("google.cloud.storage.Client"):
+            from viur.core.modules.file import File
+        return File.create_download_url(
+            "testdlkey", filename, derived=derived, expires=expires,
+            download_filename=download_filename)
+
+    def test_absolute_url(self):
+        """Admin frontends store the url including scheme and host; it must still parse."""
+        with mock.patch("google.cloud.storage.Client"):
+            from viur.core.modules.file import File
+        url = self._create_url("document.pdf")
+        result = File.parse_download_url(f"https://example.com{url}")
+        self.assertIsNotNone(result)
+        self.assertEqual(result.dlkey, "testdlkey")
+        self.assertEqual(result.filename, "document.pdf")
+
+    def test_trailing_slash_before_query(self):
+        """A slash between payload and query string must not break the signature check."""
+        with mock.patch("google.cloud.storage.Client"):
+            from viur.core.modules.file import File
+        data, _, query = self._create_url("document.pdf").removeprefix(
+            File.DOWNLOAD_URL_PREFIX).partition("?")
+        result = File.parse_download_url(f"{File.DOWNLOAD_URL_PREFIX}{data}/?{query}")
+        self.assertIsNotNone(result)
+        self.assertEqual(result.filename, "document.pdf")
+
+    def test_url_with_download_filename_path_segment(self):
+        """`download` accepts the file name as a path segment, so parsing must ignore it."""
+        with mock.patch("google.cloud.storage.Client"):
+            from viur.core.modules.file import File
+        data, _, query = self._create_url(
+            "document.pdf", download_filename="nice-name.pdf").removeprefix(
+            File.DOWNLOAD_URL_PREFIX).partition("?")
+        result = File.parse_download_url(
+            f"{File.DOWNLOAD_URL_PREFIX}{data}/nice-name.pdf?{query}")
+        self.assertIsNotNone(result)
+        self.assertEqual(result.dlkey, "testdlkey")
+        self.assertEqual(result.filename, "document.pdf")
+
+    def test_query_with_additional_parameters(self):
+        """Other query parameters next to `sig` must not confuse the parser."""
+        with mock.patch("google.cloud.storage.Client"):
+            from viur.core.modules.file import File
+        url = self._create_url("document.pdf")
+        result = File.parse_download_url(f"{url}&download=1")
+        self.assertIsNotNone(result)
+        self.assertEqual(result.filename, "document.pdf")
+
+    def test_url_without_query_is_rejected(self):
+        with mock.patch("google.cloud.storage.Client"):
+            from viur.core.modules.file import File
+        url = self._create_url("document.pdf").split("?", 1)[0]
+        self.assertIsNone(File.parse_download_url(url))


### PR DESCRIPTION
### Description

`parse_download_url` matched the raw URL string: it required the string to start with
`/file/download/` and treated everything before `?` as the signed payload. Three common forms
therefore failed `hmac_verify` and returned `None`:

- **absolute URLs** — admin frontends store the URL including scheme and host
- **an appended download file name** — `/file/download/<payload>/<name>?sig=…`, which
  `File.download` itself accepts as its `fileName` argument
- **a bare trailing slash** after the payload

The consequence is not cosmetic. `TextBone.getReferencedBlobs` resolves embedded files through
this method, so a file referenced by such a URL never receives a blob lock. As long as the
`file` entity exists, `FileLeafSkel.preProcessBlobLocks` still holds the blob — but once an
editor deletes the entry in the file manager, nothing does, and `doCleanupDeletedFiles` removes
the blob. The image in the rich-text content is then gone for good.

### Changes

- Split the URL with `urlsplit` and validate `parsed_url.path`, so scheme and host no longer
  matter.
- Take only the segment up to the first slash as the payload — urlsafe-base64 never contains a
  slash, so this covers both the appended file name and the trailing slash.
- Read `sig` with `parse_qs` instead of `removeprefix("sig=")`, which also makes the parser
  tolerate further query parameters.

Signature and expiry handling are unchanged.

### Tests

Five new cases in `tests/modules/test_file.py`: absolute URL, trailing slash, appended file
name, an additional query parameter, and a URL without a query string. The full suite passes
locally (`python -m unittest discover tests`: 68 tests).