### PR TITLE
fix: `getDefaultValue` shares one list across all languages of a multiple bone

### DIFF
--- a/src/viur/core/bones/base.py
+++ b/src/viur/core/bones/base.py
@@ -537,7 +537,13 @@ class BaseBone(object):
         elif isinstance(self.defaultValue, list):
             return self.defaultValue[:]
         elif isinstance(self.defaultValue, dict):
-            return self.defaultValue.copy()
+            # A shallow dict copy is not enough: the inner lists must be copied as well,
+            # otherwise all languages share one list instance living on the bone, and any
+            # mutation bleeds into the other languages and into every other skeleton.
+            return {
+                lang: value[:] if isinstance(value, list) else value
+                for lang, value in self.defaultValue.items()
+            }
         else:
             return self.defaultValue
 

--- a/src/viur/core/bones/base.py
+++ b/src/viur/core/bones/base.py
@@ -535,12 +535,15 @@ class BaseBone(object):
             return res
 
         elif isinstance(self.defaultValue, list):
-            return copy.deepcopy(self.defaultValue)
+            return self.defaultValue[:]
         elif isinstance(self.defaultValue, dict):
-            # Deep copy each value on its own: inside self.defaultValue all languages
-            # can share one list instance, and a single deepcopy over the whole dict
-            # would faithfully reproduce exactly that aliasing.
-            return {lang: copy.deepcopy(value) for lang, value in self.defaultValue.items()}
+            # A shallow dict copy is not enough: the inner lists must be copied as well,
+            # otherwise all languages share one list instance living on the bone, and any
+            # mutation bleeds into the other languages and into every other skeleton.
+            return {
+                lang: value[:] if isinstance(value, list) else value
+                for lang, value in self.defaultValue.items()
+            }
         else:
             return self.defaultValue
 

--- a/src/viur/core/bones/base.py
+++ b/src/viur/core/bones/base.py
@@ -535,15 +535,12 @@ class BaseBone(object):
             return res
 
         elif isinstance(self.defaultValue, list):
-            return self.defaultValue[:]
+            return copy.deepcopy(self.defaultValue)
         elif isinstance(self.defaultValue, dict):
-            # A shallow dict copy is not enough: the inner lists must be copied as well,
-            # otherwise all languages share one list instance living on the bone, and any
-            # mutation bleeds into the other languages and into every other skeleton.
-            return {
-                lang: value[:] if isinstance(value, list) else value
-                for lang, value in self.defaultValue.items()
-            }
+            # Deep copy each value on its own: inside self.defaultValue all languages
+            # can share one list instance, and a single deepcopy over the whole dict
+            # would faithfully reproduce exactly that aliasing.
+            return {lang: copy.deepcopy(value) for lang, value in self.defaultValue.items()}
         else:
             return self.defaultValue
 

--- a/tests/bones/test_base_bone.py
+++ b/tests/bones/test_base_bone.py
@@ -18,6 +18,18 @@ class TestBaseBone_getDefaultValue(ViURTestCase):
         # ... and must not pollute the default of the next skeleton
         self.assertEqual({"de": [], "en": []}, bone.getDefaultValue(None))
 
+    def test_getDefaultValue_languages_default_key_no_shared_list(self):
+        from viur.core.bones import BaseBone
+        bone = BaseBone(languages=["de", "en"], multiple=True, defaultValue={"__default__": ["x"]})
+
+        value = bone.getDefaultValue(None)
+        self.assertEqual({"de": ["x"], "en": ["x"]}, value)
+        self.assertIsNot(value["de"], value["en"])
+
+        value["de"].append("y")
+        self.assertEqual(["x"], value["en"])
+        self.assertEqual({"de": ["x"], "en": ["x"]}, bone.getDefaultValue(None))
+
     def test_getDefaultValue_multiple_no_shared_list(self):
         from viur.core.bones import BaseBone
         bone = BaseBone(multiple=True)

--- a/tests/bones/test_base_bone.py
+++ b/tests/bones/test_base_bone.py
@@ -1,0 +1,29 @@
+from abstract import ViURTestCase
+
+
+class TestBaseBone_getDefaultValue(ViURTestCase):
+    def test_getDefaultValue_languages_multiple_no_shared_list(self):
+        from viur.core.bones import BaseBone
+        bone = BaseBone(languages=["de", "en"], multiple=True)
+
+        value = bone.getDefaultValue(None)
+        self.assertEqual({"de": [], "en": []}, value)
+        # Each language must get its own list instance
+        self.assertIsNot(value["de"], value["en"])
+
+        # Mutating one language must not affect the others
+        value["de"].append("foo")
+        self.assertEqual([], value["en"])
+
+        # ... and must not pollute the default of the next skeleton
+        self.assertEqual({"de": [], "en": []}, bone.getDefaultValue(None))
+
+    def test_getDefaultValue_multiple_no_shared_list(self):
+        from viur.core.bones import BaseBone
+        bone = BaseBone(multiple=True)
+
+        value = bone.getDefaultValue(None)
+        self.assertEqual([], value)
+
+        value.append("foo")
+        self.assertEqual([], bone.getDefaultValue(None))


### PR DESCRIPTION
For a bone with `languages` and `multiple`, the constructor builds the default value as `{lang: default for lang in self.languages}` - with a single empty list instance as `default`. `getDefaultValue()` then only returns `self.defaultValue.copy()`, a shallow copy: the dict is new, but all languages still point to that one list, which also remains the instance stored on the bone itself.

Any code that fills the freshly initialized value in place - e.g. `skel[name][lang].append(...)`, which is how `setBoneValue(..., append=True, language=...)` works - therefore writes into all languages at once. And since the mutated list is the bone's own `defaultValue` (bones live on the skeleton class, i.e. process level), the mutation survives the request: every skeleton created afterwards starts with the accumulated entries of previous ones. Introduced with #1282, which turned the per-language `None` default into a single shared `[]`.

Fixed by copying the inner lists as well when `getDefaultValue` hands out a dict default, analogous to the existing `self.defaultValue[:]` for plain list defaults. `fromClient` and `unserialize` are not affected - they already build fresh lists per language.