### PR TITLE
fix: `allow_client_defined` was not in `List.view`

### DIFF
--- a/src/viur/core/prototypes/list.py
+++ b/src/viur/core/prototypes/list.py
@@ -169,7 +169,7 @@ class List(SkelModule):
             :raises: :exc:`viur.core.errors.NotFound`, when no entry with the given *key* was found.
             :raises: :exc:`viur.core.errors.Unauthorized`, if the current user does not have the required permissions.
         """
-        skel = self.viewSkel()
+        skel = self.viewSkel(allow_client_defined=utils.string.is_prefix(self.render.kind, "json"))
         if not skel.read(key):
             raise errors.NotFound()
 

--- a/src/viur/core/prototypes/skelmodule.py
+++ b/src/viur/core/prototypes/skelmodule.py
@@ -138,7 +138,7 @@ class SkelModule(Module):
         if allow_client_defined:
             # if bonelist := current.request.get().kwargs.get(X_VIUR_BONELIST.lower()):  # DEBUG
             if bonelist := current.request.get().request.headers.get(X_VIUR_BONELIST):
-                if "*" not in skel_cls.subSkels:  # a named star-subskel "*"" must exist!
+                if "*" not in skel_cls.subSkels:  # a named star-subskel "*" must exist!
                     raise errors.BadRequest(f"Use of {X_VIUR_BONELIST!r} requires a defined star-subskel")
 
                 bones |= {bone.strip() for bone in bonelist.split(",")}


### PR DESCRIPTION
- `List.index`, `List.structure`, `List.list` and `List.preview` provided this possibility, but not `List.view`.
- `List.edit`, `List.add` and other, relevant actions should correctly not implement this feature