### PR TITLE
fix: `read_all_modules` overwrites existing `ModuleConf` entries

### DIFF
--- a/src/viur/core/modules/moduleconf.py
+++ b/src/viur/core/modules/moduleconf.py
@@ -151,7 +151,9 @@ class ModuleConf(List):
     @tasks.StartupTask
     @staticmethod
     def read_all_modules():
-        db_module_names = (m["name"] for m in db.Query(MODULECONF_KINDNAME).run(999))
+        # Must be a set, not a generator: the membership test below runs once per module
+        # and a generator would be consumed by it (see #1762).
+        db_module_names = {m["name"] for m in db.Query(MODULECONF_KINDNAME).run(999)}
         visited_modules = set()
 
         def collect_modules(parent, depth: int = 0, prefix: str = "") -> None:

--- a/tests/modules/test_moduleconf.py
+++ b/tests/modules/test_moduleconf.py
@@ -1,0 +1,89 @@
+from unittest import mock
+
+from abstract import ViURTestCase
+
+
+class FakeSkel(dict):
+    """Minimal stand-in for the skeleton returned by ``ModuleConf.addSkel()``."""
+
+    def __init__(self, sink: list):
+        super().__init__()
+        self._sink = sink
+
+    def write(self, *args, **kwargs):
+        self._sink.append(self["name"])
+
+
+class TestReadAllModules(ViURTestCase):
+    """Regression tests for :meth:`ModuleConf.read_all_modules`."""
+
+    def setUp(self):
+        super().setUp()
+        from viur.core.modules.moduleconf import ModuleConf
+        ModuleConf.MODULES.clear()
+
+    def _collect_written(self, in_db: list[str], in_code: list[str]) -> list[str]:
+        """Run ``read_all_modules()`` against a faked datastore and module tree.
+
+        :param in_db: module names that already have a ``viur-module-conf`` entry.
+        :param in_code: module names the application exposes below ``vi``.
+        :return: the module names a new entry was written for.
+        """
+        from viur.core import Module, conf
+        from viur.core.modules.moduleconf import ModuleConf
+
+        written = []
+
+        class Vi:
+            pass
+
+        vi = Vi()
+        for name in in_code:
+            setattr(vi, name, Module(name, name))
+
+        # not a Module instance, so collect_modules() skips it -- just like at runtime
+        vi._moduleconf = mock.Mock()
+        vi._moduleconf.addSkel = lambda: FakeSkel(written)
+
+        main_app = mock.Mock()
+        main_app.vi = vi
+
+        fake_db = mock.MagicMock()
+        fake_db.Query.return_value.run.return_value = [{"name": name} for name in in_db]
+
+        with mock.patch.object(conf, "main_app", main_app), \
+                mock.patch("viur.core.modules.moduleconf.db", fake_db):
+            ModuleConf.read_all_modules()
+
+        return written
+
+    def test_missing_module_is_created(self):
+        """A module without a `viur-module-conf` entry gets one."""
+        self.assertEqual(self._collect_written(in_db=[], in_code=["alpha"]), ["alpha"])
+
+    def test_known_modules_are_left_alone(self):
+        """Modules that already have an entry must not be written again."""
+        self.assertEqual(self._collect_written(in_db=["alpha", "beta"], in_code=["alpha", "beta"]), [])
+
+    def test_known_module_after_missing_one_is_left_alone(self):
+        """A missing module must not cause the modules checked after it to be rewritten.
+
+        ``read_all_modules()`` tests every module name against the names already
+        stored in the datastore. When that collection is consumed by the test --
+        as a generator expression is -- the first unknown module exhausts it, and
+        every module checked afterwards looks unknown as well. Those entries are
+        then overwritten with a blank skeleton, silently discarding whatever an
+        application stores on its ``ModuleConfSkel`` subclass.
+        """
+        written = self._collect_written(in_db=["alpha", "gamma"], in_code=["alpha", "beta", "gamma"])
+        self.assertEqual(written, ["beta"])
+
+    def test_lookup_is_order_independent(self):
+        """Known modules are recognized regardless of the order they are checked in.
+
+        ``dir()`` yields the module names sorted, so a datastore query returning
+        them in key order happens to line up. Nothing guarantees that, and the
+        lookup must not depend on it.
+        """
+        written = self._collect_written(in_db=["gamma", "alpha"], in_code=["alpha", "beta", "gamma"])
+        self.assertEqual(written, ["beta"])


### PR DESCRIPTION
## The bug

`ModuleConf.read_all_modules` collects the module names that already have a `viur-module-conf` entry, then checks every routable module against them:

```python
db_module_names = (m["name"] for m in db.Query(MODULECONF_KINDNAME).run(999))
...
    if module_name not in db_module_names:
        skel = conf.main_app.vi._moduleconf.addSkel()
        skel["key"] = db.Key(MODULECONF_KINDNAME, module_name)
        skel["name"] = module_name
        skel.write()
```

`db_module_names` is a **generator expression**, and `in` consumes it.

As long as every lookup succeeds, the generator merely advances and the check appears to work. But the first module that has no entry yet drains the generator to exhaustion — and from then on it is empty. Every module checked afterwards is reported as missing and gets written with a blank `addSkel()`.

## Why this loses data

That write is not additive. `ModuleConfSkel` is explicitly meant to be subclassed by applications, and every bone an application adds to it is part of the skeleton — so it is persisted as its empty default. SEO identifiers, per-module configuration, editorial help texts: all silently replaced with `None` / `[]`.

The blast radius is *everything sorted after the first newly added module*. Since `dir()` yields names sorted and the datastore query returns them in key order, the two happen to line up, so the damage is a contiguous run from the new module to the end of the module list.

## Why it went unnoticed for so long

It needs a module to be **added**. On an unchanged deployment every lookup hits, the generator is never exhausted, and the task is correct. It only fires on the first startup after a release that introduces a module or sub-module — and then it leaves no trace: `read_all_modules` completes successfully, it just writes the wrong thing. No exception, no log line.

Worth knowing for anyone assessing exposure: a version that is **deployed but not yet serving traffic** is enough. The startup task runs on the first request that version receives and writes to the same datastore — opening a staged version's URL once can wipe the production entries.

## The fix

The lookup collection becomes a `set`, which is what a repeated membership test needs: it cannot be consumed, and each check is O(1) instead of O(n).

## Regression coverage

`tests/modules/test_moduleconf.py` runs `read_all_modules` against a faked datastore and module tree:

- `test_known_module_after_missing_one_is_left_alone` — the actual regression: a missing module must not cause the modules checked after it to be rewritten.
- `test_lookup_is_order_independent` — the lookup must not depend on the query returning names in the same order `dir()` yields them. Nothing guarantees that alignment.
- plus the two baseline cases (missing module is created, known modules are left alone).

Both regression tests fail on `main` and pass with this change; the full suite is green (79 tests).

## Origin

`read_all_modules` was rewritten into the recursive `collect_modules` form in #1073, which turned the former list into a generator expression. Releases before that are unaffected.

## Left untouched

`run(999)` still caps the lookup — an application with more than 999 modules would reach the same overwrite by a different route. Kept out of this PR to keep the fix minimal, but it is the same failure class and may deserve its own issue.