### PR TITLE
fix: `ColorBone` rejects misplaced `#` and non-string values

### DIFF
--- a/src/viur/core/bones/color.py
+++ b/src/viur/core/bones/color.py
@@ -1,4 +1,5 @@
 import string
+import typing as t
 from viur.core import i18n
 from .base import BaseBone, ReadFromClientError, ReadFromClientErrorSeverity
 
@@ -14,45 +15,55 @@ class ColorBone(BaseBone):
     """
     type = "color"
 
+    # Accepted number of hex digits (without the leading "#") per mode
+    VALID_LENGTHS: t.Final[dict[str, tuple[int, ...]]] = {
+        "rgb": (3, 6),
+        "rgba": (8,),
+    }
+
     def __init__(self, *, mode="rgb", **kwargs):  # mode rgb/rgba
         super().__init__(**kwargs)
-        assert mode in {"rgb", "rgba"}
+        assert mode in self.VALID_LENGTHS
         self.mode = mode
 
     def singleValueFromClient(self, value, skel, bone_name, client_data):
+        """
+        Normalize a hex color to a lower-case value with exactly one leading "#".
+
+        A leading "#" is optional in the input, but it's the only position a "#" may
+        appear in. The remaining characters must be hex digits in a length valid for
+        the bone's mode; the 3-digit shorthand is expanded. Everything else is
+        rejected as invalid.
+        """
+        def invalid():
+            return self.getEmptyValue(), [ReadFromClientError(ReadFromClientErrorSeverity.Invalid)]
+
+        if not isinstance(value, str):
+            return invalid()
+
         value = value.lower()
 
-        if value.count("#") > 1:
-            return self.getEmptyValue(), [
-                ReadFromClientError(ReadFromClientErrorSeverity.Invalid)]
+        if value.startswith("#"):  # strip the optional leading "#"
+            value = value[1:]
 
-        for char in value:
-            if char not in string.hexdigits + "#":
-                return self.getEmptyValue(), [
-                    ReadFromClientError(ReadFromClientErrorSeverity.Invalid)]
+        if any(char not in string.hexdigits for char in value):
+            return invalid()
 
-        if self.mode == "rgb":
-            if len(value) == 3:
-                value = "#" + value
-            if len(value) == 4:
-                value = value[0:2] + value[1] + 2 * value[2] + 2 * value[3]
-            if len(value) == 6 or len(value) == 7:
-                if len(value) == 6:
-                    value = "#" + value
-            else:
-                return self.getEmptyValue(), [
-                    ReadFromClientError(ReadFromClientErrorSeverity.Invalid)]
+        if len(value) not in self.VALID_LENGTHS[self.mode]:
+            return invalid()
 
-        if self.mode == "rgba":
-            if len(value) == 8 or len(value) == 9:
-                if len(value) == 8:
-                    value = "#" + value
-            else:
-                return self.getEmptyValue(), [
-                    ReadFromClientError(ReadFromClientErrorSeverity.Invalid)]
+        if len(value) == 3:  # expand the shorthand: "abc" --> "aabbcc"
+            value = "".join(char * 2 for char in value)
+
+        value = f"#{value}"
 
         err = self.isInvalid(value)
         if not err:
             return value, None
 
         return self.getEmptyValue(), [ReadFromClientError(ReadFromClientErrorSeverity.Invalid, err)]
+
+    def structure(self) -> dict:
+        return super().structure() | {
+            "mode": self.mode,
+        }

--- a/src/viur/core/bones/color.py
+++ b/src/viur/core/bones/color.py
@@ -23,7 +23,8 @@ class ColorBone(BaseBone):
 
     def __init__(self, *, mode="rgb", **kwargs):  # mode rgb/rgba
         super().__init__(**kwargs)
-        assert mode in self.VALID_LENGTHS
+        if mode not in self.VALID_LENGTHS:
+            raise ValueError(f"{mode=} is not in {self.VALID_LENGTHS!r}")
         self.mode = mode
 
     def singleValueFromClient(self, value, skel, bone_name, client_data):

--- a/tests/bones/test_color_bone.py
+++ b/tests/bones/test_color_bone.py
@@ -107,7 +107,7 @@ class TestColorBoneSingleValueFromClient(ViURTestCase):
 
     def test_invalid_mode_raises(self):
         from viur.core.bones.color import ColorBone
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(ValueError):
             ColorBone(mode="hsv")
 
 

--- a/tests/bones/test_color_bone.py
+++ b/tests/bones/test_color_bone.py
@@ -50,6 +50,35 @@ class TestColorBoneSingleValueFromClient(ViURTestCase):
         # 8-char hex is RGBA length, not valid in rgb mode
         self._invalid(self.rgb, "aabbccdd")
 
+    def test_rgb_short_3_chars_expanded(self):
+        self._valid(self.rgb, "abc", "#aabbcc")
+
+    def test_rgb_short_3_chars_with_hash_expanded(self):
+        self._valid(self.rgb, "#abc", "#aabbcc")
+
+    def test_rgb_short_2_chars_with_hash(self):
+        # "#ab" is 2 hex digits, no valid length
+        self._invalid(self.rgb, "#ab")
+
+    def test_rgb_seven_hex_digits_without_hash(self):
+        self._invalid(self.rgb, "abcdefa")
+
+    def test_rgb_hash_in_the_middle(self):
+        self._invalid(self.rgb, "ab#cde")
+
+    def test_rgb_hash_only(self):
+        self._invalid(self.rgb, "#")
+
+    def test_rgb_empty_string(self):
+        self._invalid(self.rgb, "")
+
+    def test_rgb_non_string_value(self):
+        # a JSON client may send anything - must be a validation error, not a crash
+        self._invalid(self.rgb, 123)
+
+    def test_rgb_non_string_container(self):
+        self._invalid(self.rgb, {"color": "#aabbcc"})
+
     # --- RGBA mode ---
 
     def test_rgba_full_with_hash(self):
@@ -64,9 +93,31 @@ class TestColorBoneSingleValueFromClient(ViURTestCase):
     def test_rgba_invalid_char(self):
         self._invalid(self.rgba, "#aabbccgg")
 
+    def test_rgba_short_3_chars(self):
+        # the rgb shorthand is not expanded in rgba mode
+        self._invalid(self.rgba, "abc")
+
+    def test_rgba_hash_in_the_middle(self):
+        self._invalid(self.rgba, "aabb#ccdd")
+
+    def test_rgba_non_string_value(self):
+        self._invalid(self.rgba, 123)
+
     # --- mode validation ---
 
     def test_invalid_mode_raises(self):
         from viur.core.bones.color import ColorBone
         with self.assertRaises(AssertionError):
             ColorBone(mode="hsv")
+
+
+class TestColorBoneStructure(ViURTestCase):
+    """ColorBone.structure: the mode must reach the client."""
+
+    def test_structure_contains_rgb_mode(self):
+        from viur.core.bones.color import ColorBone
+        self.assertEqual("rgb", ColorBone().structure()["mode"])
+
+    def test_structure_contains_rgba_mode(self):
+        from viur.core.bones.color import ColorBone
+        self.assertEqual("rgba", ColorBone(mode="rgba").structure()["mode"])


### PR DESCRIPTION
## What                                                                                                                                                                                                          
                                                                                                                                                                                                                   
  `ColorBone.singleValueFromClient` only counted the `#` characters and then                                                                                                                                       
  looked at lengths. The position of the `#` was never checked and the length                                                                                                                                      
  branches cascaded into each other (len 3 → prepend `#` → len 4 → expand), so                                                                                                                                     
  malformed input was silently accepted and stored in a broken form:                                                                                                                                               
                                                                                                                                                                                                                   
  | Input       | Before                       | After     |                                                                                                                                                       
  |-------------|------------------------------|-----------|                                                                                                                                                       
  | `"#ab"`     | stored as `"###aabb"`        | `Invalid` |                                                                                                                                                       
  | `"abcdefa"` | stored as-is, without a `#`  | `Invalid` |                                                                                                                                                       
  | `"ab#cde"`  | stored as `"#ab#cde"`        | `Invalid` |                                                                                                                                                       
  | `123`       | `AttributeError` → HTTP 500  | `Invalid` |                                                                                                                                                       
                                                                                                                                                                                                                   
  Validation now works the other way round: strip an optional leading `#` once,                                                                                                                                    
  check the remainder as pure hex digits, check its length against the ones valid                                                                                                                                  
  for the mode (3 or 6 for `rgb`, 8 for `rgba`), expand the 3-digit shorthand and                                                                                                                                  
  prepend exactly one `#`. Non-string values are rejected instead of crashing.                                                                                                                                     
                                                                                                                                                                                                                   
  Additionally, `ColorBone` had no `structure()` override, so `mode` never reached                                                                                                                                 
  the client — an rgb and an rgba bone looked identical. `structure()` now exposes                                                                                                                                 
  `mode`.                                                                                                                                                                                                          
                                                                                                                                                                                                                   
  Unchanged behaviour: `"aabbcc"`/`"#aabbcc"` → `"#aabbcc"`, `"abc"` → `"#aabbcc"`,                                                                                                                                
  `"AABBCC"` → `"#aabbcc"`, `"##aabbcc"` → `Invalid`, `mode="rgba"` accepts 8 hex                                                                                                                                  
  digits only.                                                                                                                                                                                                     
                                                                                                                                                                                                                   
  ## Breaking change                                                                                                                                                                                               
                                                                                                                                                                                                                   
  This is a behaviour change: input that used to be accepted (and mangled) is now                                                                                                                                  
  rejected with `ReadFromClientErrorSeverity.Invalid`. Values already stored in the                                                                                                                                
  datastore are untouched and are not re-validated on read, so existing malformed                                                                                                                                  
  values (e.g. `###aabb`) stay as they are.