### PR TITLE
fix: refresh each source entity only once in `update_relations`

### DIFF
--- a/src/viur/core/skeleton/tasks.py
+++ b/src/viur/core/skeleton/tasks.py
@@ -80,7 +80,18 @@ def update_relations(
 
     query.setCursor(cursor)
 
+    # A single entity can reference the same destination more than once (e.g. a list
+    # bone holding the same reference several times), yielding one relation per
+    # occurrence. Refreshing that entity once is enough -- doing it per relation only
+    # stacks transactions on the very same entity and can exceed the request deadline.
+    seen_src_keys: set[db.Key] = set()
+
     for src_rel in query.run():
+        src_key = src_rel["src"].key
+        if src_key in seen_src_keys:
+            continue
+        seen_src_keys.add(src_key)
+
         try:
             skel = skeletonByKind(src_rel["viur_src_kind"])()
         except AssertionError:
@@ -88,9 +99,9 @@ def update_relations(
             continue
 
         try:
-            skel.patch(lambda skel: skel.refresh(), key=src_rel["src"].key, update_relations=False)
+            skel.patch(lambda skel: skel.refresh(), key=src_key, update_relations=False)
         except ValueError:
-            logging.warning(f"Cannot update stale reference to {src_rel["src"].key!r} referenced by {src_rel.key!r}")
+            logging.warning(f"Cannot update stale reference to {src_key!r} referenced by {src_rel.key!r}")
             continue
 
         total += 1

--- a/tests/test_skeleton_tasks.py
+++ b/tests/test_skeleton_tasks.py
@@ -1,0 +1,76 @@
+from unittest import mock
+
+from abstract import ViURTestCase
+
+
+class FakeKey:
+    """A minimal stand-in for a db.Key, hashable and comparable by name."""
+
+    def __init__(self, name: str):
+        self.name = name
+
+    def __hash__(self) -> int:
+        return hash(self.name)
+
+    def __eq__(self, other) -> bool:
+        return isinstance(other, FakeKey) and other.name == self.name
+
+    def __repr__(self) -> str:
+        return f"<FakeKey {self.name}>"
+
+
+class TestUpdateRelations(ViURTestCase):
+
+    def _refreshed_keys(self, src_keys: list) -> list:
+        """Run update_relations over relations with the given source keys.
+
+        :param src_keys: One source key per ``viur-relations`` entry the query yields.
+        :return: The keys actually passed to ``skel.patch()``.
+        """
+        from viur.core.skeleton import tasks
+
+        relations = []
+        for index, src_key in enumerate(src_keys):
+            relation = dict(src=mock.Mock(key=src_key), viur_src_kind="wishlist")
+            relation = type("Rel", (dict,), {})(relation)
+            relation.key = f"relation-{index}"
+            relations.append(relation)
+
+        query = mock.MagicMock()
+        query.run.return_value = relations
+        query.getCursor.return_value = None
+        query.filter.return_value = query
+
+        refreshed = []
+        skel = mock.MagicMock()
+        skel.patch.side_effect = lambda *args, **kwargs: refreshed.append(kwargs.get("key"))
+
+        with mock.patch.object(tasks.db, "Query", return_value=query), \
+                mock.patch.object(tasks, "skeletonByKind", return_value=lambda: skel), \
+                mock.patch.object(tasks.current, "request_data", mock.MagicMock()):
+            tasks.update_relations(
+                FakeKey("variant"),
+                changed_bones=["shop_name"],
+                _call_deferred=False,
+            )
+        return refreshed
+
+    def test_same_source_is_refreshed_once(self):
+        """A source referencing the destination N times must be refreshed only once.
+
+        Without deduplication this stacks N transactions on the very same entity,
+        which can exceed the request deadline and make the task retry forever.
+        """
+        source = FakeKey("wishlist-1")
+        self.assertEqual(self._refreshed_keys([source] * 48), [source])
+
+    def test_distinct_sources_are_all_refreshed(self):
+        sources = [FakeKey(f"wishlist-{i}") for i in range(5)]
+        self.assertEqual(self._refreshed_keys(sources), sources)
+
+    def test_mixed_sources(self):
+        first, second = FakeKey("wishlist-1"), FakeKey("wishlist-2")
+        self.assertEqual(self._refreshed_keys([first, first, first, second]), [first, second])
+
+    def test_no_relations(self):
+        self.assertEqual(self._refreshed_keys([]), [])


### PR DESCRIPTION
An entity can reference the same destination multiple times — e.g. a list bone
holding the same reference repeatedly — which yields one `viur-relations` entry
per occurrence.

`update_relations` iterated over those relations and issued one
`skel.patch(lambda skel: skel.refresh())` **per relation**, all of them on the
very same source entity. Since every patch opens its own transaction on that
entity, the repetitions stack up and can exceed the request deadline. The
deferred task then answers HTTP 500/408, the Task API retries it, and the next
attempt starts over from the beginning — so the task never completes and keeps
its queue busy indefinitely.

Observed in the wild: a single entity referenced 48 times caused 48 transactions
on that one entity per attempt; the task hit the 10-minute deadline on every one
of its 67 retries across three days. After deduplication it completes in seconds.

Related to #770.

## Change

Deduplicate by source key, so each entity is refreshed once per run. Distinct
sources are unaffected.

## Verification

- Added `tests/test_skeleton_tasks.py` covering the repeated-source case,
  distinct sources, a mixed set and an empty query.
- Confirmed the new tests fail without the fix (48 `patch()` calls instead of 1)
  and pass with it.
- Full suite green: 75 tests, no failures.