### PR TITLE
fix: import cycle on direct `viur.core.skeleton` import, and test isolation

### DIFF
--- a/src/viur/core/skeleton/__init__.py
+++ b/src/viur/core/skeleton/__init__.py
@@ -2,6 +2,12 @@ import logging
 import warnings
 
 from .adapter import DatabaseAdapter, ViurTagsSearchAdapter
+# The bones package has to be complete before the first skeleton class is built: MetaBaseSkel
+# reaches into it while the class body is executed, and bones.image in turn subclasses RelSkel.
+# Importing viur.core establishes that order anyway; this keeps it intact for anyone importing
+# viur.core.skeleton directly.
+from .. import bones as _bones  # noqa: F401
+
 from .base import BaseSkeleton
 from .instance import SkeletonInstance
 from .meta import ABSTRACT_SKEL_CLS_SUFFIX, MetaBaseSkel, MetaSkel, Skeleton_Cls

--- a/tests/abstract.py
+++ b/tests/abstract.py
@@ -1,3 +1,4 @@
+import contextvars
 import os
 import unittest
 from unittest import mock
@@ -16,4 +17,20 @@ class ViURTestCase(unittest.TestCase):
         google.auth.default = mock.Mock(return_value=(mock.Mock(), os.getenv("GOOGLE_CLOUD_PROJECT")))
 
     def tearDown(self) -> None:
+        self._reset_context_vars()
         self.testbed.deactivate()
+
+    @staticmethod
+    def _reset_context_vars() -> None:
+        """Clear the context variables of :mod:`viur.core.current`.
+
+        They live for as long as the process does, so a request or session left behind by one
+        test is still in place for every test running after it. That silently changes what the
+        code under test sees -- a request in the context can, for instance, turn a direct call
+        into a deferred one.
+        """
+        from viur.core import current
+
+        for value in vars(current).values():
+            if isinstance(value, contextvars.ContextVar):
+                value.set(None)


### PR DESCRIPTION
## Summary

- Load the bones package before the first skeleton class is built, which resolves the import
  cycle hit when `viur.core.skeleton` is imported without `viur.core` having been imported first
- Reset the `viur.core.current` context variables in `ViURTestCase.tearDown`, so tests no longer
  inherit a request or session from whatever ran before them

## Motivation

The three `test_skeleton_tasks` tests fail on `develop` and pass on `main`, which looks odd
because the tests and the code under test are identical in both branches.

The difference is the test infrastructure. `develop` has two test modules that `main` does not
(`test_decorators.py` and `modules/test_user_app_login.py`, both from #1661). Both call
`current.request.set(...)` and never reset it. Context variables outlive the test, so every
test running afterwards sees that request — and with a request in the context, `make_deferred`
sends the task down the deferred path instead of running it. The assertion then compares
against an empty list.

So neither #1661 nor #1756 is wrong on its own; `develop` went red when the latter arrived
through the `v3.8.35` merge and met the leak left by the former.

The import cycle is unrelated and only visible when `viur.core.skeleton` is the first thing
imported, which is what `test_skeleton_tasks` does:

```
skeleton/base.py → bones/__init__ → bones/image.py → skeleton/relskel.py → skeleton/base.py
```

`MetaBaseSkel` reaches into bones while the `BaseSkeleton` class body runs, so the package has
to be complete by then. Importing `viur.core` establishes that order anyway — this keeps it for
the direct entry point too. It surfaced in #1738, when `BaseSkeleton` moved into `base.py`.

## Verification

Full suite on this branch: 515 tests, no failures — the three failures are gone with the
isolation fix alone. `test_skeleton_tasks` run on its own goes from one import error to 4 ok.

## Merge order matters

The deferred-dispatch behaviour these tests stumbled over is a defect in its own right:
`_call_deferred=False` is ignored whenever no queue is reachable. It exists in `main` as well
and is fixed in #1758, together with the regression test for it.

This PR does **not** fix that defect — it removes the leaked request that happened to expose it.
Merging this one alone therefore turns a visible bug back into a silent one, and `develop` would
carry no test for it until #1758 arrives here through the next `main` merge.

So: merge #1758 first, let it reach `develop`, then merge this one. Or merge this one knowingly
and treat #1758 as the follow-up that must not be dropped.
