### PR TITLE
fix: SEO key collision resolution was reverted on every write

### DIFF
--- a/src/viur/core/skeleton/skeleton.py
+++ b/src/viur/core/skeleton/skeleton.py
@@ -475,7 +475,6 @@ class Skeleton(BaseSkeleton, metaclass=MetaSkel):
             skel.dbEntity.pop("viur_incomming_relational_locks", None)
 
             # Ensure the SEO-Keys are up-to-date
-            last_requested_seo_keys = skel.dbEntity["viur"].get("viurLastRequestedSeoKeys") or {}
             last_set_seo_keys = skel.dbEntity["viur"].get("viurCurrentSeoKeys") or {}
             # Filter garbage serialized into this field by the SeoKeyBone
             last_set_seo_keys = {k: v for k, v in last_set_seo_keys.items() if not k.startswith("_") and v}
@@ -492,24 +491,27 @@ class Skeleton(BaseSkeleton, metaclass=MetaSkel):
                 if current_seo_keys and language in current_seo_keys:
                     current_seo_key = current_seo_keys[language]
 
-                    if current_seo_key != last_requested_seo_keys.get(language):  # This one is new or has changed
-                        new_seo_key = current_seo_keys[language]
-
-                        for _ in range(0, 3):
-                            entry_using_key = db.Query(skel.kindName).filter(
-                                "viur.viurActiveSeoKeys =", new_seo_key).getEntry()
-
-                            if entry_using_key and entry_using_key.key != skel.dbEntity.key:
-                                # It's not unique; append a random string and try again
-                                new_seo_key = f"{current_seo_keys[language]}-{utils.string.random(5).lower()}"
-
-                            else:
-                                # We found a new SeoKey
-                                break
-                        else:
-                            raise ValueError("Could not generate an unique seo key in 3 attempts")
-                    else:
+                    # Start from the key this entry currently holds: it may carry a suffix
+                    # from an earlier collision, and that suffix has to survive this write.
+                    new_seo_key = last_set_seo_keys.get(language) or current_seo_key
+                    if not (new_seo_key == current_seo_key or new_seo_key.startswith(f"{current_seo_key}-")):
+                        # The held key no longer derives from the requested one
                         new_seo_key = current_seo_key
+
+                    for _ in range(0, 3):
+                        entry_using_key = db.Query(skel.kindName).filter(
+                            "viur.viurActiveSeoKeys =", new_seo_key).getEntry()
+
+                        if entry_using_key and entry_using_key.key != skel.dbEntity.key:
+                            # It's not unique; append a random string and try again
+                            new_seo_key = f"{current_seo_key}-{utils.string.random(5).lower()}"
+
+                        else:
+                            # We found a new SeoKey
+                            break
+                    else:
+                        raise ValueError("Could not generate an unique seo key in 3 attempts")
+
                     last_set_seo_keys[language] = new_seo_key
 
                 else:
@@ -532,7 +534,7 @@ class Skeleton(BaseSkeleton, metaclass=MetaSkel):
                 skel.dbEntity["viur"]["viurActiveSeoKeys"].insert(0, str(skel.dbEntity.key.id_or_name))
             # Trim to the last 200 used entries
             skel.dbEntity["viur"]["viurActiveSeoKeys"] = skel.dbEntity["viur"]["viurActiveSeoKeys"][:200]
-            # Store lastRequestedKeys so further updates can run more efficient
+            # Store the requested keys; kept for applications reading this property
             skel.dbEntity["viur"]["viurLastRequestedSeoKeys"] = current_seo_keys
 
             # mark entity as "dirty" when update_relations is set, to zero otherwise.


### PR DESCRIPTION
A resolved SEO key collision never survived the next write, so two entries of the same
kind could permanently share one SEO key.

## Problem

`Skeleton.write` resolves a collision by appending a random suffix to the requested key.
That resolution was guarded by:

```py
if current_seo_key != last_requested_seo_keys.get(language):  # This one is new or has changed
    ...  # query + suffix
else:
    new_seo_key = current_seo_key
```

`viurLastRequestedSeoKeys` holds what `getCurrentSEOKeys()` *requested*, not what was
actually *assigned*:

```py
skel.dbEntity["viur"]["viurLastRequestedSeoKeys"] = current_seo_keys
```

The first write therefore assigns `my-key-a1b2c`, but every later write takes the `else`
branch and restores `my-key` — the key another entry already holds. Both entries then
carry the same `viurCurrentSeoKeys`, and `seoUrlToEntry` resolves that URL to whichever
entry the datastore returns first. If that one is not viewable for the visitor, the URL
errors out instead of serving the intended page.

Two details made this hard to spot:

- the guard also skips the check for entries whose requested key is simply unchanged, so
  an already existing collision is never repaired — no matter how often the entries are
  written, `refresh` (formerly `rebuildSearchIndex`) included
- `viurActiveSeoKeys` keeps the discarded suffixed key, so an affected entry looks as if
  the resolution had worked

## Changes

- the check starts from the key the entry currently holds, so an assigned suffix gets
  confirmed instead of dropped
- the check runs on every write, so an existing collision is resolved the next time
  either entry is written
- a held key that no longer derives from the requested one is given up
- `viurLastRequestedSeoKeys` is no longer read; it is still written for applications
  reading that property

The extra query only concerns skeletons overriding `getCurrentSEOKeys()`. The default
implementation returns `None`, which takes the db-key branch without querying.

The diff reads much better with `-w` — the loop body only lost one indentation level.

## Verification

- `python -m unittest discover` in `tests/`: 81 tests, no failures
- against a live datastore holding two entries that shared one SEO key: writing the
  second one assigned it a suffixed key while the first kept the plain one; two further
  writes left that suffix unchanged; writing the first one left it untouched. Before the
  change, the same writes left both entries on the identical key.
