### PR TITLE
fix: Use `history` as default kindname

### DIFF
--- a/src/viur/core/modules/history.py
+++ b/src/viur/core/modules/history.py
@@ -19,7 +19,7 @@ class HistorySkel(Skeleton):
     see below.
     """
 
-    kindName = "viur-history"
+    kindName = "history"
     creationdate = changedate = None
 
     version = NumericBone(
@@ -229,7 +229,7 @@ class BigQueryHistory:
 
         except exceptions.NotFound:
             app, dataset, table = self.PATH.split(".")
-            logging.error(f"{app}:{dataset}:{table}")
+
             # create dataset if needed
             try:
                 self.client.get_dataset(dataset)
@@ -322,7 +322,7 @@ class HistoryAdapter(DatabaseAdapter):
             if kindname in conf.history.excluded_kinds:
                 return None
 
-            if kindname == "viur-history":
+            if kindname == history_module.kindName:
                 return None
 
         return history_module.log(
@@ -337,8 +337,6 @@ class History(List):
     """
     ViUR history module
     """
-    kindName = "viur-history"
-
     adminInfo = {
         "name": "History",
         "icon": "clock-history",


### PR DESCRIPTION
The initial version of the history-module used `viur-history`. We should reduce the amount of `viur-*`-prefixed kindnames, as they assume data which can be recreated and is temporal (like `viur-relations`).

This PR changes the kindname to just `history`, to be kept in order with `file` and `user`, which is also not called `viur-file` or `viur-user`.