### PR TITLE
feat: add `escape_html`-parameter to `TextBone`

### DIFF
--- a/src/viur/core/bones/text.py
+++ b/src/viur/core/bones/text.py
@@ -7,7 +7,7 @@ import string
 import typing as t
 import warnings
 from html.parser import HTMLParser
-from viur.core import db, conf, i18n
+from viur.core import db, conf, i18n, utils
 from .base import ReadFromClientError, ReadFromClientErrorSeverity
 from .raw import RawBone
 
@@ -300,7 +300,15 @@ class TextBone(RawBone):
     :param srcSet: An optional dictionary containing width and height for srcset generation.
         Must be a dict of "width": [List of Ints], "height": [List of Ints], eg {"height": [720, 1080]}
     :param indexed: Whether the content should be indexed for searching. Defaults to False.
+    :param escape_html: If set to False, the content is stored as-is, without any sanitizing.
+        Only allowed together with `validHtml=None`.
     :param kwargs: Additional keyword arguments to be passed to the base class constructor.
+
+    ..Warning: Setting `escape_html=False` disables any server-side sanitizing and therefore leads to
+        security vulnerabilities like reflected XSS unless the content is either otherwise
+        validated/stripped or comes from a trusted source. Additionally, the bone stops tracking
+        referenced files, so blobs linked from within the content are no longer protected from
+        being deleted.
     """
 
     class __undefinedC__:
@@ -315,6 +323,7 @@ class TextBone(RawBone):
         max_length: int = 200000,
         srcSet: t.Optional[dict[str, list]] = None,
         indexed: bool = False,
+        escape_html: bool = True,
         **kwargs
     ):
         """
@@ -324,6 +333,9 @@ class TextBone(RawBone):
             :param indexed: Must not be set True, unless you limit max_length accordingly
             :param srcSet: If set, inject srcset tags to embedded images. Must be a dict of
                 "width": [List of Ints], "height": [List of Ints], eg {"height": [720, 1080]}
+            :param escape_html: If set to False, the content is stored without any sanitizing;
+                neither tags are filtered nor special characters are escaped, and line breaks are
+                kept. Requires `validHtml=None`.
         """
         # fixme: Remove in viur-core >= 4
         if "maxLength" in kwargs:
@@ -334,9 +346,13 @@ class TextBone(RawBone):
         if validHtml == TextBone.__undefinedC__:
             validHtml = conf.bone_html_default_allow
 
+        if not escape_html and validHtml is not None:
+            raise ValueError("escape_html=False is only allowed with validHtml=None")
+
         self.validHtml = validHtml
         self.max_length = max_length
         self.srcSet = srcSet
+        self.escape_html = escape_html
 
     def singleValueSerialize(self, value, skel: 'SkeletonInstance', name: str, parentIndexed: bool):
         """
@@ -348,10 +364,13 @@ class TextBone(RawBone):
         return value
 
     def singleValueFromClient(self, value, skel, bone_name, client_data):
-        if not (err := self.isInvalid(value)):  # Returns None on success, error-str otherwise
-            return HtmlSerializer(self.validHtml, self.srcSet, False).sanitize(value), None
-        else:
+        if err := self.isInvalid(value):  # Returns None on success, error-str otherwise
             return self.getEmptyValue(), [ReadFromClientError(ReadFromClientErrorSeverity.Invalid, err)]
+
+        if not self.escape_html:
+            return value, None
+
+        return HtmlSerializer(self.validHtml, self.srcSet, False).sanitize(value), None
 
     def getEmptyValue(self):
         """
@@ -392,8 +411,11 @@ class TextBone(RawBone):
         :param SkeletonInstance skel: A SkeletonInstance object containing the data of an entry.
         :param str name: The name of the TextBone for which to find referenced blobs.
         :return: A set containing the blob keys of the referenced files in the TextBone's HTML content.
+            Always empty when `escape_html` is disabled, as the content is then not treated as HTML.
         :rtype: Set[str]
         """
+        if not self.escape_html:
+            return set()
 
         collector = CollectBlobKeys()
 
@@ -428,9 +450,33 @@ class TextBone(RawBone):
         to the existing HTML content. It re-parses the content and updates the src-set attributes
         accordingly.
 
+        When `escape_html` is disabled, the content is unescaped instead, to revert values that
+        have been escaped by a previous configuration of this bone. Note that line breaks removed
+        by the former sanitizing cannot be restored.
+
         :param SkeletonInstance skel: A SkeletonInstance object containing the data of an entry.
         :param str boneName: The name of the TextBone for which to refresh the src-set.
         """
+        if not self.escape_html:
+            # TODO: duplicate code, this is the same iteration logic as in StringBone
+            new_value = {}
+            for _, lang, value in self.iter_bone_value(skel, boneName):
+                if value is not None:
+                    value = utils.string.unescape(value)
+                new_value.setdefault(lang, []).append(value)
+
+            if not self.multiple:
+                # take the first one
+                new_value = {lang: values[0] for lang, values in new_value.items() if values}
+
+            if self.languages:
+                skel[boneName] = new_value
+            else:
+                # just the value(s) with None language
+                skel[boneName] = new_value.get(None, [] if self.multiple else self.getEmptyValue())
+
+            return
+
         if self.srcSet:
             val = skel[boneName]
             if self.languages and isinstance(val, dict):
@@ -441,4 +487,5 @@ class TextBone(RawBone):
     def structure(self) -> dict:
         return super().structure() | {
             "valid_html": self.validHtml,
+            "escape_html": self.escape_html,
         }

--- a/tests/bones/test_text_bone.py
+++ b/tests/bones/test_text_bone.py
@@ -118,6 +118,79 @@ class TestTextBone_fromClient(ViURTestCase):
         )
         self.assertEqual(1, len(result))
 
+    def test_escape_html_requires_valid_html_none(self):
+        from viur.core.bones import TextBone
+        # The default validHtml (conf.bone_html_default_allow) conflicts with a disabled escaping
+        with self.assertRaises(ValueError):
+            TextBone(escape_html=False)
+        # ... an explicitly given validHtml as well
+        with self.assertRaises(ValueError):
+            TextBone(validHtml={"validTags": ["b"]}, escape_html=False)
+        # Only the plain-text mode may skip the sanitizer
+        TextBone(validHtml=None, escape_html=False)
+
+    def test_escape_html_false_keeps_value_raw(self):
+        from viur.core.bones import TextBone
+        bone = TextBone(validHtml=None, escape_html=False)
+        skel = {}
+        client_value = 'line 1 with <b>bold</b> and a < b\nline 2 with "quotes" and \'apostrophes\'\nline 3'
+        res = bone.singleValueFromClient(client_value, skel, self.bone_name, None)
+        self.assertEqual((client_value, None), res)
+
+    def test_escape_html_false_still_validates(self):
+        from viur.core.bones import TextBone
+        from viur.core.bones import ReadFromClientError, ReadFromClientErrorSeverity
+        bone = TextBone(validHtml=None, escape_html=False, max_length=5)
+        skel = {}
+        # None is still rejected
+        value, errors = bone.singleValueFromClient(None, skel, self.bone_name, None)
+        self.assertEqual("", value)
+        self.assertIsInstance(rfce := errors[0], ReadFromClientError)
+        self.assertIs(ReadFromClientErrorSeverity.Invalid, rfce.severity)
+        # max_length is still enforced
+        value, errors = bone.singleValueFromClient("too long", skel, self.bone_name, None)
+        self.assertEqual("", value)
+        self.assertIsInstance(errors[0], ReadFromClientError)
+
+    def test_escape_html_false_tracks_no_blobs(self):
+        from viur.core.bones import TextBone
+        bone = TextBone(validHtml=None, escape_html=False)
+        skel = {self.bone_name: '<img src="/file/download/some-dlkey">'}
+        self.assertEqual(set(), bone.getReferencedBlobs(skel, self.bone_name))
+
+    def test_refresh_unescapes(self):
+        from viur.core.bones import TextBone
+        bone = TextBone(validHtml=None, escape_html=False)
+        skel = {self.bone_name: "a &lt; b and &quot;quoted&quot;"}
+        bone.refresh(skel, self.bone_name)
+        self.assertEqual('a < b and "quoted"', skel[self.bone_name])
+
+    def test_refresh_unescapes_multiple(self):
+        from viur.core.bones import TextBone
+        bone = TextBone(validHtml=None, escape_html=False, multiple=True)
+        skel = {self.bone_name: ["a &lt; b", "c &gt; d"]}
+        bone.refresh(skel, self.bone_name)
+        self.assertEqual(["a < b", "c > d"], skel[self.bone_name])
+
+    def test_refresh_unescapes_languages(self):
+        from viur.core.bones import TextBone
+        bone = TextBone(validHtml=None, escape_html=False, languages=["de", "en"])
+        skel = {self.bone_name: {"de": "a &lt; b", "en": "c &gt; d"}}
+        bone.refresh(skel, self.bone_name)
+        self.assertEqual({"de": "a < b", "en": "c > d"}, skel[self.bone_name])
+
+    def test_refresh_keeps_value_when_escaping(self):
+        from viur.core.bones import TextBone
+        bone = TextBone()
+        skel = {self.bone_name: "a &lt; b"}
+        bone.refresh(skel, self.bone_name)
+        self.assertEqual("a &lt; b", skel[self.bone_name])
+
+    def test_structure_contains_escape_html(self):
+        from viur.core.bones import TextBone
+        self.assertTrue(TextBone().structure()["escape_html"])
+        self.assertFalse(TextBone(validHtml=None, escape_html=False).structure()["escape_html"])
+
     def test_html_parsing(self):
         from viur.core.bones import TextBone
         bone = TextBone()


### PR DESCRIPTION
Adds `escape_html` to `TextBone`, mirroring the `StringBone` option. With `escape_html=False` the value is stored as-is — no tags filtered, no characters escaped, line breaks preserved. Previously every value 
  went through `HtmlSerializer`, so a plain multi-line text bone was impossible even with `validHtml=None`.                                                                                                        
                                                                                                                                                                                                                   
  - Only allowed with `validHtml=None`, otherwise `ValueError` (default included, it falls back to `conf.bone_html_default_allow`)                                                                                 
  - Validation (`max_length`, `required`, type) unchanged — only sanitizing is skipped                                                                                                                             
  - `getReferencedBlobs()` returns an empty set; content is no longer parsed as HTML                                                                                                                               
  - `refresh()` unescapes stored values to migrate entries written under the old behavior (`multiple` and `languages` included)                                                                                    
  - `structure()` exposes the flag for the admin UI                                                                                                                                                                
  - Default `True` → no behavior change                                                                                                                                                                            
                                                                                                                                                                                                                   
  **Security:** disabling escaping removes all server-side sanitizing (XSS risk) and blob tracking, so linked files are no longer protected from deletion. Documented as a warning in the docstring.               
                                                                                                                                                                                                                   
  **Tests:** invalid parameter combinations, raw pass-through, validation, empty blob set, `refresh()` unescaping in all variants, `structure()`.                                                                  
                                                                                                                                                                                                                      