### PR TITLE
fix(tasks): honour `_call_deferred=False` when no queue is reachable

### DIFF
--- a/src/viur/core/tasks.py
+++ b/src/viur/core/tasks.py
@@ -524,6 +524,20 @@ def CallDeferred(func: t.Callable) -> t.Callable:
         except Exception:  # This will fail for warmup requests
             req = None
 
+        # It's the deferred method which is called from the task queue, this has to be called directly
+        _call_deferred &= not (req and req.request.headers.get("X-Appengine-Taskretrycount")
+                               and "DEFERRED_TASK_CALLED" not in dir(req))
+
+        if not _call_deferred:
+            # An explicit request to run the task right here. Whether a queue can be reached is a
+            # property of the environment and must not turn this into a deferred call.
+            if self is __undefinedFlag_:
+                return func(*args, **kwargs)
+
+            if req is not None:
+                req.DEFERRED_TASK_CALLED = True
+            return func(self, *args, **kwargs)
+
         if not queueRegion:
             # Run tasks inline
             logging.debug(f"{func=} will be executed inline")
@@ -542,17 +556,6 @@ def CallDeferred(func: t.Callable) -> t.Callable:
                 task()
 
             return  # Ensure no result gets passed back
-
-        # It's the deferred method which is called from the task queue, this has to be called directly
-        _call_deferred &= not (req and req.request.headers.get("X-Appengine-Taskretrycount")
-                               and "DEFERRED_TASK_CALLED" not in dir(req))
-
-        if not _call_deferred:
-            if self is __undefinedFlag_:
-                return func(*args, **kwargs)
-
-            req.DEFERRED_TASK_CALLED = True
-            return func(self, *args, **kwargs)
 
         else:
             try:

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,0 +1,51 @@
+"""Tests for the dispatching in :mod:`viur.core.tasks`."""
+from unittest import mock
+
+from abstract import ViURTestCase
+
+
+class TestCallDeferredDirectCall(ViURTestCase):
+    """``_call_deferred=False`` must run the wrapped function right away.
+
+    Whether a task queue can be reached is a property of the environment and must not
+    change that: callers use the parameter precisely because they need the result now,
+    for instance to invoke a `@CallDeferred` decorated super method.
+    """
+
+    def _decorated_task(self) -> tuple:
+        """Build a freshly decorated task recording its calls.
+
+        :return: Tuple of the tasks module, the decorated function and the list of calls.
+        """
+        from viur.core import tasks
+
+        calls = []
+
+        @tasks.CallDeferred
+        def record_call(value):
+            calls.append(value)
+
+        self.addCleanup(tasks._deferred_tasks.pop, f"record_call.{__name__}", None)
+        return tasks, record_call, calls
+
+    def test_direct_call_without_queue(self):
+        tasks, record_call, calls = self._decorated_task()
+        with mock.patch.object(tasks, "queueRegion", None):
+            record_call("a", _call_deferred=False)
+        self.assertEqual(["a"], calls)
+
+    def test_direct_call_without_queue_but_inside_a_request(self):
+        """A request in the context must not turn the direct call into a pending task."""
+        from viur.core import current
+
+        tasks, record_call, calls = self._decorated_task()
+        request = mock.MagicMock()
+        request.request.headers = {}
+        token = current.request.set(request)
+        self.addCleanup(current.request.reset, token)
+
+        with mock.patch.object(tasks, "queueRegion", None):
+            record_call("b", _call_deferred=False)
+
+        self.assertEqual(["b"], calls)
+        request.pendingTasks.append.assert_not_called()


### PR DESCRIPTION
## Summary

Move the `_call_deferred` evaluation in `make_deferred` in front of the "no queue region"
branch, so an explicit direct call is honoured regardless of whether a task queue can be
reached. Adds `tests/test_tasks.py` covering both cases.

## Motivation

`_call_deferred=False` is documented as "Calls the @CallDeferred decorated method directly",
with calling a decorated super method as the use case. That did not hold whenever no queue
region was available: the branch running tasks inline came first, appended the call to
`req.pendingTasks` and returned, without ever looking at `_call_deferred`.

The effect depended on whether a request was in the context:

- no request → the task was executed immediately, the parameter appeared to work
- request present → the call was deferred to the end of the request, or never happened

So on a development server without the tasks emulator, code relying on the super method
having run silently continued with a stale state. `req.DEFERRED_TASK_CALLED` is now only
set when there actually is a request, which the reordering makes reachable.

## Verification

`tests/test_tasks.py` fails on the previous code with `['b'] != []` — the wrapped function
was never called — and passes with the change. Full suite on this branch: 77 tests, no
failures.

Found while investigating the three failing `test_skeleton_tasks` tests on `develop`. They
fail there and not here only because `develop` has tests that set `current.request` without
resetting it, which makes the request-present path above the default for everything running
after them. The test isolation is addressed separately against `develop`; this is the
underlying defect and it exists in both branches.
