### PR TITLE
fix: validate required `FileBone` refKeys and export `max_file_size`

### DIFF
--- a/src/viur/core/bones/file.py
+++ b/src/viur/core/bones/file.py
@@ -196,14 +196,22 @@ class FileBone(TreeLeafBone):
         """
         super().__init__(refKeys=refKeys, **kwargs)
 
-        for _required in ("dlkey", "name"):
-            if _required not in self.refKeys:
-                raise ValueError(f"FileBone not operable without refKey {_required!r}")
-
         self.derive = derive
         self.public = public
         self.validMimeTypes = validMimeTypes
         self.maxFileSize = maxFileSize
+
+        # isInvalid() reads these bones from the RefSkel; a missing one silently
+        # becomes None there, so require them up-front instead.
+        for _required in ("dlkey", "name", "public"):
+            if _required not in self.refKeys:
+                raise ValueError(f"FileBone not operable without refKey {_required!r}")
+
+        if self.validMimeTypes and "mimetype" not in self.refKeys:
+            raise ValueError("FileBone with validMimeTypes not operable without refKey 'mimetype'")
+
+        if self.maxFileSize and "size" not in self.refKeys:
+            raise ValueError("FileBone with maxFileSize not operable without refKey 'size'")
 
     def isInvalid(self, value):
         """
@@ -370,6 +378,7 @@ class FileBone(TreeLeafBone):
     def structure(self) -> dict:
         return super().structure() | {
             "valid_mime_types": self.validMimeTypes,
+            "max_file_size": self.maxFileSize,
             "public": self.public,
         }
 

--- a/tests/bones/test_file_bone.py
+++ b/tests/bones/test_file_bone.py
@@ -1,0 +1,95 @@
+from unittest import mock
+
+from abstract import ViURTestCase
+from viur.core import conf
+from viur.core.bones.file import FileBone
+from viur.core.skeleton import Skeleton
+
+# MetaSkel only accepts skeletons defined below conf.skeleton_search_path. The paths
+# are relative to the test root, so this file is seen as "/bones/test_file_bone.py".
+conf.skeleton_search_path = tuple(conf.skeleton_search_path) + ("/bones/",)
+
+# Importing the file module registers FileSkel as kind "file", which the FileBone
+# needs to build its RefSkel. The module creates a GCS client on import.
+with mock.patch("google.cloud.storage.Client"):
+    from viur.core.modules.file import File  # noqa: F401
+
+
+class StructureProbeSkel(Skeleton):
+    """Host skeleton, so the bone below gets a RefSkel to report its structure from."""
+    kindName = "structure_probe"
+    file = FileBone(maxFileSize=1024, validMimeTypes=["image/*"])
+
+
+class TestFileBoneStructure(ViURTestCase):
+    """FileBone.structure: values the admin UI needs before uploading."""
+
+    def setUp(self):
+        super().setUp()
+        self.bone = StructureProbeSkel.file
+        self.bone.setSystemInitialized()
+
+    def test_max_file_size_is_exported(self):
+        self.assertEqual(1024, self.bone.structure()["max_file_size"])
+
+    def test_valid_mime_types_are_exported(self):
+        self.assertEqual(["image/*"], self.bone.structure()["valid_mime_types"])
+
+    def test_public_is_exported(self):
+        self.assertIs(False, self.bone.structure()["public"])
+
+
+class TestFileBoneRefKeys(ViURTestCase):
+    """FileBone.__init__: refKeys required by isInvalid must be present."""
+
+    def setUp(self):
+        super().setUp()
+        from viur.core.bones.file import FileBone
+        self.FileBone = FileBone
+
+    # --- accepted configurations ---
+
+    def test_defaults_are_operable(self):
+        bone = self.FileBone()
+        self.assertIn("public", bone.refKeys)
+
+    def test_minimal_refkeys_without_validation(self):
+        bone = self.FileBone(refKeys=["dlkey", "name", "public"])
+        self.assertEqual({"dlkey", "name", "public"}, bone.refKeys & {"dlkey", "name", "public"})
+
+    def test_mimetype_not_required_without_valid_mime_types(self):
+        self.FileBone(refKeys=["dlkey", "name", "public", "size"])
+
+    def test_size_not_required_without_max_file_size(self):
+        self.FileBone(refKeys=["dlkey", "name", "public", "mimetype"])
+
+    # --- rejected configurations ---
+
+    def test_missing_dlkey_raises(self):
+        with self.assertRaises(ValueError):
+            self.FileBone(refKeys=["name", "public"])
+
+    def test_missing_name_raises(self):
+        with self.assertRaises(ValueError):
+            self.FileBone(refKeys=["dlkey", "public"])
+
+    def test_missing_public_raises(self):
+        with self.assertRaises(ValueError) as cm:
+            self.FileBone(refKeys=["dlkey", "name"])
+        self.assertIn("public", str(cm.exception))
+
+    def test_missing_mimetype_with_valid_mime_types_raises(self):
+        with self.assertRaises(ValueError) as cm:
+            self.FileBone(
+                refKeys=["dlkey", "name", "public"],
+                validMimeTypes=["image/*"],
+            )
+        self.assertIn("mimetype", str(cm.exception))
+
+    def test_missing_size_with_max_file_size_raises(self):
+        with self.assertRaises(ValueError) as cm:
+            self.FileBone(
+                refKeys=["dlkey", "name", "public"],
+                maxFileSize=1024,
+            )
+        self.assertIn("size", str(cm.exception))

--- a/tests/bones/test_file_bone.py
+++ b/tests/bones/test_file_bone.py
@@ -1,94 +1,60 @@
-from unittest import mock
-
 from abstract import ViURTestCase
-from viur.core import conf
-from viur.core.bones.file import FileBone
-from viur.core.skeleton import Skeleton
-
-# MetaSkel only accepts skeletons defined below conf.skeleton_search_path. The paths
-# are relative to the test root, so this file is seen as "/bones/test_file_bone.py".
-conf.skeleton_search_path = tuple(conf.skeleton_search_path) + ("/bones/",)
-
-# Importing the file module registers FileSkel as kind "file", which the FileBone
-# needs to build its RefSkel. The module creates a GCS client on import.
-with mock.patch("google.cloud.storage.Client"):
-    from viur.core.modules.file import File  # noqa: F401
-
-
-class StructureProbeSkel(Skeleton):
-    """Host skeleton, so the bone below gets a RefSkel to report its structure from."""
-    kindName = "structure_probe"
-    file = FileBone(maxFileSize=1024, validMimeTypes=["image/*"])
-
-
-class TestFileBoneStructure(ViURTestCase):
-    """FileBone.structure: values the admin UI needs before uploading."""
-
-    def setUp(self):
-        super().setUp()
-        self.bone = StructureProbeSkel.file
-        self.bone.setSystemInitialized()
-
-    def test_max_file_size_is_exported(self):
-        self.assertEqual(1024, self.bone.structure()["max_file_size"])
-
-    def test_valid_mime_types_are_exported(self):
-        self.assertEqual(["image/*"], self.bone.structure()["valid_mime_types"])
-
-    def test_public_is_exported(self):
-        self.assertIs(False, self.bone.structure()["public"])
 
 
 class TestFileBoneRefKeys(ViURTestCase):
     """FileBone.__init__: refKeys required by isInvalid must be present."""
 
-    def setUp(self):
-        super().setUp()
-        from viur.core.bones.file import FileBone
-        self.FileBone = FileBone
-
     # --- accepted configurations ---
 
     def test_defaults_are_operable(self):
-        bone = self.FileBone()
+        from viur.core.bones import FileBone
+        bone = FileBone()
         self.assertIn("public", bone.refKeys)
 
     def test_minimal_refkeys_without_validation(self):
-        bone = self.FileBone(refKeys=["dlkey", "name", "public"])
+        from viur.core.bones import FileBone
+        bone = FileBone(refKeys=["dlkey", "name", "public"])
         self.assertEqual({"dlkey", "name", "public"}, bone.refKeys & {"dlkey", "name", "public"})
 
     def test_mimetype_not_required_without_valid_mime_types(self):
-        self.FileBone(refKeys=["dlkey", "name", "public", "size"])
+        from viur.core.bones import FileBone
+        FileBone(refKeys=["dlkey", "name", "public", "size"])
 
     def test_size_not_required_without_max_file_size(self):
-        self.FileBone(refKeys=["dlkey", "name", "public", "mimetype"])
+        from viur.core.bones import FileBone
+        FileBone(refKeys=["dlkey", "name", "public", "mimetype"])
 
     # --- rejected configurations ---
 
     def test_missing_dlkey_raises(self):
+        from viur.core.bones import FileBone
         with self.assertRaises(ValueError):
-            self.FileBone(refKeys=["name", "public"])
+            FileBone(refKeys=["name", "public"])
 
     def test_missing_name_raises(self):
+        from viur.core.bones import FileBone
         with self.assertRaises(ValueError):
-            self.FileBone(refKeys=["dlkey", "public"])
+            FileBone(refKeys=["dlkey", "public"])
 
     def test_missing_public_raises(self):
+        from viur.core.bones import FileBone
         with self.assertRaises(ValueError) as cm:
-            self.FileBone(refKeys=["dlkey", "name"])
+            FileBone(refKeys=["dlkey", "name"])
         self.assertIn("public", str(cm.exception))
 
     def test_missing_mimetype_with_valid_mime_types_raises(self):
+        from viur.core.bones import FileBone
         with self.assertRaises(ValueError) as cm:
-            self.FileBone(
+            FileBone(
                 refKeys=["dlkey", "name", "public"],
                 validMimeTypes=["image/*"],
             )
         self.assertIn("mimetype", str(cm.exception))
 
     def test_missing_size_with_max_file_size_raises(self):
+        from viur.core.bones import FileBone
         with self.assertRaises(ValueError) as cm:
-            self.FileBone(
+            FileBone(
                 refKeys=["dlkey", "name", "public"],
                 maxFileSize=1024,
             )


### PR DESCRIPTION
`FileBone.isInvalid()` reads `mimetype`, `size` and `public` from the RefSkel.                                                                                                                                   
  A bone missing from the RefSkel resolves to `None` there instead of raising, so                                                                                                                                  
  restricting `refKeys` silently rejected every file (`public`) or crashed on the                                                                                                                                  
  first request (`mimetype`, `size`).                                                                                                                                                                              
                                                                                                                                                                                                                   
  - `__init__` now requires `public` next to `dlkey`/`name`, plus `mimetype` when                                                                                                                                  
    `validMimeTypes` is set and `size` when `maxFileSize` is set — the                                                                                                                                             
    misconfiguration surfaces on import instead of at runtime.                                                                                                                                                     
  - `structure()` exports `maxFileSize` as `max_file_size`, so the admin UI knows                                                                                                                                  
    the limit before uploading.                                                                                                                                                                                    
  - Adds `tests/bones/test_file_bone.py`.                                                                                                                                                                          
                                                                                                                                                                                                                   
  ⚠️ **Breaking:** projects restricting `refKeys` without `public` (or without                                                                                                                                     
  `mimetype`/`size` while the matching validation is set) now fail on import —                                                                                                                                     
  add the missing key to `refKeys`.     