### PR TITLE
fix: `DateBone` `now` parsing

### DIFF
--- a/src/viur/core/bones/date.py
+++ b/src/viur/core/bones/date.py
@@ -97,8 +97,8 @@ class DateBone(BaseBone):
                 assumes UTC timezone
                 is digit (may include one '-') and NOT valid POSIX timestamp and not date and time: interpreted as
                 seconds after epoch
-                'now': current time
-                'nowX', where X converted into String is added as seconds to current time
+                'now': current time, only if time
+                'nowX', where X converted into String is added as seconds to current time, only if time
                 '%H:%M:%S' if not date and time
                 '%M:%S' if not date and time
                 '%S' if not date and time
@@ -127,9 +127,10 @@ class DateBone(BaseBone):
             else:
                 value = datetime.datetime.fromtimestamp(float(value), tz=time_zone).replace(microsecond=0)
 
-        elif value.lower().startswith("now"):
+        elif self.time and value.lower().startswith("now"):
             # must be checked before the time-only branch below, otherwise "now" would end up
-            # in the time parser and get rejected on bones with date=False
+            # in the time parser and get rejected on bones with date=False.
+            # Only bones carrying a time accept it; on a date-only bone the time is cropped anyway.
             now = datetime.datetime.now(time_zone)
             if offset := value[3:]:
                 try:

--- a/src/viur/core/bones/date.py
+++ b/src/viur/core/bones/date.py
@@ -127,6 +127,18 @@ class DateBone(BaseBone):
             else:
                 value = datetime.datetime.fromtimestamp(float(value), tz=time_zone).replace(microsecond=0)
 
+        elif value.lower().startswith("now"):
+            # must be checked before the time-only branch below, otherwise "now" would end up
+            # in the time parser and get rejected on bones with date=False
+            now = datetime.datetime.now(time_zone)
+            if offset := value[3:]:
+                try:
+                    now += datetime.timedelta(seconds=int(offset))
+                except ValueError:
+                    now = None
+
+            value = now
+
         elif not self.date and self.time:
             try:
                 value = datetime.datetime.fromisoformat(value)
@@ -154,16 +166,6 @@ class DateBone(BaseBone):
 
                 except ValueError:
                     value = None
-
-        elif value.lower().startswith("now"):
-            now = datetime.datetime.now(time_zone)
-            if len(value) > 4:
-                try:
-                    now += datetime.timedelta(seconds=int(value[3:]))
-                except ValueError:
-                    now = None
-
-            value = now
 
         else:
             # try to parse ISO-formatted date string

--- a/src/viur/core/bones/date.py
+++ b/src/viur/core/bones/date.py
@@ -97,8 +97,9 @@ class DateBone(BaseBone):
                 assumes UTC timezone
                 is digit (may include one '-') and NOT valid POSIX timestamp and not date and time: interpreted as
                 seconds after epoch
-                'now': current time, only if time
-                'nowX', where X converted into String is added as seconds to current time, only if time
+                'now': current time, only if date and time
+                'nowX', where X converted into String is added as seconds to current time,
+                only if date and time
                 '%H:%M:%S' if not date and time
                 '%M:%S' if not date and time
                 '%S' if not date and time
@@ -127,18 +128,20 @@ class DateBone(BaseBone):
             else:
                 value = datetime.datetime.fromtimestamp(float(value), tz=time_zone).replace(microsecond=0)
 
-        elif self.time and value.lower().startswith("now"):
-            # must be checked before the time-only branch below, otherwise "now" would end up
-            # in the time parser and get rejected on bones with date=False.
-            # Only bones carrying a time accept it; on a date-only bone the time is cropped anyway.
-            now = datetime.datetime.now(time_zone)
-            if offset := value[3:]:
-                try:
-                    now += datetime.timedelta(seconds=int(offset))
-                except ValueError:
-                    now = None
+        elif value.lower().startswith("now"):
+            # must be checked before the time-only branch below, so that "now" is answered here
+            # instead of silently falling through into the time parser
+            if not self.time or not self.date:
+                value = None
+            else:
+                now = datetime.datetime.now(time_zone)
+                if offset := value[3:]:
+                    try:
+                        now += datetime.timedelta(seconds=int(offset))
+                    except ValueError:
+                        now = None
 
-            value = now
+                value = now
 
         elif not self.date and self.time:
             try:

--- a/tests/bones/test_date_bone.py
+++ b/tests/bones/test_date_bone.py
@@ -86,3 +86,66 @@ class TestDateBone_setBoneValue(ViURTestCase):
             self.assertTrue(bone.setBoneValue(skel, self.bone_name, value.strftime(fmt), False, None))
             self.assertIn(self.bone_name, skel)
             self.assertEqual(skel[self.bone_name], value)
+
+
+class TestDateBone_now(ViURTestCase):
+    """Tests for the "now" / "nowX" input format, which must work in any bone configuration."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.bone_name = "myDateBone"
+
+    def _assert_now(self, bone, value: str, offset: td = td()) -> None:
+        """Assert that `value` is accepted and resolves to the current time plus `offset`."""
+        skel = {}
+        before = dt.now(tz=tz.utc)
+        self.assertTrue(bone.setBoneValue(skel, self.bone_name, value, False, None))
+        after = dt.now(tz=tz.utc)
+
+        self.assertIn(self.bone_name, skel)
+        result = skel[self.bone_name]
+        self.assertIsInstance(result, dt)
+        # microseconds are stripped, so the result may lag up to one second behind
+        self.assertGreaterEqual(result, before + offset - td(seconds=1))
+        self.assertLessEqual(result, after + offset)
+
+    def _assert_invalid(self, bone, value: str) -> None:
+        skel = {}
+        self.assertFalse(bone.setBoneValue(skel, self.bone_name, value, False, None))
+        self.assertNotIn(self.bone_name, skel)
+
+    def test_now_date_and_time(self):
+        from viur.core.bones import DateBone
+        self._assert_now(DateBone(), "now")
+
+    def test_now_time_only(self):
+        from viur.core.bones import DateBone
+        self._assert_now(DateBone(date=False), "now")
+
+    def test_now_date_only(self):
+        from viur.core.bones import DateBone
+        self._assert_now(DateBone(time=False), "now")
+
+    def test_now_case_insensitive(self):
+        from viur.core.bones import DateBone
+        self._assert_now(DateBone(), "NOW")
+        self._assert_now(DateBone(), "Now")
+        self._assert_now(DateBone(), "NOW5", td(seconds=5))
+
+    def test_now_offset(self):
+        from viur.core.bones import DateBone
+        # a single-digit offset must not be swallowed
+        self._assert_now(DateBone(), "now5", td(seconds=5))
+        self._assert_now(DateBone(), "now10", td(seconds=10))
+        self._assert_now(DateBone(), "now-5", td(seconds=-5))
+        self._assert_now(DateBone(), "now-3600", td(hours=-1))
+
+    def test_now_offset_time_only(self):
+        from viur.core.bones import DateBone
+        self._assert_now(DateBone(date=False), "now5", td(seconds=5))
+
+    def test_now_invalid_offset(self):
+        from viur.core.bones import DateBone
+        self._assert_invalid(DateBone(), "nowfoo")
+        self._assert_invalid(DateBone(), "now-foo")
+        self._assert_invalid(DateBone(date=False), "nowfoo")

--- a/tests/bones/test_date_bone.py
+++ b/tests/bones/test_date_bone.py
@@ -89,7 +89,7 @@ class TestDateBone_setBoneValue(ViURTestCase):
 
 
 class TestDateBone_now(ViURTestCase):
-    """Tests for the "now" / "nowX" input format, which must work in any bone configuration."""
+    """Tests for the "now" / "nowX" input format, which is accepted by any bone carrying a time."""
 
     @classmethod
     def setUpClass(cls) -> None:
@@ -122,9 +122,11 @@ class TestDateBone_now(ViURTestCase):
         from viur.core.bones import DateBone
         self._assert_now(DateBone(date=False), "now")
 
-    def test_now_date_only(self):
+    def test_now_rejected_on_date_only(self):
         from viur.core.bones import DateBone
-        self._assert_now(DateBone(time=False), "now")
+        # without a time there is nothing "now" could express, the date part is cropped anyway
+        self._assert_invalid(DateBone(time=False), "now")
+        self._assert_invalid(DateBone(time=False), "now5")
 
     def test_now_case_insensitive(self):
         from viur.core.bones import DateBone

--- a/tests/bones/test_date_bone.py
+++ b/tests/bones/test_date_bone.py
@@ -89,7 +89,7 @@ class TestDateBone_setBoneValue(ViURTestCase):
 
 
 class TestDateBone_now(ViURTestCase):
-    """Tests for the "now" / "nowX" input format, which is accepted by any bone carrying a time."""
+    """Tests for the "now" / "nowX" input format, which requires a bone with both date and time."""
 
     @classmethod
     def setUpClass(cls) -> None:
@@ -118,13 +118,15 @@ class TestDateBone_now(ViURTestCase):
         from viur.core.bones import DateBone
         self._assert_now(DateBone(), "now")
 
-    def test_now_time_only(self):
+    def test_now_rejected_on_time_only(self):
         from viur.core.bones import DateBone
-        self._assert_now(DateBone(date=False), "now")
+        # without a date the offset has nothing to carry the overflow into
+        self._assert_invalid(DateBone(date=False), "now")
+        self._assert_invalid(DateBone(date=False), "now5")
 
     def test_now_rejected_on_date_only(self):
         from viur.core.bones import DateBone
-        # without a time there is nothing "now" could express, the date part is cropped anyway
+        # without a time there is nothing "now" could express, the time part is cropped anyway
         self._assert_invalid(DateBone(time=False), "now")
         self._assert_invalid(DateBone(time=False), "now5")
 
@@ -142,12 +144,7 @@ class TestDateBone_now(ViURTestCase):
         self._assert_now(DateBone(), "now-5", td(seconds=-5))
         self._assert_now(DateBone(), "now-3600", td(hours=-1))
 
-    def test_now_offset_time_only(self):
-        from viur.core.bones import DateBone
-        self._assert_now(DateBone(date=False), "now5", td(seconds=5))
-
     def test_now_invalid_offset(self):
         from viur.core.bones import DateBone
         self._assert_invalid(DateBone(), "nowfoo")
         self._assert_invalid(DateBone(), "now-foo")
-        self._assert_invalid(DateBone(date=False), "nowfoo")


### PR DESCRIPTION
The docstring lists `now` and `nowX` as accepted formats. Neither behaved as                                                                                                                                     
  documented.                                                                                                                                                                                                      
                                                                                                                                                                                                                   
  **Single-digit offsets were swallowed.** The offset was guarded by                                                                                                                                               
  `len(value) > 4`, so `"now5"` (length 4) silently meant "now", while `"now10"`                                                                                                                                   
  added ten seconds and `"now-5"` worked by accident. The decision is now made on                                                                                                                                  
  the remainder `value[3:]`, so any offset is applied; an unparsable remainder                                                                                                                                     
  (`"nowfoo"`) stays `Invalid`.                                                                                                                                                                                    
                                                                                                                                                                                                                   
  **`now` now requires both date and time.** It resolves to a full timestamp, so                                                                                                                                   
  it only carries meaning on a bone that keeps both parts: a date-only bone crops                                                                                                                                  
  the time, and a time-only bone has no date to carry the overflow of an offset.                                                                                                                                   
  The branch was also moved ahead of the time-only branch                                                                                                                                                          
  (`not self.date and self.time`), so `now` is answered where it belongs instead                                                                                                                                   
  of falling through into the time parser and being rejected there as a malformed                                                                                                                                  
  time.                                                                                                                                                                                                            
                                                                                                                                                                                                                   
  | bone | `"now"` / `"now5"` |                                                                                                                                                                                    
  |---|---|                                                                                                                                                                                                        
  | `DateBone()` | accepted |                                                                                                                                                                                      
  | `DateBone(date=False)` | `Invalid` (unchanged, just decided earlier) |                                                                                                                                         
  | `DateBone(time=False)` | `Invalid` (was accepted) |                                                                                                                                                            
                                                                                                                                                                                                                   
                     
  Behaviour change for existing clients: `"now5"` means now + 5 seconds instead of                                                                                                                                 
  now, and `DateBone(time=False)` no longer accepts `now`.                                                 