### PR TITLE
fix: known bugs quick fixes

### DIFF
--- a/docs/known_bugs.md
+++ b/docs/known_bugs.md
@@ -1,60 +1,14 @@
 # Known bugs
 
 Found while reading the code for the seam documentation in `docs/adr/`, at tag
-`v3.8.33`. Nothing in this list has been fixed. Line numbers refer to that tag.
+`v3.8.33`. Line numbers refer to that tag. Everything listed here is still
+open; fixed entries are removed from this file.
 
 The first pass covered the framework seams (skeleton, module, tasks, email,
 file module, ...), the second pass every bone type under
 `src/viur/core/bones/`.
 
 Each entry: what is wrong, what it costs, what the fix would be.
-
-## Broken comparisons and type checks
-
-### `src/viur/core/email.py:403` - dev-server guard never triggers
-
-```python
-if not conf.email.send_from_local_development_server or transport_class is EmailTransportAppengine:
-```
-
-`transport_class` is an *instance* (`conf.email.transport_class`), so
-`is EmailTransportAppengine` is always False. The intent - never deliver
-through the App Engine Mail API from a local development server - is not
-enforced: with `send_from_local_development_server = True` the call goes
-through and fails inside the API instead.
-
-Fix: `isinstance(transport_class, EmailTransportAppengine)`.
-
-### `src/viur/core/email.py:579` - Brevo quota check never runs
-
-```python
-if not isinstance(conf.email.transport_class, EmailTransportSendInBlue):
-    return  # no SIB key, we cannot check
-```
-
-`EmailTransportSendInBlue` is the *deprecated subclass* of
-`EmailTransportBrevo`. A project configured correctly with
-`EmailTransportBrevo()` fails this check, so `check_sib_quota` returns
-immediately and the credit warning emails are never sent.
-
-Fix: check against `EmailTransportBrevo`.
-
-### `src/viur/core/i18n.py:651` - swapped `isinstance` arguments
-
-```python
-if not isinstance(dict, entity["translation"]):
-```
-
-Arguments are the wrong way round; this raises
-`TypeError: isinstance() arg 2 must be a type` instead of validating. It sits
-in `migrate_translation`, which is *not* deferred and not retried (those
-decorators belong to `add_missing_translation`): `DatastoreSource.load` calls
-it synchronously for every translation entity without a `name`, and
-`initializeTranslations` re-raises whatever a source throws. A single
-unmigrated entity that still carries a `translation` field therefore takes the
-whole instance down at startup.
-
-Fix: `isinstance(entity["translation"], dict)`.
 
 ## Wrong values
 
@@ -76,21 +30,6 @@ locked forever.
 
 Fix: `fileskel["weak"] = not parentrepokey`.
 
-### `src/viur/core/bones/base.py:123` - single error is dropped
-
-```python
-if isinstance(errors, ReadFromClientError):
-    errors = (ReadFromClientError, )
-```
-
-The tuple holds the *class*, not the instance. The `isinstance` filter on the
-next lines removes it again, `self.errors` ends up empty and the constructor
-raises `ValueError("ReadFromClientException requires for at least one
-ReadFromClientError")`. Passing a single `ReadFromClientError` - which the
-docstring explicitly allows - is therefore impossible.
-
-Fix: `errors = (errors, )`.
-
 ## Control flow
 
 ### `src/viur/core/modules/file.py:1489` - GC run aborts instead of skipping
@@ -102,20 +41,6 @@ cursor batch) are not processed. Cleanup then only progresses on the next
 periodic call, and only until it hits an already-marked blob again.
 
 Fix: `continue`.
-
-### `src/viur/core/tasks.py:421` - retry notification mail always fails
-
-```python
-stringTemplate=string_template if tpl is None else string_template,
-```
-
-Both branches are identical, so `stringTemplate` is always passed. When
-`retry_n_times(..., tpl="...")` is used, `send_email` receives `tpl` *and*
-`stringTemplate` and raises `ValueError` on its xor check. The surrounding
-`except Exception` swallows it, so the "task failed permanently" mail is
-silently lost - exactly in the situation it exists for.
-
-Fix: pass `stringTemplate` only when `tpl is None`.
 
 ## Dead code paths
 
@@ -140,41 +65,6 @@ endpoint at all.
 
 Fix prompt: `docs/superpowers/plans/2026-09-03-file-download-without-signature.md`
 in the ag-dev repo.
-
-### `src/viur/core/bones/uid.py:22` - the `CollisionError` retry is dead code
-
-```python
-for i in range(3):
-    try:
-        ...
-        db.put(db_obj)
-        break
-    except db.CollisionError:  # recall the function
-        time.sleep(i + 1)
-else:
-    raise ValueError("Can't set the Uid")
-```
-
-`db.CollisionError` does not exist. The symbol came from `viur.datastore` and
-disappeared with the re-integration of the Google Datastore API (#1431);
-`src/viur/core/db/__init__.py` no longer exports it. Python only evaluates the
-`except` expression once something is raised inside the `try`, and then the
-original exception is replaced by `AttributeError: 'super' object has no
-attribute 'CollisionError'`.
-
-So the retry never runs, `time.sleep` is unreachable, the `else` branch of the
-loop cannot raise its `ValueError`, and every real datastore error is masked
-as an `AttributeError`.
-
-Even if the symbol existed the retry would be pointless: `serialize_compute`
-runs inside the skeleton's write transaction (`skeleton/skeleton.py:421`), so
-retrying inside the transaction body cannot resolve a conflict that only
-surfaces on commit - and sleeping there blocks the request. The commit
-conflict is already handled by `db.run_in_transaction`
-(`db/transport.py:166-178`).
-
-Fix: drop the loop and let the conflict propagate to the surrounding
-`run_in_transaction`.
 
 ### `src/viur/core/modules/file.py:767` - `create_src_set` on a multi-language bone
 
@@ -212,20 +102,6 @@ not exist.
 
 Fix: list the names as strings.
 
-### `src/viur/core/prototypes/skelmodule.py:171` - `_apply_default_order` docstring contradicts the code
-
-```python
-The `default_order` will only be applied when the query has no other order, or is on a multquery.
-```
-
-The code does the opposite of the second half: a multi-query is explicitly
-excluded (`not isinstance(query.queries, list)`), so `default_order` is
-applied only to a single query. "multquery" is a typo as well, and the third
-condition (no `search` parameter in the request) is not mentioned at all.
-
-Fix: "... only be applied when the query has no other order, is not a
-multi-query and no `search` parameter was sent."
-
 ### `src/viur/core/db/query.py:485-526` - three methods break on an unsatisfiable query
 
 `queries is None` is the documented "unsatisfiable" state, and `filter`,
@@ -250,29 +126,7 @@ HTTP 500.
 Fix prompt: `docs/superpowers/plans/2026-09-03-query-unsatisfiable-cursor-methods.md`
 in the ag-dev repo.
 
-### `src/viur/core/securityheaders.py:159` - `extendCsp` assumes a policy exists
-
-`conf.security.content_security_policy` may legitimately be `None` (the type
-hint says `t.Optional`), which makes the `.get("enforce")` raise
-`AttributeError`. Note the error page calls `extendCsp` for its style nonce,
-so this turns an error response into a second error.
-
 ## Bones: validation that does not validate
-
-### `src/viur/core/bones/spatial.py:269,273` - invalid geo filter is ignored
-
-```python
-dbFilter.datastoreQuery = None
-```
-
-Both error paths in `SpatialBone.buildDBFilter` (unparseable lat/lng, and
-coordinates outside the configured bounds) try to make the query
-unsatisfiable. `db.Query` has no `datastoreQuery` attribute - the correct one
-is `queries` - so this only creates a new, unused attribute. The query then
-runs **without the spatial constraint** and returns everything the remaining
-filters allow, instead of nothing.
-
-Fix: `dbFilter.queries = None`.
 
 ### `src/viur/core/bones/uri.py:56` - a protocol string becomes a character set
 
@@ -346,44 +200,7 @@ field into a 500.
 Fix: convert with `float(value)` (the value is passed to `fromtimestamp` as a
 float anyway) or catch the ValueError.
 
-### `src/viur/core/bones/randomslice.py:36` - `NotImplemented` is not an exception
-
-```python
-raise NotImplemented("A RandomSliceBone must not visible and readonly!")
-```
-
-`NotImplemented` is a singleton, not an exception class, so this raises
-`TypeError: exceptions must derive from BaseException` and the intended message
-is lost.
-
-Fix: `raise NotImplementedError(...)`.
-
-### `src/viur/core/bones/record.py:124,145` - missing None guard in the write path
-
-`RecordBone.postSavedHandler` and `postDeletedHandler` iterate
-`value.items()` for every entry, while `getSearchTags` and
-`getReferencedBlobs` guard the same loop with `if value is None: continue`. A
-stored `null` inside a `multiple` record therefore raises `AttributeError`
-during save or delete.
-
-Fix: add the same guard.
-
 ## Bones: contract violations
-
-### `src/viur/core/bones/numeric.py:160-162` - missing comma in the error message
-
-```python
-i18n.translate(
-    "core.bones.error.minmax"
-    "Value not between {{min}} and {{max}}",
-```
-
-Two adjacent string literals are concatenated, so the translation *key*
-becomes `core.bones.error.minmaxValue not between {{min}} and {{max}}` and
-there is no default text. The min/max error can never be translated, and
-`add_missing_translations` records the garbage key.
-
-Fix: insert the comma.
 
 ### `src/viur/core/bones/password.py:115` - `isInvalid` returns a list
 

--- a/docs/known_bugs.md
+++ b/docs/known_bugs.md
@@ -128,34 +128,6 @@ in the ag-dev repo.
 
 ## Bones: validation that does not validate
 
-### `src/viur/core/bones/uri.py:56` - a protocol string becomes a character set
-
-```python
-if not isinstance(self.accepted_protocols, Iterable) or isinstance(self.accepted_protocols, str):
-    self.accepted_protocols = set(self.accepted_protocols)
-```
-
-For a plain string, `set("https")` yields `{"h", "t", "p", "s"}`. So
-`UriBone(accepted_protocols="https")` allows the protocols `h`, `t`, `p` and
-`s` - and rejects `https`. The whole restriction is silently inverted.
-
-Two lines later the same parameter is checked for the wildcard - on the
-original argument, not on the normalized one:
-
-```python
-if "*" in accepted_protocols:
-    self.accepted_protocols = None
-```
-
-For a list this is a membership test, for a string a substring test. Any
-string containing a `*` therefore switches the protocol check off entirely:
-`UriBone(accepted_protocols="http*")` accepts `file://x`. Since fnmatch
-patterns are a documented and tested way to write this option, that spelling
-is the obvious one to reach for.
-
-Fix: normalize the str case to `{self.accepted_protocols}` first, then test
-the wildcard against the normalized set.
-
 ### `src/viur/core/bones/uri.py:145` - default ports are rejected
 
 ```python

--- a/docs/known_bugs.md
+++ b/docs/known_bugs.md
@@ -128,21 +128,6 @@ in the ag-dev repo.
 
 ## Bones: validation that does not validate
 
-### `src/viur/core/bones/uri.py:145` - default ports are rejected
-
-```python
-if not any(parsed_url.port in rng for rng in self.accepted_ports):
-```
-
-`urlparse(...).port` is `None` when the URL relies on the scheme default, so
-with `accepted_ports=(443,)` the valid `https://example.com` is rejected. A
-malformed port additionally makes the property itself raise `ValueError`,
-which `isInvalid` does not catch - that becomes a 500 rather than a validation
-error.
-
-Fix: map a missing port to the scheme default before the check, and guard the
-`ValueError`.
-
 ### `src/viur/core/bones/date.py:80` - creation/update magic does not lock the bone
 
 ```python

--- a/docs/known_bugs.md
+++ b/docs/known_bugs.md
@@ -1,8 +1,7 @@
 # Known bugs
 
-Found while reading the code for the seam documentation in `docs/adr/`, at tag
-`v3.8.33`. Line numbers refer to that tag. Everything listed here is still
-open; fixed entries are removed from this file.
+Found while reading the code for the seam documentation in `docs/adr/`.
+Everything listed here is still open; fixed entries are removed from this file.
 
 The first pass covered the framework seams (skeleton, module, tasks, email,
 file module, ...), the second pass every bone type under

--- a/src/viur/core/bones/base.py
+++ b/src/viur/core/bones/base.py
@@ -120,7 +120,7 @@ class ReadFromClientException(Exception):
 
         # Allow to specifiy a single ReadFromClientError
         if isinstance(errors, ReadFromClientError):
-            errors = (ReadFromClientError, )
+            errors = (errors, )
 
         self.errors = tuple(error for error in errors if isinstance(error, ReadFromClientError))
 

--- a/src/viur/core/bones/numeric.py
+++ b/src/viur/core/bones/numeric.py
@@ -212,7 +212,7 @@ class NumericBone(BaseBone):
                 ReadFromClientError(
                     ReadFromClientErrorSeverity.Invalid,
                     i18n.translate(
-                        "core.bones.error.minmax"
+                        "core.bones.error.minmax",
                         "Value not between {{min}} and {{max}}",
                         default_variables={
                             "min": self.min,

--- a/src/viur/core/bones/randomslice.py
+++ b/src/viur/core/bones/randomslice.py
@@ -33,7 +33,7 @@ class RandomSliceBone(BaseBone):
 
         """
         if visible or not readOnly:
-            raise NotImplemented("A RandomSliceBone must not visible and readonly!")
+            raise NotImplementedError("A RandomSliceBone must not visible and readonly!")
         super().__init__(indexed=True, visible=False, readOnly=True, **kwargs)
         self.slices = slices
         self.sliceSize = sliceSize

--- a/src/viur/core/bones/record.py
+++ b/src/viur/core/bones/record.py
@@ -121,6 +121,9 @@ class RecordBone(BaseBone):
                 drop_relations_higher.clear()
                 break
 
+            if value is None:
+                continue
+
             for sub_bone_name, bone in value.items():
                 path = ".".join(name for name in (boneName, lang, f"{idx or 0:02}", sub_bone_name) if name)
                 if utils.string.is_prefix(bone.type, "relational"):
@@ -142,6 +145,9 @@ class RecordBone(BaseBone):
         super().postDeletedHandler(skel, boneName, key)
 
         for idx, lang, value in self.iter_bone_value(skel, boneName):
+            if value is None:
+                continue
+
             for sub_bone_name, bone in value.items():
                 path = ".".join(part for part in (boneName, lang, f"{idx or 0:02}", sub_bone_name) if part)
                 bone.postDeletedHandler(value, path, key)

--- a/src/viur/core/bones/spatial.py
+++ b/src/viur/core/bones/spatial.py
@@ -266,11 +266,11 @@ class SpatialBone(BaseBone):
                 lng = float(rawFilter[name + ".lng"])
             except:
                 logging.debug(f"Received invalid values for lat/lng in {name}")
-                dbFilter.datastoreQuery = None
+                dbFilter.queries = None
                 return
             if self.isInvalid((lat, lng)):
                 logging.debug(f"Values out of range in {name}")
-                dbFilter.datastoreQuery = None
+                dbFilter.queries = None
                 return
             gridSizeLat, gridSizeLng = self.getGridSize()
             tileLat = int(floor((lat - self.boundsLat[0]) / gridSizeLat))

--- a/src/viur/core/bones/uid.py
+++ b/src/viur/core/bones/uid.py
@@ -1,4 +1,3 @@
-import time
 import typing as t
 from viur.core import db
 from viur.core.bones.base import BaseBone, Compute, ComputeInterval, ComputeMethod, UniqueValue, UniqueLockMethod
@@ -10,19 +9,14 @@ def generate_number(db_key: db.Key) -> int:
     """
 
     def transact(_key: db.Key):
-        for i in range(3):
-            try:
-                if db_obj := db.get(_key):
-                    db_obj["count"] += 1
-                else:
-                    db_obj = db.Entity(_key)
-                    db_obj["count"] = 0
-                db.put(db_obj)
-                break
-            except db.CollisionError:  # recall the function
-                time.sleep(i + 1)
+        # A commit conflict only surfaces when the surrounding transaction commits and is
+        # retried by db.run_in_transaction, so it must propagate out of this function.
+        if db_obj := db.get(_key):
+            db_obj["count"] += 1
         else:
-            raise ValueError("Can't set the Uid")
+            db_obj = db.Entity(_key)
+            db_obj["count"] = 0
+        db.put(db_obj)
         return db_obj["count"]
 
     if db.is_in_transaction():

--- a/src/viur/core/bones/uri.py
+++ b/src/viur/core/bones/uri.py
@@ -52,9 +52,17 @@ class UriBone(BaseBone):
 
         self.accepted_protocols = accepted_protocols
         if self.accepted_protocols:
-            if not isinstance(self.accepted_protocols, Iterable) or isinstance(self.accepted_protocols, str):
+            if isinstance(self.accepted_protocols, str):
+                # A single protocol, not a set of its characters
+                self.accepted_protocols = {self.accepted_protocols}
+            elif isinstance(self.accepted_protocols, Iterable):
                 self.accepted_protocols = set(self.accepted_protocols)
-            if "*" in accepted_protocols:
+            else:
+                raise ValueError("accepted_protocols must be a string, an iterable of strings or None")
+
+            # Test the wildcard against the normalized set: "*" on its own switches the
+            # check off, while a pattern such as "http*" is kept and matched by fnmatch.
+            if "*" in self.accepted_protocols:
                 self.accepted_protocols = None
 
         if not isinstance(clean_get_params, bool):

--- a/src/viur/core/bones/uri.py
+++ b/src/viur/core/bones/uri.py
@@ -8,6 +8,18 @@ from collections import namedtuple
 PORT_MIN: t.Final[int] = 1
 PORT_MAX: t.Final[int] = 2 ** 16 - 1
 
+DEFAULT_PORTS: t.Final[dict[str, int]] = {
+    "ftp": 21,
+    "ftps": 990,
+    "http": 80,
+    "https": 443,
+    "sftp": 22,
+    "ssh": 22,
+    "ws": 80,
+    "wss": 443,
+}
+"""The port a URL uses when it does not name one, by scheme"""
+
 
 class UriBone(BaseBone):
     type = "uri"
@@ -28,6 +40,8 @@ class UriBone(BaseBone):
 
         :param accepted_protocols: The accepted protocols can be set to allow only the provide protocols.
         :param accepted_ports The accepted ports can be set to allow only the provide ports.
+            A URL that names no port is checked against the default port of its scheme,
+            see :data:`DEFAULT_PORTS`.
         ..  code-block:: python
             # Example
             UriBone(accepted_ports=1)
@@ -150,8 +164,18 @@ class UriBone(BaseBone):
             return f"""No protocol specified"""
 
         if self.accepted_ports:
-            if not any(parsed_url.port in rng for rng in self.accepted_ports):
-                return f""""{parsed_url.port}" not in the accepted ports."""
+            try:
+                port = parsed_url.port
+            except ValueError:  # the property parses the port, urlparse itself does not
+                return "Can't read the port from the URL"
+
+            if port is None:
+                # The URL relies on the default of its scheme. An unknown scheme leaves the
+                # port undecidable, and an undecidable port cannot be an accepted one.
+                port = DEFAULT_PORTS.get(parsed_url.scheme)
+
+            if port is None or not any(port in rng for rng in self.accepted_ports):
+                return f""""{port}" not in the accepted ports."""
 
         if self.accepted_protocols:
             for protocol in self.accepted_protocols:

--- a/src/viur/core/email.py
+++ b/src/viur/core/email.py
@@ -400,7 +400,8 @@ def send_email(
     transport_class.validate_queue_entity(queued_email)  # Will raise an exception if the entity is not valid
 
     if conf.instance.is_dev_server:
-        if not conf.email.send_from_local_development_server or transport_class is EmailTransportAppengine:
+        if (not conf.email.send_from_local_development_server
+                or isinstance(transport_class, EmailTransportAppengine)):
             logging.info("Not sending email from local development server")
             logging.info(f"""Subject: {queued_email["subject"]}""")
             logging.info(f"""Body: {queued_email["body"]}""")
@@ -576,7 +577,7 @@ class EmailTransportBrevo(EmailTransport):
 
         .. seealso:: https://developers.brevo.com/reference/getaccount
         """
-        if not isinstance(conf.email.transport_class, EmailTransportSendInBlue):
+        if not isinstance(conf.email.transport_class, EmailTransportBrevo):
             return  # no SIB key, we cannot check
 
         req = requests.get(

--- a/src/viur/core/i18n.py
+++ b/src/viur/core/i18n.py
@@ -648,7 +648,7 @@ def migrate_translation(
     if "name" not in entity:
         entity["name"] = entity["key"] or key.name
     if "translation" in entity:
-        if not isinstance(dict, entity["translation"]):
+        if not isinstance(entity["translation"], dict):
             logging.error("translation is not a dict?")
         entity["translation"]["_viurLanguageWrapper_"] = True
     skel = TranslationSkel()

--- a/src/viur/core/i18n.py
+++ b/src/viur/core/i18n.py
@@ -516,9 +516,9 @@ class DatastoreSource(TranslationSource):
             if not entity.get("name"):
                 logging.error(f'translations entity {entity.key} has an empty {entity["name"]=} set. Skipping.')
                 continue
-            if entity and not isinstance(entity["translations"], dict):
-                logging.error(f'translations entity {entity.key} has invalid '
-                              f'translations set: {entity["translations"]}. Skipping.')
+            if not isinstance(entity.get("translations"), dict):
+                logging.error(f"translations entity {entity.key} has invalid "
+                              f"translations set: {entity.get('translations')!r}. Skipping.")
                 continue
 
             res[entity["name"]] = entity["translations"] | {
@@ -647,10 +647,16 @@ def migrate_translation(
     entity: db.Entity = db.get(key)
     if "name" not in entity:
         entity["name"] = entity["key"] or key.name
-    if "translation" in entity:
-        if not isinstance(entity["translation"], dict):
-            logging.error("translation is not a dict?")
-        entity["translation"]["_viurLanguageWrapper_"] = True
+
+    # Pre-3.6 stored the texts as a plain {lang: text} dict. Without the LanguageWrapper
+    # marker BaseBone.unserialize cannot tell the languages apart and puts the whole dict
+    # into the main language -- and translations_missing (compute=OnWrite) reads the bone
+    # during write(), so that is what would be persisted.
+    if not isinstance(translations := entity.get("translations"), dict):
+        logging.error(f"Skipping translation {key}: {translations!r} is not a dict")
+        return
+    translations["_viurLanguageWrapper_"] = True
+
     skel = TranslationSkel()
     skel.setEntity(entity)
     skel["key"] = key

--- a/src/viur/core/prototypes/skelmodule.py
+++ b/src/viur/core/prototypes/skelmodule.py
@@ -169,7 +169,8 @@ class SkelModule(Module):
         """
         Apply the setting from `default_order` to a given db.Query.
 
-        The `default_order` will only be applied when the query has no other order, or is on a multquery.
+        The `default_order` will only be applied when the query has no other order,
+        is not a multi-query and no `search` parameter was sent.
         """
 
         # Apply default_order when possible!

--- a/src/viur/core/securityheaders.py
+++ b/src/viur/core/securityheaders.py
@@ -177,7 +177,7 @@ def extendCsp(additionalRules: dict = None, overrideRules: dict = None) -> None:
     """
     assert additionalRules or overrideRules, "Either additionalRules or overrideRules must be given!"
     tmpDict = {}  # Copy the project-wide config in
-    if conf.security.content_security_policy.get("enforce"):
+    if conf.security.content_security_policy and conf.security.content_security_policy.get("enforce"):
         tmpDict.update({k: v[:] for k, v in conf.security.content_security_policy["enforce"].items()})
     if overrideRules:  # Merge overrideRules
         for k, v in overrideRules.items():

--- a/src/viur/core/tasks.py
+++ b/src/viur/core/tasks.py
@@ -417,8 +417,8 @@ def retry_n_times(retries: int, email_recipients: None | str | list[str] = None,
                             from viur.core import email
                             email.send_email(
                                 dests=email_recipients,
-                                tpl=tpl,
-                                stringTemplate=string_template if tpl is None else string_template,
+                                # send_email accepts tpl xor stringTemplate, never both
+                                **({"tpl": tpl} if tpl is not None else {"stringTemplate": string_template}),
                                 # The following params provide information for the emails templates
                                 func_name=func.__name__,
                                 func_qualname=func.__qualname__,

--- a/tests/bones/test_base_bone.py
+++ b/tests/bones/test_base_bone.py
@@ -39,3 +39,28 @@ class TestBaseBone_getDefaultValue(ViURTestCase):
 
         value.append("foo")
         self.assertEqual([], bone.getDefaultValue(None))
+
+
+class TestReadFromClientException(ViURTestCase):
+    """A single ReadFromClientError has to be accepted, as documented."""
+
+    @staticmethod
+    def _error():
+        from viur.core.bones.base import ReadFromClientError, ReadFromClientErrorSeverity
+        return ReadFromClientError(ReadFromClientErrorSeverity.Invalid, "broken")
+
+    def test_single_error(self):
+        from viur.core.bones.base import ReadFromClientException
+        error = self._error()
+        exception = ReadFromClientException(error)
+        self.assertEqual((error,), exception.errors)
+
+    def test_iterable_of_errors(self):
+        from viur.core.bones.base import ReadFromClientException
+        errors = (self._error(), self._error())
+        self.assertEqual(errors, ReadFromClientException(errors).errors)
+
+    def test_empty_iterable_raises(self):
+        from viur.core.bones.base import ReadFromClientException
+        with self.assertRaises(ValueError):
+            ReadFromClientException([])

--- a/tests/bones/test_numeric_bone.py
+++ b/tests/bones/test_numeric_bone.py
@@ -575,3 +575,20 @@ class TestNumericBoneInit(ViURTestCase):
         from viur.core.bones import NumericBone
         bone = NumericBone(precision=2)
         self.assertIsInstance(bone.getEmptyValue(), float)
+
+
+class TestNumericBoneMinMaxError(ViURTestCase):
+    """The min/max error must carry a usable translation key and a default text."""
+
+    def _error(self, value):
+        from viur.core.bones import NumericBone
+        bone = NumericBone(min=1, max=10)
+        _, errors = bone.singleValueFromClient(value, {}, "amount", {})
+        self.assertEqual(1, len(errors))
+        return errors[0]
+
+    def test_key_is_not_merged_with_the_default_text(self):
+        self.assertEqual("core.bones.error.minmax", self._error(20).errorMessage.key)
+
+    def test_default_text_is_rendered(self):
+        self.assertEqual("Value not between 1 and 10", str(self._error(20).errorMessage))

--- a/tests/bones/test_randomslice_bone.py
+++ b/tests/bones/test_randomslice_bone.py
@@ -1,0 +1,20 @@
+from abstract import ViURTestCase
+
+
+class TestRandomSliceBoneInit(ViURTestCase):
+
+    def test_default_init(self):
+        from viur.core.bones import RandomSliceBone
+        bone = RandomSliceBone()
+        self.assertFalse(bone.visible)
+        self.assertTrue(bone.readOnly)
+
+    def test_visible_raises_not_implemented_error(self):
+        from viur.core.bones import RandomSliceBone
+        with self.assertRaises(NotImplementedError):
+            RandomSliceBone(visible=True)
+
+    def test_writable_raises_not_implemented_error(self):
+        from viur.core.bones import RandomSliceBone
+        with self.assertRaises(NotImplementedError):
+            RandomSliceBone(readOnly=False)

--- a/tests/bones/test_record_bone.py
+++ b/tests/bones/test_record_bone.py
@@ -1,0 +1,64 @@
+from unittest import mock
+
+from abstract import ViURTestCase
+
+
+def _bone():
+    from viur.core.bones import RecordBone
+    from viur.core.skeleton import RelSkel
+
+    class _Using(RelSkel):
+        pass
+
+    return RecordBone(using=_Using, format="$(name)", multiple=True)
+
+
+class TestRecordBoneWritePathNoneValues(ViURTestCase):
+    """A stored ``null`` inside a ``multiple`` record must not break save or delete.
+
+    ``getSearchTags`` and ``getReferencedBlobs`` guard the same loop with
+    ``if value is None: continue``; the write path did not and raised an AttributeError.
+    """
+
+    def _skel_and_key(self):
+        from viur.core import db
+        return mock.MagicMock(), db.Key("test", "1")
+
+    def _iter_values(self, bone, values):
+        """Make ``iter_bone_value`` yield the given values, as the datastore would."""
+        return mock.patch.object(
+            bone, "iter_bone_value",
+            return_value=iter([(idx, None, value) for idx, value in enumerate(values)]),
+        )
+
+    def test_postSavedHandler_skips_none(self):
+        bone = _bone()
+        skel, key = self._skel_and_key()
+        with self._iter_values(bone, [None]):
+            bone.postSavedHandler(skel, "records", key)
+
+    def test_postDeletedHandler_skips_none(self):
+        bone = _bone()
+        skel, key = self._skel_and_key()
+        with self._iter_values(bone, [None]):
+            bone.postDeletedHandler(skel, "records", key)
+
+    def test_postSavedHandler_still_processes_entries_after_none(self):
+        bone = _bone()
+        skel, key = self._skel_and_key()
+        sub_bone = mock.MagicMock()
+        sub_bone.type = "string"
+        entry = {"name": sub_bone}
+        with self._iter_values(bone, [None, entry]):
+            bone.postSavedHandler(skel, "records", key)
+        sub_bone.postSavedHandler.assert_called_once_with(entry, "records.01.name", key)
+
+    def test_postDeletedHandler_still_processes_entries_after_none(self):
+        bone = _bone()
+        skel, key = self._skel_and_key()
+        sub_bone = mock.MagicMock()
+        sub_bone.type = "string"
+        entry = {"name": sub_bone}
+        with self._iter_values(bone, [None, entry]):
+            bone.postDeletedHandler(skel, "records", key)
+        sub_bone.postDeletedHandler.assert_called_once_with(entry, "records.01.name", key)

--- a/tests/bones/test_spatial_bone.py
+++ b/tests/bones/test_spatial_bone.py
@@ -237,3 +237,33 @@ class TestSpatialBoneSingleValueUnserialize(ViURTestCase):
     def test_falsy_returns_none(self):
         self.assertIsNone(self.bone.singleValueUnserialize(None))
         self.assertIsNone(self.bone.singleValueUnserialize({}))
+
+
+class TestSpatialBoneBuildDBFilter(ViURTestCase):
+    """An invalid geo filter has to make the query unsatisfiable, not drop the constraint."""
+
+    def _query(self):
+        from viur.core import db
+        return db.Query("test")
+
+    def test_unparsable_coordinates_clear_the_query(self):
+        query = self._query()
+        _bone().buildDBFilter("location", {}, query, {"location.lat": "abc", "location.lng": "13.4"})
+        self.assertIsNone(query.queries)
+
+    def test_coordinates_out_of_bounds_clear_the_query(self):
+        query = self._query()
+        # Outside of BOUNDS_LAT/BOUNDS_LNG (Germany)
+        _bone().buildDBFilter("location", {}, query, {"location.lat": "10.0", "location.lng": "10.0"})
+        self.assertIsNone(query.queries)
+
+    def test_valid_coordinates_keep_the_query(self):
+        query = self._query()
+        _bone().buildDBFilter("location", {}, query, {"location.lat": "52.5", "location.lng": "13.4"})
+        self.assertIsNotNone(query.queries)
+
+    def test_bone_not_in_filter_is_a_noop(self):
+        query = self._query()
+        before = query.queries
+        _bone().buildDBFilter("location", {}, query, {"other": "1"})
+        self.assertIs(before, query.queries)

--- a/tests/bones/test_uid_bone.py
+++ b/tests/bones/test_uid_bone.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 from abstract import ViURTestCase
 
 
@@ -64,3 +66,50 @@ class TestUidBoneStructure(ViURTestCase):
         self.assertEqual("INV-*", s["pattern"])
         self.assertEqual(10, s["length"])
         self.assertEqual("0", s["fillchar"])
+
+
+class TestGenerateNumber(ViURTestCase):
+    """The counter must not swallow datastore errors.
+
+    ``generate_number`` used to wrap the increment in a retry loop catching a
+    ``db.CollisionError`` that no longer exists. Evaluating that name replaced every real
+    error with an ``AttributeError``, so the actual cause never reached the caller. A
+    commit conflict is resolved by the surrounding ``db.run_in_transaction`` instead.
+    """
+
+    def _patched_db(self, entity=None, put_side_effect=None):
+        from viur.core import db
+        from viur.core.bones import uid
+        stack = mock.patch.multiple(
+            uid.db,
+            get=mock.DEFAULT,
+            put=mock.DEFAULT,
+            is_in_transaction=mock.DEFAULT,
+        )
+        mocks = stack.start()
+        self.addCleanup(stack.stop)
+        mocks["get"].return_value = entity
+        mocks["put"].side_effect = put_side_effect
+        mocks["is_in_transaction"].return_value = True
+        return db, mocks
+
+    def test_first_call_starts_at_zero(self):
+        from viur.core.bones.uid import generate_number
+        db, mocks = self._patched_db(entity=None)
+        with mock.patch.object(db, "Entity", lambda key: {}):
+            self.assertEqual(0, generate_number(db.Key("viur-uids", "test")))
+        mocks["put"].assert_called_once()
+
+    def test_existing_counter_is_incremented(self):
+        from viur.core.bones.uid import generate_number
+        db, mocks = self._patched_db(entity={"count": 41})
+        self.assertEqual(42, generate_number(db.Key("viur-uids", "test")))
+        mocks["put"].assert_called_once_with({"count": 42})
+
+    def test_datastore_error_propagates_unchanged(self):
+        from viur.core.bones.uid import generate_number
+        error = RuntimeError("datastore unavailable")
+        db, _ = self._patched_db(entity={"count": 0}, put_side_effect=error)
+        with self.assertRaises(RuntimeError) as ctx:
+            generate_number(db.Key("viur-uids", "test"))
+        self.assertIs(error, ctx.exception)

--- a/tests/bones/test_uri_bone.py
+++ b/tests/bones/test_uri_bone.py
@@ -122,3 +122,60 @@ class TestUriBone(ViURTestCase):
         url_value = "http://https://viur.dev"
         res = bone.singleValueFromClient(url_value, skel, self.bone_name, None)
         self.assertEqual((url_value, None), res)
+
+
+class TestUriBoneAcceptedProtocols(ViURTestCase):
+    """``accepted_protocols`` takes a single protocol, an iterable of them, or patterns.
+
+    A plain string used to be turned into a set of its characters, which inverted the
+    restriction: ``"https"`` allowed h, t, p and s but not https. The wildcard was then
+    tested against the original argument, so for a string it was a substring test and any
+    pattern containing a ``*`` switched the protocol check off altogether.
+    """
+
+    @staticmethod
+    def _bone(accepted_protocols):
+        from viur.core.bones import UriBone
+        return UriBone(accepted_protocols=accepted_protocols)
+
+    def _accepts(self, bone, url) -> bool:
+        return bone.isInvalid(url) is None
+
+    def test_string_is_one_protocol(self):
+        bone = self._bone("https")
+        self.assertEqual({"https"}, bone.accepted_protocols)
+        self.assertTrue(self._accepts(bone, "https://www.viur.dev/"))
+        self.assertFalse(self._accepts(bone, "http://www.viur.dev/"))
+
+    def test_string_pattern_stays_a_pattern(self):
+        bone = self._bone("http*")
+        self.assertEqual({"http*"}, bone.accepted_protocols)
+        self.assertTrue(self._accepts(bone, "http://www.viur.dev/"))
+        self.assertTrue(self._accepts(bone, "https://www.viur.dev/"))
+        # The point of the restriction: a pattern must not allow everything
+        self.assertFalse(self._accepts(bone, "file://etc/passwd"))
+
+    def test_iterable_is_normalized_to_a_set(self):
+        bone = self._bone(["http", "https"])
+        self.assertEqual({"http", "https"}, bone.accepted_protocols)
+        self.assertTrue(self._accepts(bone, "http://www.viur.dev/"))
+        self.assertFalse(self._accepts(bone, "ftp://www.viur.dev/"))
+
+    def test_bare_wildcard_string_allows_everything(self):
+        bone = self._bone("*")
+        self.assertIsNone(bone.accepted_protocols)
+        self.assertTrue(self._accepts(bone, "file://etc/passwd"))
+
+    def test_bare_wildcard_in_an_iterable_allows_everything(self):
+        bone = self._bone(["http", "*"])
+        self.assertIsNone(bone.accepted_protocols)
+        self.assertTrue(self._accepts(bone, "file://etc/passwd"))
+
+    def test_no_restriction_by_default(self):
+        bone = self._bone(None)
+        self.assertIsNone(bone.accepted_protocols)
+        self.assertTrue(self._accepts(bone, "file://etc/passwd"))
+
+    def test_non_iterable_raises_value_error(self):
+        with self.assertRaises(ValueError):
+            self._bone(5)

--- a/tests/bones/test_uri_bone.py
+++ b/tests/bones/test_uri_bone.py
@@ -179,3 +179,57 @@ class TestUriBoneAcceptedProtocols(ViURTestCase):
     def test_non_iterable_raises_value_error(self):
         with self.assertRaises(ValueError):
             self._bone(5)
+
+
+class TestUriBoneAcceptedPorts(ViURTestCase):
+    """A URL that names no port still has one: the default of its scheme.
+
+    ``urlparse(...).port`` is None in that case, so ``accepted_ports=(443,)`` used to
+    reject the perfectly valid ``https://example.com``. The property also parses the port
+    itself and raises ValueError for a malformed one, which isInvalid did not catch -- a
+    500 rather than a validation error.
+    """
+
+    @staticmethod
+    def _bone(accepted_ports):
+        from viur.core.bones import UriBone
+        return UriBone(accepted_ports=accepted_ports)
+
+    def _accepts(self, bone, url) -> bool:
+        return bone.isInvalid(url) is None
+
+    def test_scheme_default_port_is_accepted(self):
+        bone = self._bone(443)
+        self.assertTrue(self._accepts(bone, "https://example.com"))
+        self.assertTrue(self._accepts(bone, "https://example.com:443"))
+        self.assertFalse(self._accepts(bone, "http://example.com"))
+
+    def test_scheme_default_port_is_rejected_when_not_accepted(self):
+        bone = self._bone(8080)
+        self.assertFalse(self._accepts(bone, "https://example.com"))
+        self.assertTrue(self._accepts(bone, "https://example.com:8080"))
+
+    def test_explicit_port_still_wins(self):
+        bone = self._bone(80)
+        self.assertTrue(self._accepts(bone, "http://example.com"))
+        self.assertFalse(self._accepts(bone, "http://example.com:8080"))
+
+    def test_unknown_scheme_without_port_is_rejected(self):
+        """An undecidable port cannot be shown to be an accepted one."""
+        bone = self._bone(443)
+        self.assertFalse(self._accepts(bone, "customscheme://example.com"))
+
+    def test_malformed_port_is_a_validation_error(self):
+        bone = self._bone(443)
+        self.assertEqual("Can't read the port from the URL", bone.isInvalid("https://example.com:abc"))
+
+    def test_out_of_range_port_is_a_validation_error(self):
+        bone = self._bone(443)
+        self.assertEqual("Can't read the port from the URL", bone.isInvalid("https://example.com:99999"))
+
+    def test_no_restriction_ignores_the_port(self):
+        bone = self._bone(None)
+        self.assertTrue(self._accepts(bone, "https://example.com"))
+        self.assertTrue(self._accepts(bone, "https://example.com:8080"))
+        # A malformed port is not looked at either, as no port check runs
+        self.assertTrue(self._accepts(bone, "https://example.com:abc"))

--- a/tests/test_email.py
+++ b/tests/test_email.py
@@ -1,0 +1,90 @@
+"""Tests for the guards in :mod:`viur.core.email`.
+
+Anything from :mod:`viur.core` is imported inside the test methods, see
+:mod:`tests.test_securityheaders` for the reason.
+"""
+from unittest import mock
+
+from abstract import ViURTestCase
+
+
+class TestSendEmailOnDevServer(ViURTestCase):
+    """The App Engine Mail API is never reachable from a local development server.
+
+    ``conf.email.transport_class`` holds an *instance*, so the guard has to use
+    ``isinstance``. Comparing against the class was always False and let the call through
+    to fail inside the API instead.
+    """
+
+    def _send(self, transport_class, send_from_local_development_server: bool) -> tuple:
+        """Call ``send_email`` on a simulated dev server.
+
+        :return: Tuple of the return value and the mock that replaced ``db.put``.
+        """
+        from viur.core import email
+        from viur.core.config import conf
+
+        # conf.emailRenderer is only wired up by viur.core.setup()
+        conf.emailRenderer = lambda *args, **kwargs: ("subject", "body")
+        self.addCleanup(delattr, conf, "emailRenderer")
+
+        with mock.patch.object(conf.email, "transport_class", transport_class), \
+                mock.patch.object(conf.email, "send_from_local_development_server",
+                                  send_from_local_development_server), \
+                mock.patch.object(conf.instance, "is_dev_server", True), \
+                mock.patch.object(email.db, "put") as put, \
+                mock.patch.object(email, "send_email_deferred"):
+            result = email.send_email(dests="user@example.com", stringTemplate="hello")
+
+        return result, put
+
+    def test_appengine_transport_is_never_used_locally(self):
+        from viur.core.email import EmailTransportAppengine
+        result, put = self._send(EmailTransportAppengine(), send_from_local_development_server=True)
+        self.assertFalse(result)
+        put.assert_not_called()
+
+    def test_other_transport_may_send_when_enabled(self):
+        from viur.core.email import EmailTransportSmtp
+        transport = EmailTransportSmtp(host="localhost", user="u", password="p")
+        result, put = self._send(transport, send_from_local_development_server=True)
+        self.assertTrue(result)
+        put.assert_called_once()
+
+    def test_other_transport_is_blocked_when_disabled(self):
+        from viur.core.email import EmailTransportSmtp
+        transport = EmailTransportSmtp(host="localhost", user="u", password="p")
+        result, put = self._send(transport, send_from_local_development_server=False)
+        self.assertFalse(result)
+        put.assert_not_called()
+
+
+class TestCheckBrevoQuota(ViURTestCase):
+    """The quota check must run for :class:`EmailTransportBrevo`, not only for its
+    deprecated subclass :class:`EmailTransportSendInBlue`."""
+
+    def _check(self, transport_class) -> mock.Mock:
+        """Run ``check_sib_quota`` and return the mock that replaced ``requests.get``."""
+        from viur.core import email
+        from viur.core.config import conf
+
+        response = mock.Mock()
+        response.ok = False
+        with mock.patch.object(conf.email, "transport_class", transport_class), \
+                mock.patch.object(email.requests, "get", return_value=response) as get:
+            email.EmailTransportBrevo.check_sib_quota()
+
+        return get
+
+    def test_brevo_transport_is_checked(self):
+        from viur.core.email import EmailTransportBrevo
+        self._check(EmailTransportBrevo(api_key="key")).assert_called_once()
+
+    def test_deprecated_subclass_is_still_checked(self):
+        from viur.core.email import EmailTransportSendInBlue
+        self._check(EmailTransportSendInBlue(api_key="key")).assert_called_once()
+
+    def test_other_transport_is_skipped(self):
+        from viur.core.email import EmailTransportSmtp
+        transport = EmailTransportSmtp(host="localhost", user="u", password="p")
+        self._check(transport).assert_not_called()

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -1,51 +1,166 @@
-"""Tests for :func:`viur.core.i18n.migrate_translation`."""
+"""Tests for the translation migration and loading in :mod:`viur.core.i18n`."""
 import logging
 from unittest import mock
 
 from abstract import ViURTestCase
 
 
-class TestMigrateTranslation(ViURTestCase):
-    """A legacy entity must not take the instance down.
+def _skeleton_search_path():
+    """Make ``TranslationSkel`` importable, see :mod:`tests.modules.test_user_app_login`."""
+    from viur.core.config import conf
+    if "/src/viur/core/" not in conf.skeleton_search_path:
+        conf.skeleton_search_path = list(conf.skeleton_search_path) + ["/src/viur/core/"]
 
-    ``migrate_translation`` is called synchronously by ``DatastoreSource.load`` for every
-    translation entity without a name, and ``initializeTranslations`` re-raises whatever a
-    source throws. The type check therefore has to validate rather than raise.
+
+class TestMigrateTranslation(ViURTestCase):
+    """A pre-3.6 entity stores the texts as a plain ``{lang: text}`` dict.
+
+    ``TranslationSkel.translations`` is a multi-language bone, whose serialized form is a
+    dict carrying ``_viurLanguageWrapper_``. Without that marker
+    ``BaseBone.unserialize`` cannot tell the languages apart and puts the whole dict into
+    the main language; ``translations_missing`` (``compute=OnWrite``) reads the bone during
+    ``write()``, so the migration would persist exactly that.
     """
 
-    def _migrate(self, translation):
-        """Run the migration on an entity carrying the given ``translation`` value.
+    def setUp(self) -> None:
+        super().setUp()
+        # Importing viur.core installs the ViURDefaultLogger and replaces the root
+        # handlers. Inside an assertLogs block that would drop its capture handler, so the
+        # import has to happen before any test method runs.
+        from viur.core import bones, i18n  # noqa: F401
 
-        :return: The entity as it was handed to the skeleton.
+    def _migrate(self, entity_fields: dict):
+        """Run the migration on an entity built from the given fields.
+
+        :return: Tuple of the entity as handed to the skeleton, or None when the migration
+            skipped it, and the mock that replaced ``TranslationSkel``.
         """
-        from viur.core import db, i18n
+        from viur.core import bones, db  # noqa: F401  (import order, see project memory)
+        from viur.core import i18n
         from viur.core.modules import translation as translation_module
 
         key = db.Key("viur-translations", "legacy")
         entity = db.Entity(key)
-        entity["key"] = "some.key"
-        entity["translation"] = translation
+        for name, value in entity_fields.items():
+            entity[name] = value
 
         skel = mock.MagicMock()
         with mock.patch.object(i18n.db, "get", return_value=entity), \
                 mock.patch.object(translation_module, "TranslationSkel", return_value=skel):
-            i18n.migrate_translation(key)
+            i18n.migrate_translation(key, _call_deferred=False)
 
-        skel.setEntity.assert_called_once()
-        return skel.setEntity.call_args.args[0]
+        if not skel.setEntity.called:
+            return None, skel
+        return skel.setEntity.call_args.args[0], skel
 
-    def test_dict_translation_is_wrapped(self):
-        entity = self._migrate({"de": "Hallo"})
-        self.assertTrue(entity["translation"]["_viurLanguageWrapper_"])
-        self.assertEqual("Hallo", entity["translation"]["de"])
+    def test_legacy_dict_gets_the_language_wrapper_marker(self):
+        entity, _ = self._migrate({"key": "some.key", "translations": {"de": "Hallo", "en": "Hello"}})
+        self.assertTrue(entity["translations"]["_viurLanguageWrapper_"])
+        self.assertEqual("Hallo", entity["translations"]["de"])
+        self.assertEqual("Hello", entity["translations"]["en"])
 
     def test_missing_name_is_filled_from_key(self):
-        entity = self._migrate({"de": "Hallo"})
+        entity, _ = self._migrate({"key": "some.key", "translations": {"en": "Hello"}})
         self.assertEqual("some.key", entity["name"])
 
-    def test_non_dict_translation_is_logged_not_raised(self):
+    def test_already_migrated_entity_is_left_alone(self):
+        translations = {"en": "Hello", "_viurLanguageWrapper_": True}
+        entity, _ = self._migrate({"key": "some.key", "name": "some.key", "translations": translations})
+        self.assertEqual(translations, dict(entity["translations"]))
+
+    def test_entity_without_translations_is_skipped(self):
         with self.assertLogs(level=logging.ERROR) as logs:
-            with self.assertRaises(TypeError):
-                # A str has no place to put the wrapper marker in
-                self._migrate("Hallo")
-        self.assertTrue(any("translation is not a dict" in line for line in logs.output))
+            entity, skel = self._migrate({"key": "some.key"})
+        self.assertIsNone(entity)
+        skel.write.assert_not_called()
+        self.assertTrue(any("is not a dict" in line for line in logs.output))
+
+    def test_non_dict_translations_is_skipped(self):
+        with self.assertLogs(level=logging.ERROR) as logs:
+            entity, skel = self._migrate({"key": "some.key", "translations": "Hello"})
+        self.assertIsNone(entity)
+        skel.write.assert_not_called()
+        self.assertTrue(any("is not a dict" in line for line in logs.output))
+
+
+class TestMigratedEntityUnserializes(ViURTestCase):
+    """The migrated entity has to keep its languages apart in the skeleton."""
+
+    def _translations_of(self, stored: dict) -> dict:
+        """Unserialize a stored ``translations`` value through a real TranslationSkel."""
+        from viur.core import bones, db  # noqa: F401
+        _skeleton_search_path()
+        from viur.core.modules.translation import TranslationSkel
+
+        entity = db.Entity(db.Key("viur-translations", "legacy"))
+        entity["key"] = "some.key"
+        entity["translations"] = stored
+
+        skel = TranslationSkel()
+        skel.setEntity(entity)
+        return skel["translations"]
+
+    def test_without_marker_the_whole_dict_lands_in_one_language(self):
+        """The state this migration exists to get out of -- kept as the contrast."""
+        main_lang = self._main_language()
+        result = self._translations_of({"de": "Hallo", "en": "Hello"})
+        self.assertEqual(str({"de": "Hallo", "en": "Hello"}), result[main_lang])
+
+    def test_with_marker_each_language_keeps_its_own_text(self):
+        result = self._translations_of({"de": "Hallo", "en": "Hello", "_viurLanguageWrapper_": True})
+        for lang, text in (("de", "Hallo"), ("en", "Hello")):
+            if lang in result:
+                self.assertEqual(text, result[lang])
+
+    @staticmethod
+    def _main_language() -> str:
+        from viur.core import bones  # noqa: F401
+        _skeleton_search_path()
+        from viur.core.modules.translation import TranslationSkel
+        return TranslationSkel().translations.languages[0]
+
+
+class TestDatastoreSourceLoad(ViURTestCase):
+    """One unusable entity must not abort the whole load.
+
+    ``initializeTranslations`` re-raises whatever a source throws, so a KeyError here
+    takes the instance down at startup.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        # Importing viur.core installs the ViURDefaultLogger and replaces the root
+        # handlers. Inside an assertLogs block that would drop its capture handler, so the
+        # import has to happen before any test method runs.
+        from viur.core import bones, i18n  # noqa: F401
+
+    def _load(self, entities: list[dict]) -> dict:
+        from viur.core import bones, db  # noqa: F401
+        from viur.core import i18n
+
+        built = []
+        for idx, fields in enumerate(entities):
+            entity = db.Entity(db.Key("viur-translations", f"e{idx}"))
+            for name, value in fields.items():
+                entity[name] = value
+            built.append(entity)
+
+        query = mock.MagicMock()
+        query.run.return_value = built
+        with mock.patch.object(i18n.db, "Query", return_value=query), \
+                mock.patch.object(i18n, "migrate_translation"):
+            return i18n.DatastoreSource().load()
+
+    def test_entity_without_translations_is_skipped(self):
+        with self.assertLogs(level=logging.ERROR):
+            res = self._load([{"name": "broken.key"}])
+        self.assertEqual({}, res)
+
+    def test_usable_entities_survive_a_broken_one(self):
+        with self.assertLogs(level=logging.ERROR):
+            res = self._load([
+                {"name": "broken.key"},
+                {"name": "good.key", "translations": {"en": "Hello"}},
+            ])
+        self.assertIn("good.key", res)
+        self.assertEqual("Hello", res["good.key"]["en"])

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -1,0 +1,51 @@
+"""Tests for :func:`viur.core.i18n.migrate_translation`."""
+import logging
+from unittest import mock
+
+from abstract import ViURTestCase
+
+
+class TestMigrateTranslation(ViURTestCase):
+    """A legacy entity must not take the instance down.
+
+    ``migrate_translation`` is called synchronously by ``DatastoreSource.load`` for every
+    translation entity without a name, and ``initializeTranslations`` re-raises whatever a
+    source throws. The type check therefore has to validate rather than raise.
+    """
+
+    def _migrate(self, translation):
+        """Run the migration on an entity carrying the given ``translation`` value.
+
+        :return: The entity as it was handed to the skeleton.
+        """
+        from viur.core import db, i18n
+        from viur.core.modules import translation as translation_module
+
+        key = db.Key("viur-translations", "legacy")
+        entity = db.Entity(key)
+        entity["key"] = "some.key"
+        entity["translation"] = translation
+
+        skel = mock.MagicMock()
+        with mock.patch.object(i18n.db, "get", return_value=entity), \
+                mock.patch.object(translation_module, "TranslationSkel", return_value=skel):
+            i18n.migrate_translation(key)
+
+        skel.setEntity.assert_called_once()
+        return skel.setEntity.call_args.args[0]
+
+    def test_dict_translation_is_wrapped(self):
+        entity = self._migrate({"de": "Hallo"})
+        self.assertTrue(entity["translation"]["_viurLanguageWrapper_"])
+        self.assertEqual("Hallo", entity["translation"]["de"])
+
+    def test_missing_name_is_filled_from_key(self):
+        entity = self._migrate({"de": "Hallo"})
+        self.assertEqual("some.key", entity["name"])
+
+    def test_non_dict_translation_is_logged_not_raised(self):
+        with self.assertLogs(level=logging.ERROR) as logs:
+            with self.assertRaises(TypeError):
+                # A str has no place to put the wrapper marker in
+                self._migrate("Hallo")
+        self.assertTrue(any("translation is not a dict" in line for line in logs.output))

--- a/tests/test_securityheaders.py
+++ b/tests/test_securityheaders.py
@@ -160,3 +160,51 @@ class TestCspReportingDirectives(ViURTestCase):
         header = conf.security.content_security_policy["_headerCache"]["Content-Security-Policy"]
         self.assertIn("report-to csp; ", header)
         self.assertIn("report-uri /cspReport; ", header)
+
+
+class TestExtendCsp(ViURTestCase):
+    """``conf.security.content_security_policy`` is optional and may be None.
+
+    The error page calls :func:`extendCsp` for its style nonce, so a crash here turns an
+    error response into a second error.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        from viur.core import current
+        from viur.core.config import conf
+        self.csp_backup = copy.deepcopy(conf.security.content_security_policy)
+        request = mock.MagicMock()
+        request.response.headers = {}
+        self.request = request
+        token = current.request.set(request)
+        self.addCleanup(current.request.reset, token)
+
+    def tearDown(self) -> None:
+        from viur.core.config import conf
+        conf.security.content_security_policy = self.csp_backup
+        super().tearDown()
+
+    def _header(self) -> str:
+        return self.request.response.headers["Content-Security-Policy"]
+
+    def test_without_project_policy(self):
+        from viur.core import securityheaders
+        from viur.core.config import conf
+        conf.security.content_security_policy = None
+        securityheaders.extendCsp({"style-src": ["nonce-abc"]})
+        self.assertEqual("style-src 'nonce-abc'; ", self._header())
+
+    def test_project_policy_is_extended(self):
+        from viur.core import securityheaders
+        from viur.core.config import conf
+        conf.security.content_security_policy = {"enforce": {"style-src": ["self"]}}
+        securityheaders.extendCsp({"style-src": ["nonce-abc"]})
+        self.assertEqual("style-src 'self' 'nonce-abc'; ", self._header())
+
+    def test_project_policy_is_not_mutated(self):
+        from viur.core import securityheaders
+        from viur.core.config import conf
+        conf.security.content_security_policy = {"enforce": {"style-src": ["self"]}}
+        securityheaders.extendCsp({"style-src": ["nonce-abc"]})
+        self.assertEqual({"enforce": {"style-src": ["self"]}}, conf.security.content_security_policy)

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -49,3 +49,56 @@ class TestCallDeferredDirectCall(ViURTestCase):
 
         self.assertEqual(["b"], calls)
         request.pendingTasks.append.assert_not_called()
+
+
+class TestRetryNTimesNotification(ViURTestCase):
+    """The "task failed permanently" mail must actually be sent.
+
+    :func:`viur.core.email.send_email` accepts ``tpl`` xor ``stringTemplate``. Passing
+    both raises a ValueError which the surrounding ``except Exception`` swallows, so the
+    notification was lost in exactly the situation it exists for.
+    """
+
+    def _run_failing_task(self, **decorator_kwargs) -> mock.Mock:
+        """Run a task that always fails until the retry limit is reached.
+
+        :return: The mock that replaced ``email.send_email``.
+        """
+        from viur.core import current, tasks
+        from viur.core import email
+
+        request = mock.MagicMock()
+        request.request.headers = {"X-Appengine-Taskretrycount": "3"}
+        token = current.request.set(request)
+        self.addCleanup(current.request.reset, token)
+
+        @tasks.retry_n_times(retries=3, email_recipients="admin@example.com", **decorator_kwargs)
+        def always_fails():
+            raise ValueError("boom")
+
+        with mock.patch.object(email, "send_email") as send_email:
+            with self.assertRaises(tasks.PermanentTaskFailure):
+                always_fails()
+
+        return send_email
+
+    def test_default_template_is_passed_as_string_template(self):
+        send_email = self._run_failing_task()
+        send_email.assert_called_once()
+        kwargs = send_email.call_args.kwargs
+        self.assertNotIn("tpl", kwargs)
+        self.assertIn("{{func_name}}", kwargs["stringTemplate"])
+
+    def test_custom_template_is_passed_alone(self):
+        send_email = self._run_failing_task(tpl="task_failed")
+        send_email.assert_called_once()
+        kwargs = send_email.call_args.kwargs
+        self.assertEqual("task_failed", kwargs["tpl"])
+        self.assertNotIn("stringTemplate", kwargs)
+
+    def test_notification_reports_the_task(self):
+        send_email = self._run_failing_task()
+        kwargs = send_email.call_args.kwargs
+        self.assertEqual("admin@example.com", kwargs["dests"])
+        self.assertEqual("always_fails", kwargs["func_name"])
+        self.assertEqual(3, kwargs["retries"])


### PR DESCRIPTION
Fixes defects collected in `docs/known_bugs.md` while writing the ADRs. All of them are
cases where the code does not do what it says — a type check against a class instead of
an instance, an assignment to an attribute that does not exist, a missing comma. No
intended behaviour changes.

- **`i18n.py`** — the translation migration marked `entity["translation"]`, singular. No
  bone reads that name, and without the `_viurLanguageWrapper_` marker on `translations`
  `unserialize` collapses `{"de": "Hallo", "en": "Hello"}` into
  `{"en": "{'de': 'Hallo', 'en': 'Hello'}"}`. `translations_missing` is computed on write,
  so that was serialized back — the migration destroyed the data it exists to migrate.
  `DatastoreSource.load` also guarded with `entity["translations"]`, a `KeyError` that
  `initializeTranslations` re-raises, taking the instance down at startup.
- **`bones/uri.py`** — `accepted_protocols="https"` became `set("https")`, allowing h, t,
  p and s; the wildcard was then tested against the original argument, so `"http*"`
  accepted `file://etc/passwd`. And `urlparse(...).port` is `None` without an explicit
  port, so `accepted_ports=(443,)` rejected `https://example.com`; a malformed port raised
  `ValueError` uncaught.
- **`bones/spatial.py`** — `buildDBFilter` assigned to `dbFilter.datastoreQuery`, which
  does not exist, so an invalid geo filter ran the query *without* the spatial constraint
  and returned everything instead of nothing.
- **`email.py`** — the dev-server guard compared an instance against a class, so mail went
  to the App Engine Mail API locally; the quota check tested the deprecated
  `EmailTransportSendInBlue`, so Brevo projects never got a credit warning.
- **`securityheaders.py`** — `extendCsp` assumed `content_security_policy` is set; the
  error page calls it, turning an error response into a second error.
- **`bones/record.py`** — the write path lacked the `None` guard `getSearchTags` has.
- **`tasks.py`** — `send_email` takes `tpl` xor `stringTemplate` and `retry_n_times` passed
  both, silently losing the "task failed permanently" mail.
- **`bones/uid.py`** — `db.CollisionError` is gone since #1431, so the retry never ran and
  real errors surfaced as `AttributeError`. Conflicts belong to `db.run_in_transaction`.
- Smaller: `bones/base.py` (a single `ReadFromClientError` was dropped),
  `bones/randomslice.py` (`raise NotImplemented`), `bones/numeric.py` (missing comma merged
  the translation key into the default text), `prototypes/skelmodule.py` (docstring).



Two changes go slightly beyond the above, both noted in their commits: `UriBone` raises
`ValueError` for a non-iterable `accepted_protocols` instead of the `TypeError` from
`set(5)`, and a scheme with no known default port stays a rejection — which is what the
old code did by testing `None` against the accepted ranges.
